### PR TITLE
Update Oracles for Raft.fi 

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -7924,7 +7924,7 @@ const data3: Protocol[] = [
     chains: ["Ethereum"],
     module: "raft/index.js",
     twitter: "raft_fi",
-    oracles: ["Chainlink", "Tellor"],
+    oracles: ["Chainlink"],
     forkedFrom: ["Liquity"],
     audit_links: [ "https://github.com/trailofbits/publications/blob/master/reviews/2023-04-tempus-raft-securityreview.pdf"],
     github: ["raft-fi"],


### PR DESCRIPTION
TVS methodology by @0xngmi here: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254

According to the Raft.fi docs, Chainlink is the primary oracle and Tellor will only be used under the following conditions: 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/acc308b9-2c48-4edc-97ee-6ffa6a2cae82)

You can read more [here](https://docs.raft.fi/how-it-works/oracles) and [here ](https://docs.raft.fi/how-it-works/lsd-collaterals).

As such, this TVS falls under the following statement of the TVS Methodology: 

>For protocols that have failover mechanisms for oracles, eg they use an oracle for everything but if that oracle stopped reporting new prices for X time period it would switch to a second oracle, we use our main methodology question: If the 2nd failover oracle malfunctioned, would those assets be lost? No, if it malfunctioned nothing would happen, assets would only be lost if the first oracle malfunctions AND the second oracle malfunctions as well. So in this case we don't count the protocol's TVL towards the failover oracle's TVS.

This PR is created to enforce the Defillama TVS methodology and remove TVS attributed to Tellor from Raft.fi. 