### PR TITLE
Add IBC Denom for stATOM on Kujira

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -6565,6 +6565,12 @@
       "decimals": "6",
       "symbol": "MARS",
       "to": "coingecko#mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3"
+    },
+    "0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87": {
+      "name": "Stride Staked Atom",
+      "decimals": "6",
+      "symbol": "STATOM",
+      "to": "coingecko#stride-staked-atom"
     }
   },
   "bitindi": {


### PR DESCRIPTION
The proposed change will add the IBC Denom for stATOM on the Kujira chain. This will allow the TVL Adapter for USK Minting Collateral to include stATOM.