### PR TITLE
Adding Binance Oracle as the oracle service provider for Apollo X

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -8003,7 +8003,7 @@ const data2: Protocol[] = [
     cmcId: "16334",
     category: "Derivatives",
     chains: ["Binance"],
-    oracles: [],
+    oracles: [BinanceOracle],
     forkedFrom: [],
     module: "apollox/index.js",
     twitter: "ApolloX_com",


### PR DESCRIPTION
On Apr 13th, Binance Oracle starts to support ApolloX. This change is to reflect this information to DefiLlama. Please see below tweet for the details

<img width="600" alt="image" src="https://user-images.githubusercontent.com/24940480/232507430-dba0679f-aad2-4a6a-a61b-5484c7739ccc.png">

https://twitter.com/ApolloX_Finance/status/1646407620666748930?s=20

