### PR TITLE
Fix issue associating Ondo Finance v1 and Ondo Finance

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -7313,7 +7313,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
   },
   {
     id: "460",
-    name: "Ondo Finance V1",
+    name: "Ondo v1 (Legacy)",
     address: "-",
     symbol: "-",
     url: "https://v1.ondo.finance",
@@ -7334,7 +7334,6 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
       "https://docs.ondo.finance/assets/files/Ondo-ABDK-Audit-October-2022-b08d29dce81d383e0d2c05fbf51af385.pdf",
       "https://docs.ondo.finance/assets/files/Ondo-Quantstamp-Audit-January_2022-c670ae4579ad332729bcc271612dda74.pdf"
     ],
-    parentProtocol: "Ondo Finance"
   },
   {
     id: "461",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -25038,7 +25038,7 @@ const data2: Protocol[] = [
   },
   {
     id: "2542",
-    name: "Ondo Finance V2",
+    name: "Ondo Finance",
     address: "-",
     symbol: "-",
     url: "https://ondo.finance",
@@ -25055,7 +25055,6 @@ const data2: Protocol[] = [
     module: "ondofinance/index.js",
     twitter: "OndoFinance",
     audit_links: ["https://www.certik.org/projects/ondofinance"],
-    parentProtocol: "Ondo Finance"
   },
   {
     id: "2543",

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -861,18 +861,6 @@ const parentProtocols: IParentProtocol[] = [
     twitter: "ScrubFinance",
   },
   {
-    id: "Ondo Finance",
-    name: "Ondo Finance",
-    url: "https://ondo.finance",
-    description:
-    "Institutional-Grade Finance. On-Chain. For Everyone",
-    logo: `${baseIconsUrl}/ondo-finance.jpg`,
-    gecko_id: null,
-    cmcId: null,
-    chains: [],
-    twitter: "OndoFinance",
-  },
-  {
     id: "Bank Of Cronos",
     name: "Bank Of Cronos",
     url: "https://boc.bankofcronos.com",


### PR DESCRIPTION
Ondo v1 and Ondo Finance are completely separate endeavors from different organizations. Ondo v1 was a DeFi-native protocol supported by an offshore (Cayman) foundation. Ondo Finance, a US-based entity, has separately launched centralized regulated security tokens like OUSG. We are supportive of preserving the historical record related to Ondo v1 through its own page in defillama but need to avoid confusion with the regulated products issued out of Ondo Finance today.