### PR TITLE
fix name of dogmoney

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -12718,9 +12718,9 @@ listedAt: 1650804679
 },
 {
   id: "1994",
-  name: "DogeMoney",
+  name: "DogMoney",
   address: "dogechain:0x93C8a00416dD8AB9701fa15CA120160172039851",
-  symbol: "DOGEMONEY",
+  symbol: "DOGMONEY",
   url: "https://app.dogmoney.money/",
   description: "Trade, launch, stake, farm, invest, automate, build on the premier DeFi platform of DogeChain",
   chain: "Dogechain",


### PR DESCRIPTION
Hi! Somehow the name got changed to dogemoney when request was approved :) I fixed the name / symbol here. Can verify at https://app.dogmoney.money/ - Thank you