### PR TITLE
Feat: add oracle for Ultronswap (Witnet)

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -13716,7 +13716,7 @@ const data2: Protocol[] = [
     cmcId: "21524",
     category: "Dexes",
     chains: ["Ultron"],
-    oracles: [],
+    oracles: ["Witnet"],
     forkedFrom: ["Uniswap V2"],
     module: "ultronSwap/index.js",
     twitter: "ultron_found",


### PR DESCRIPTION
[https://ultron.foundation/blog/ultron-x-witnet-a-powerhouse-partnership-for-cryptoeconomics](https://ultron.foundation/blog/ultron-x-witnet-a-powerhouse-partnership-for-cryptoeconomics)
[https://medium.com/witnet/witnet-deploying-on-ultron-network-bcebccaacd78](https://medium.com/witnet/witnet-deploying-on-ultron-network-bcebccaacd78)
[https://feeds.witnet.io/ultron](https://feeds.witnet.io/ultron)

![ultron_proof_of_oracle](https://github.com/DefiLlama/defillama-server/assets/58690522/7b2d7a8d-776d-40c6-aa00-614632725420)
