### PR TITLE
Remove pool token from description

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -11849,8 +11849,8 @@ listedAt: 1650804679
 {
   id: "1953",
   name: "Toucan Protocol",
-  address: "polygon:0x2f800db0fdb5223b3c3f354886d907a671414a7f",
-  symbol: "BCT",
+  address: null,
+  symbol: "-",
   url: "https://toucan.earth",
   description: "The protocol provides tools that allow anyone to bring carbon credits onto the blockchain to improve the carbon market and fuel web3 innovation. Unlocking more ideas, infrastructure and incentives to finance the world’s best climate projects.",
   chain: "Polygon",


### PR DESCRIPTION
BCT is just one of the pool tokens that
we have enabled to be pooled but should
not be associated as our main protocol
token.