### PR TITLE
RociFi: update metadata

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -14341,7 +14341,7 @@ const data2: Protocol[] = [
     description: "Under-collateralized lending protocol",
     chain: "Polygon",
     logo: `${baseIconsUrl}/rocifi.jpg`,
-    audits: "2",
+    audits: "3",
     audit_note: null,
     gecko_id: null,
     cmcId: null,
@@ -14349,7 +14349,7 @@ const data2: Protocol[] = [
     chains: ["Polygon"],
     oracles: [],
     forkedFrom: [],
-    module: "rocifiv1/index.js",
+    module: "rocifi/index.js",
     twitter: "rocifi",
     audit_links: ["https://github.com/rociFi/docs"],
     listedAt: 1662456730


### PR DESCRIPTION
Changelog:

- `audits` counter has been updated since RociFi v2 got [audited](https://github.com/RociFi/docs/blob/main/RociFi_Hexens_Dec_2022_SMA_public.pdf)
- `module` path was updated due to recent adapter update ([PR](https://github.com/DefiLlama/DefiLlama-Adapters/pull/5530))