### PR TITLE
Update Milkomeda A1 type

### DIFF
--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -1173,7 +1173,7 @@ export const chainCoingeckoIds = {
     categories: ["EVM", "Rollup"],
     parent: {
       chain: "Algorand",
-      types: ["gas"]
+      types: ["L2", "gas"]
     },
     chainId: 2002,
   },


### PR DESCRIPTION
Add L1 type for the Milkomeda A1 chain.
This PR continues the thread (https://github.com/DefiLlama/defillama-server/pull/1236)