### PR TITLE
Update info about Witnet and protocols that use its oracle

### DIFF
--- a/defi/src/adaptors/data/helpers/chains/index.ts
+++ b/defi/src/adaptors/data/helpers/chains/index.ts
@@ -56,9 +56,9 @@ export default {
         cmcId: "2092",
     },
     "Witnet": {
-        geckoId: null,
-        symbol: null,
-        cmcId: null,
+        geckoId: "witnet",
+        symbol: "WIT",
+        cmcId: "14925",
     },
     "BSC": {
         geckoId: "binancecoin",

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -7112,7 +7112,8 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "qidao/index.js",
     twitter: "QiDaoProtocol",
     audit_links: ["https://docs.mai.finance/risks/security#has-the-project-been-audited"],
-    governanceID: ["snapshot:qidao.eth"]
+    governanceID: ["snapshot:qidao.eth"],
+    oracles: ["Witnet"],
   },
   {
     id: "450",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -11943,7 +11943,7 @@ const data2: Protocol[] = [
     category: "RWA",
     chains: ["Polygon", "Celo"],
     module: "toucan-protocol/index.js",
-    oracles: [],
+    oracles: ["Witnet"],
     forkedFrom: [],
     twitter: "ToucanProtocol",
     audit_links: ["https://docs.toucan.earth/protocol/resources/security"],

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -25825,7 +25825,7 @@ const data2: Protocol[] = [
     chains: ["Conflux"],
     module: "goledo/index.js",
     twitter: "GoledoFinance",
-    oracles: [],
+    oracles: ["Witnet"],
     forkedFrom: ["AAVE"],
     audit_links: ["https://github.com/peckshield/publications/blob/master/audit_reports/PeckShield-Audit-Report-Goledo-v1.0.pdf"],
     listedAt: 1677164241

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -8606,7 +8606,7 @@ const data2: Protocol[] = [
     cmcId: "19900",
     category: "Liquid Staking",
     chains: ["Cronos"],
-    oracles: ["Crypto.org API"],
+    oracles: ["Crypto.org API", "Witnet"],
     forkedFrom: [],
     module: "argofinance/index.js",
     twitter: "ArgoProtocol",


### PR DESCRIPTION
Howdy llama frens!

Witnet Sheriff here contributing some updates on the Witnet chain, and several protocols that are using the Witnet oracle.

Sources:
- Toucan Protocol: https://medium.com/witnet/witnet-securing-toucan-protocol-193690ef055a
- Argo Finance: https://medium.com/witnet/the-witnet-foundation-funding-argo-protocol-95b0227fbdec
- QiDao: https://medium.com/witnet/qidao-getting-price-feeds-and-security-from-the-witnet-oracle-9a33b2c6ee0b
- Goledo: https://twitter.com/witnet_io/status/1643235818776002565 and https://user-images.githubusercontent.com/1316439/229831006-0baec4f7-f398-41e9-a04a-5407aa7b4747.png
