### PR TITLE
Remove Band Oracles from Loopring

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -467,7 +467,7 @@ const data: Protocol[] = [
     audit_links: [
       "https://github.com/Loopring/protocols/blob/master/packages/loopring_v3/security_audit/LoopringV3_1_Report_EN.pdf",
     ],
-    oracles: ["Chainlink", "Band"],
+    oracles: ["Chainlink"],
     governanceID: ["snapshot:loopringdao.eth"],
     github: ["Loopring"]
   },


### PR DESCRIPTION
TVS methodology by @0xngmi here: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254



Loopring utilizies Chainlink oracles. 

They've introduced Band as a price source to display prices on their **frontend only**. 

This was heavily critizised by the industry to claim to be securing Looping. 

To note Band secures **nothing** on-chain in regards to Loopring. 

Here an article for further clarification: https://cryptoslate.com/only-chainlink-loopring-clears-recent-band-protocol-integration-rumors/
[Here ](https://twitter.com/ChainLinkGod/status/1301284583908864000?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1301284583908864000%7Ctwgr%5Ef3ec2aa76864d4bf1e267270859932503560b96b%7Ctwcon%5Es1_&ref_url=https%3A%2F%2Fcryptoslate.com%2Fonly-chainlink-loopring-clears-recent-band-protocol-integration-rumors%2F) a tweet from CLG. 
[Here ](https://twitter.com/finestonematt/status/1301626560731021317?s=20) a tweet thread from from a former Loopring employee explaining the situation. 