### PR TITLE
Fix plvGLP and add Yama plvGLP

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -2335,12 +2335,6 @@
       "decimals": "18",
       "symbol": "DSU",
       "to": "coingecko#digital-standard-unit"
-    },
-    "0x5326e71ff593ecc2cf7acae5fe57582d6e74cff1": {
-      "name": "Plutus Vault GLP",
-      "decimals": "18",
-      "symbol": "plvGLP",
-      "to": "arbitrum:0x4277f8F2c384827B5273592FF7CeBd9f2C1ac258"
     }
   },
   "telos": {

--- a/coins/src/adapters/yield/beefy/beefy.ts
+++ b/coins/src/adapters/yield/beefy/beefy.ts
@@ -61,6 +61,7 @@ export const config = {
     wantVaults: [
       '0x9dbbBaecACEDf53d5Caa295b8293c1def2055Adc', // mooGmxGLP
       '0x9e75f8298e458b76382870982788988a0799195b', // mooCurveWSTETH
+      '0xa64A8CAAd2c412baCf215A351FA60cDC2a08C0E8', // Yama PlvGLP
     ],
   },
   ethereum: {

--- a/coins/src/adapters/yield/misc4626/tokens.json
+++ b/coins/src/adapters/yield/misc4626/tokens.json
@@ -12,7 +12,7 @@
     "voltGNS": "0x39ff5098081fbe1ab241c31fe0a9974fe9891d04",
     "UVRT": "0xa485a0bc44988B95245D5F20497CCaFF58a73E99",
     "gDAI": "0xd85e038593d7a098614721eae955ec2022b9b91b",
-    "plvGLP": "0x4277f8F2c384827B5273592FF7CeBd9f2C1ac258"
+    "plvGLP": "0x5326e71ff593ecc2cf7acae5fe57582d6e74cff1"
   },
   "polygon": {
     "gDAI": "0x91993f2101cc758d0deb7279d41e880f7defe827"

--- a/coins/src/adapters/yield/misc4626/tokens.json
+++ b/coins/src/adapters/yield/misc4626/tokens.json
@@ -11,7 +11,8 @@
   "arbitrum": {
     "voltGNS": "0x39ff5098081fbe1ab241c31fe0a9974fe9891d04",
     "UVRT": "0xa485a0bc44988B95245D5F20497CCaFF58a73E99",
-    "gDAI": "0xd85e038593d7a098614721eae955ec2022b9b91b"
+    "gDAI": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+    "plvGLP": "0x4277f8F2c384827B5273592FF7CeBd9f2C1ac258"
   },
   "polygon": {
     "gDAI": "0x91993f2101cc758d0deb7279d41e880f7defe827"


### PR DESCRIPTION
plvGLP was incorrectly set up to track the price of GLP 1:1. It's an ERC4626 token, so I added it as one. The Yama plvGLP vault has been added as well.