### PR TITLE
renaming all Pyth, Pyth Network oracles to Pyth

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -17391,7 +17391,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "upfi.js",
     twitter: "upfi_network",
     audit_links: ["https://www.rdauditors.com/wp-content/uploads/2021/11/UPFI-Network-Smart-Contract-Security-Report.pdf"],
-    oracles: ["Pyth Network"],
+    oracles: ["Pyth"],
     listedAt: 1639176180,
   },
   {


### PR DESCRIPTION
https://007vasy.github.io/

because of the different name, the Pyth oracle integration count is lower than in the defillama data

@Nemusonaneko 

![image](https://user-images.githubusercontent.com/12837887/149029812-64242505-9409-4c5d-8595-ca10e561b8a0.png)

the 3 should will 4 with this correction