### PR TITLE
Kava: include axlwBTC in Lend TVL

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -92,7 +92,6 @@
       "symbol": "AXLUSDC",
       "to": "coingecko#usd-coin"
     },
-
     "erc20:axelar:wbtc": {
       "decimals": "8",
       "symbol": "WBTC",

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -92,6 +92,12 @@
       "symbol": "AXLUSDC",
       "to": "coingecko#usd-coin"
     },
+
+    "erc20:axelar:wbtc": {
+      "decimals": "8",
+      "symbol": "WBTC",
+      "to": "coingecko#wrapped-bitcoin"
+    },
     "erc20:multichain:usdc": {
       "decimals": "6",
       "symbol": "USDC",


### PR DESCRIPTION
Pending the outcome of [Proposal 143](https://app.kava.io/vote/governance/143), axelar wBTC will be added as an asset in Kava Lend. This will include this asset in TVL count.