### PR TITLE
Rewrite /liquidations endpoint's response format

### DIFF
--- a/defi/src/storeLiquidations.ts
+++ b/defi/src/storeLiquidations.ts
@@ -6,13 +6,17 @@ import { liquidationsFilename, storeDataset } from "./utils/s3";
 
 async function handler(){
   const time = getCurrentUnixTimestamp()
-  const data = await Promise.all(Object.entries(adaptersModules).map(async ([name, module]) => {
-    const liqs = await module.ethereum.liquidations();
-    const {bins} = await binResults(liqs)
-    console.log("done", name)
+  const data = await Promise.all(Object.entries(adaptersModules).map(async ([protocol, module]) => {
+    // too lazy to type this properly cuz issa already typed in adapters
+    const liqs : {[chain: string]: object[]} = {}
+    await Promise.all(Object.entries(module).map(async ([chain, liquidationsFunc])=> {
+      const liquidations = await liquidationsFunc()
+      liqs[chain] = liquidations
+    }));
+
     return {
-      protocol: name,
-      bins
+      protocol,
+      liqs,
     }
   }))
   


### PR DESCRIPTION
Instead of binning the data, we serve data of all parsed liquidable positions. Also make the shape more portable for aka multichain support in the future. 

Reasoning for not binning here is that this is gonna be a lower level api cuz on the frontend users will be able to filter out chains. Will have another api (api route or inside getStaticProps while ISRing) to allow users stack chains or protocols and so on