### PR TITLE
Changed Uplift website link

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -10644,7 +10644,7 @@ listedAt: 1650804679
   name: "Uplift DAO",
   address: "bsc:0x513C3200F227ebB62e3B3d00B7a83779643a71CF",
   symbol: "LIFT",
-  url: "https://about.just.money",
+  url: "https://uplift.io",
   description: "Uplift IDO platform facilitates and fosters the growth of all projects in the Uplift ecosystem; connecting projects with stakeholders and connecting investors with best in class investment opportunities.",
   chain: "Binance",
   logo: `${baseIconsUrl}/uplift-dao.jpg`,


### PR DESCRIPTION
Hey!
Someone has changed Uplift DAO's website link. This has been reported by one of our community members.
Is there a way to make sure that these changes are made only by the people who are part of the Uplift GitHub organization (https://github.com/UpliftDAO)? 
