### PR TITLE
fix: dont fail if wrong 4626

### DIFF
--- a/coins/src/adapters/utils/erc4626.ts
+++ b/coins/src/adapters/utils/erc4626.ts
@@ -5,7 +5,7 @@ import getBlock from "./block";
 import { getTokenAndRedirectData } from "./database";
 import { CoinData } from "./dbInterfaces";
 
-type Result = {
+export type Result4626 = {
   token: string;
   price: number;
   decimals: number;
@@ -15,7 +15,7 @@ export async function calculate4626Prices(
   chain: any,
   timestamp: number,
   tokens: string[],
-): Promise<Result[]> {
+): Promise<(Result4626 | null)[]> {
   const block: number | undefined = await getBlock(chain, timestamp);
   const { sharesDecimals, assets, symbols, ratios } = await getTokenData(
     block,
@@ -28,7 +28,7 @@ export async function calculate4626Prices(
     timestamp,
   );
 
-  const result: Result[] = [];
+  const result: (Result4626 | null)[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const assetInfo = assetsInfo.find(
       ({ address }) => assets[i].toLowerCase() === address.toLowerCase(),
@@ -44,13 +44,18 @@ export async function calculate4626Prices(
         (assetInfo.price * 10 ** assetInfo.decimals).toFixed(0),
       );
     }
-    const sharePrice = assetPriceBN.mul(ratios[i]).div(assetMagnitude);
-    result.push({
-      token: tokens[i].toLowerCase(),
-      price: parseFloat(utils.formatUnits(sharePrice, assetInfo.decimals)),
-      decimals: sharesDecimals[i],
-      symbol: symbols[i],
-    });
+    if (ratios[i] !== null) {
+      const sharePrice = assetPriceBN.mul(ratios[i]).div(assetMagnitude);
+      result.push({
+        token: tokens[i].toLowerCase(),
+        price: parseFloat(utils.formatUnits(sharePrice, assetInfo.decimals)),
+        decimals: sharesDecimals[i],
+        symbol: symbols[i],
+      });
+    } else {
+      result.push(null)
+    }
+    
   }
   log(result)
   return result;

--- a/coins/src/adapters/yield/mean-finance/mean-finance.ts
+++ b/coins/src/adapters/yield/mean-finance/mean-finance.ts
@@ -1,20 +1,7 @@
 import { addToDBWritesList } from "../../utils/database";
 import { Write } from "../../utils/dbInterfaces";
-import { calculate4626Prices } from "../../utils/erc4626";
+import { calculate4626Prices, Result4626 } from "../../utils/erc4626";
 import { fetch } from "../../utils";
-
-const blacklist: string[] = [
-  // Ethereum
-  "0xCd0E5871c97C663D43c62B5049C123Bb45BfE2cC", // Euler 4626 (USDC)
-  "0xd4dE9D2Fc1607d1DF63E1c95ecBfa8d7946f5457", // Euler 4626 (WETH)
-  "0xc4113b7605D691E073c162809060b6C5Ae402F1e", // Euler 4626 (DAI)
-  "0x48E345cb84895EAb4db4C44ff9B619cA0bE671d9", // Euler 4626 (WBTC)
-  "0xb95E6eee428902C234855990E18a632fA34407dc", // Euler 4626 (LUSD)
-  "0x7C6D161b367Ec0605260628c37B8dd778446256b", // Euler 4626 (wstETH)
-  "0x3c66b18f67ca6c1a71f829e2f6a0c987f97462d0",
-  "0x4169df1b7820702f566cc10938da51f6f597d264",
-  "0xcdd454ce8a23f57e7f4f948056836c5a8e2142ec",
-].map((token) => token.toLowerCase());
 
 export default async function getTokenPrices(chain: string, timestamp: number) {
   const tokens: { type: string; address: string }[] = await fetch(
@@ -22,9 +9,7 @@ export default async function getTokenPrices(chain: string, timestamp: number) {
   );
   const tokens4626 = tokens
     .filter(
-      (t) =>
-        t.type === "YIELD_BEARING_SHARE" &&
-        !blacklist.includes(t.address.toLowerCase()),
+      (t) => t.type === "YIELD_BEARING_SHARE"
     )
     .map(({ address }) => address);
   return await unwrap4626(chain, tokens4626, timestamp, "mean-finance");
@@ -39,7 +24,8 @@ export async function unwrap4626(
   const writes: Write[] = [];
   if (tokens.length > 0) {
     const prices = await calculate4626Prices(chain, timestamp, tokens);
-    for (const { token, price, decimals, symbol } of prices) {
+    const validPrices = prices.filter((priceData): priceData is Result4626 => !!priceData)
+    for (const { token, price, decimals, symbol } of validPrices) {
       addToDBWritesList(
         writes,
         chain,


### PR DESCRIPTION
We realized that blacklisting tokens was not the best approach, specially because:
1. In the case of Euler, if they un-freeze their smart contracts, it would be nice to be able to calculate the correct price without having to remove the tokens from the blacklist
2. We should prevent this from happening again

So the idea is simple: if the 4626 fails for some reason, simply ignore it and don't calculate a price for it