### PR TITLE
feat: add support for bnb for mean finance adapters

### DIFF
--- a/coins/src/adapters/yield/mean-finance/index.ts
+++ b/coins/src/adapters/yield/mean-finance/index.ts
@@ -7,5 +7,6 @@ export function meanFinance(timestamp: number = 0) {
     getTokenPrices("polygon", timestamp),
     getTokenPrices("arbitrum", timestamp),
     getTokenPrices("ethereum", timestamp),
+    getTokenPrices("bnb", timestamp),
   ]);
 }


### PR DESCRIPTION
We are simply adding support for a new chain on our coin adapters