### PR TITLE
Add Binance Oracle to Venus

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2209,7 +2209,7 @@ const data: Protocol[] = [
     twitter: "VenusProtocol",
     audit_links: ["https://www.certik.org/projects/swipe"],
     forkedFrom: ["Compound"],
-    oracles: ["Chainlink"],
+    oracles: ["Binance Oracle", "Chainlink"],
     governanceID: ["snapshot:venus-xvs.eth"]
   },
   {

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -5170,6 +5170,7 @@ const data: Protocol[] = [
     cmcId: "8799",
     category: "Insurance",
     chains: ["Ethereum", "Binance", "Polygon", "Avalanche"],
+    oracles: ["Binance Oracle"],
     module: "insurace/index.js",
     twitter: "InsurAce_io",
     audit_links: [

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -13810,7 +13810,7 @@ const data2: Protocol[] = [
     cmcId: "21330",
     category: "CDP",
     chains: ["Binance"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "Binance Oracle"],
     forkedFrom: ["MakerDAO"],
     module: "helio-money/index.js",
     twitter: "Helio_Money",


### PR DESCRIPTION
Binance Oracle is starting to support Venus. It will be used as the main oracle for certain tokens. The integration has been done. Please see the approved community proposal here: https://app.venus.io/governance/proposal/107