### PR TITLE
Cega Oracle Update to Pyth

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -14026,7 +14026,7 @@ listedAt: 1650804679
   cmcId: null,
   category: "Options",
   chains: ["Solana"],
-  oracles: [],
+  oracles: ["Pyth"],
   forkedFrom: [],
   module: "cega/index.js",
   twitter: "cega_fi",


### PR DESCRIPTION
Just an update to include Cega into the Pyth TVS, kindly check

https://twitter.com/cega_fi/status/1533819362376916994?s=20&t=U9w1HZ9erWv8jSpLAgev_w