### PR TITLE
Update Oracle specs on dForce

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -401,7 +401,7 @@ const data: Protocol[] = [
     twitter: "dForcenet",
     audit_links: ["https://github.com/dforce-network/documents/tree/master/audit_report/Lending"],
     forkedFrom: [],
-    oracles: ["Chainlink", "Band"],
+    oracles: ["Chainlink"],
     governanceID: ["snapshot:dforcenet.eth"],
     stablecoins: ["dforce-usd"],
     github: ["dforce-network"]


### PR DESCRIPTION
TVS methodology by @0xngmi here: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254

dForce initially used BAND Oracles. 
According to their documentation they rely only on Chainlink Oracles now.

Announcement of Chainlink: https://twitter.com/chainlink/status/1372158309994790913?s=20
Documentation of dForce: https://docs.dforce.network/faq-and-guides/faq#how-do-you-source-price-feeds