### PR TITLE
fix: Metavault.Trade Protocol Info

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -8571,7 +8571,7 @@ listedAt: 1650804679
   address: "polygon:0x2760E46d9BB43dafCbEcaad1F64b93207f9f0eD7",
   symbol: "MVX",
   url: "https://metavault.trade",
-  description: "Metavault.Trade is a new kind of Decentralised Exchange, designed to provide a large range of trading features and very deep liquidity on many large cap crypto assets. Traders can use it in two ways: Spot trading, with swaps and limit orders. Perpetual futures trading with up to 30x leverage on short and long positions. Metavault.Trade aims to become the go-to solution for traders who want to stay in control of their funds at all times without sharing their personal data.",
+  description: "Metavault.Trade is a new kind of Decentralised Exchange, designed to provide a large range of trading features and very deep liquidity on many large cap crypto assets. Traders can use it in two ways: Spot trading, with swaps and limit orders. Perpetual futures trading with up to 50x leverage on short and long positions. Metavault.Trade aims to become the go-to solution for traders who want to stay in control of their funds at all times without sharing their personal data.",
   chain: "Polygon",
   logo: `${baseIconsUrl}/metavault.trade.png`,
   audits: "2",


### PR DESCRIPTION
We've updated Metavault.Trade protocol info. Metavault.Trade made update on short and long leverage from 30x to 50x now.