### PR TITLE
add RedStone as an oracle to Yield Yak 

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -7759,6 +7759,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "yieldyak/index.js",
     twitter: "yieldyak_",
     parentProtocol: "parent#yield-yak",
+    oracles: ["RedStone"],
   },
   {
     id: "476",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -18268,7 +18268,7 @@ const data2: Protocol[] = [
     module: "yieldyak-staked-avax/index.js",
     twitter: "yieldyak_",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["RedStone"],
     audit_links: ["https://docs.geode.fi/developers/audits"],
     parentProtocol: "parent#yield-yak",
     listedAt: 1667041431

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -18268,7 +18268,7 @@ const data2: Protocol[] = [
     module: "yieldyak-staked-avax/index.js",
     twitter: "yieldyak_",
     forkedFrom: [],
-    oracles: ["RedStone"],
+    oracles: [],
     audit_links: ["https://docs.geode.fi/developers/audits"],
     parentProtocol: "parent#yield-yak",
     listedAt: 1667041431


### PR DESCRIPTION
gm

submitting this for your review:
https://twitter.com/redstone_defi/status/1657037951614832642
and requesting to add RedStone as an oracle for Yield Yak.

Rationale: A potential misprice would mean a cascade of liquidations and automatic withdrawal of Yield Yak’s TVL 

Additional materials:
- RedStone <> YY codebase: https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/oracle-node/src/fetchers/evm-chain/avalanche/evm-fetcher/sources/yield-yak
- Utilisation of the feeds: https://dune.com/hatskier/redstone
(So far there've been 35k+ transactions including YY token prices processed on Avalanche C-chain)

thanks