### PR TITLE
add Synthetix under Pyth TVS

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -198,7 +198,7 @@ const data: Protocol[] = [
     treasury: "synthetix.js",
     twitter: "synthetix_io",
     audit_links: ["https://docs.synthetix.io/contracts/audits/"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink","Pyth"],
     governanceID: ["snapshot:synthetix-stakers-poll.eth"]
   },
   {


### PR DESCRIPTION
gm llama sers

would like your help to review Pyth as another oracle for Synthetix

They have been a strong supporter since late last year and we want to add them under Pyth TVS

https://twitter.com/PythNetwork/status/1595099857231831041?s=20

https://twitter.com/synthetix_io/status/1601280873965371392?s=20

Thank you sers