### PR TITLE
Remove Binance Oracle from Venus TVS

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2265,7 +2265,7 @@ const data: Protocol[] = [
     twitter: "VenusProtocol",
     audit_links: ["https://www.certik.org/projects/swipe"],
     forkedFrom: ["Compound"],
-    oracles: ["Chainlink", "Pyth", "Binance Oracle", "TWAP"],
+    oracles: ["Chainlink", "Pyth", "TWAP"],
     governanceID: ["snapshot:venus-xvs.eth"],
     stablecoins: ["vai"]
   },


### PR DESCRIPTION
TVS methodology by @0xngmi here: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254

According to the Venus Protocol Docs, they imply a "Resiliant Oracle" approach. 
They have a Main Oracle, a Pivot Oracle and a Fallback oracle. 
The main oracle is being used when it falls within reasonable range of the pivot oracle. 
If this isn't the case, the Fallback oracle is used, but also checked if it falls within reasonable range of the Pivot Oracle. 
As such, the main oracle can be attributed TVS to, as it is used primarily.
The Pivot Oracle can also be attributed TVS to, because the primary oracle is *only* used when it falls within a reasonable range of the Pivot. 
The fallback oracle ***cannot*** be attributed TVS to as it is merely used when the pivot oracle determines that the main oracle isn't falling in an acceptable range, and that the fallback falls within an acceptable range. 

The Venus Protocol states that their Main Oracle is Chainlink, that they use Pyth and TWAP as a Pivot and that the binance oracle is used as a fallback. 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/dce496a0-cf83-4116-bcc4-aea8e64b8d0d)

As such Binance Oracle TVS falls under the following statement of the TVS Methodology:

> For protocols that have failover mechanisms for oracles, eg they use an oracle for everything but if that oracle stopped reporting new prices for X time period it would switch to a second oracle, we use our main methodology question: If the 2nd failover oracle malfunctioned, would those assets be lost? No, if it malfunctioned nothing would happen, assets would only be lost if the first oracle malfunctions AND the second oracle malfunctions as well. So in this case we don't count the protocol's TVL towards the failover oracle's TVS.


You can read more about Venus Protocol's oracle specs here: https://github.com/VenusProtocol/oracle/tree/develop

This PR is created to enforce the Defillama TVS methodology and remove TVS attributed to the Binance Oracle from Venus Protocol.