### PR TITLE
Change Sudoswap category to NFT Marketplace

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -11111,7 +11111,7 @@ listedAt: 1650804679
   audit_note: null,
   gecko_id: null,
   cmcId: null,
-  category: "Dexes",
+  category: "NFT Marketplace",
   chains: ["Ethereum"],
   oracles: [],
   forkedFrom: [],


### PR DESCRIPTION
Think it's more accurate to categorize Sudoswap alongside Caviar, Blur, and other NFT marketplaces vs Uniswap, Sushiswap and other dexes.