### PR TITLE
added redstone oracles to mento, moola, and pangolin

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2910,6 +2910,7 @@ const data: Protocol[] = [
     module: "pangolin/index.js",
     twitter: "pangolindex",
     forkedFrom: ["Uniswap V2"],
+    oracles: ["RedStone"],
     governanceID: ["snapshot:pangolindex.eth"]
   },
   {
@@ -8047,6 +8048,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     twitter: "Moola_Market",
     forkedFrom: ["Aave"],
     audit_links: ["https://drive.google.com/file/d/1qd1h0dujnp4Xxrl68ZTIMzbt4aXzMWY7/view"],
+    oracles: ["RedStone"],
   },
   {
     id: "490",
@@ -8353,6 +8355,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "mento/index.js",
     twitter: "CeloOrg",
     audit_links: ["https://celo.org/audits"],
+    oracles: ["RedStone"],
     stablecoins: ["celo-dollar", "celo-euro"],
   },
   {


### PR DESCRIPTION
gm,

submitting for your review:

https://twitter.com/redstone_defi/status/1659260446011179010
Source code: https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/on-chain-relayer/contracts/custom-integrations/mento
and requesting to add RedStone as an oracle for Mento & Moola-market (Moola uses same oracle flow as Mento).

https://twitter.com/redstone_defi/status/1659544475696521216
and requesting to add RedStone as an oracle for Pangolin.

Rationale: A potential misprice would mean a cascade of liquidations and automatic withdrawal of Pangolin's TVL.
RedStone <> Pangolin codebase: https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/oracle-node/src/fetchers/evm-chain/avalanche/evm-fetcher/sources/dex-lp-tokens/PangolinLP.abi.json
Utilisation of the feeds: https://dune.com/hatskier/redstone
(So far there've been 35k+ transactions including PNG token prices processed on Avalanche C-chain)