### PR TITLE
Remove Oracle from Pangolin

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2968,7 +2968,6 @@ const data: Protocol[] = [
     module: "pangolin/index.js",
     twitter: "pangolindex",
     forkedFrom: ["Uniswap V2"],
-    oracles: ["RedStone"],
     governanceID: ["snapshot:pangolindex.eth"]
   },
   {


### PR DESCRIPTION
TVS methodology by @0xngmi here: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254

Pangolin is a DEX that issues LP tokens. Redstone prices these LP tokens to be used by other protocols to utilize in e.g. lending platforms. You can read about that [here](https://blog.redstone.finance/2023/05/19/redstone-x-pangolin-unleashing-defi-potential/).

It is important to note that Pangolin's TVL is in no way secured by Redstone. They merely price their LP tokens to be used by other protocols. One such integration is [DeltaPrime](https://defillama.com/protocol/deltaprime), that allows Pangolin LP tokens to be used on Avax. The TVL of DeltaPrime is hence correctly attributed to Redstone's TVS. The Pangolin TVL is wrongly attributed to Redstone's TVS, since it is a) not securing any value on Pangolin directly and b) double counted here as the value securing occurs on DeltaPrime. 


This PR is created to enforce the Defillama TVS methodology and remove TVS attributed to Redstone from Pangolin.

PS: Note also that the Redstone announcement specifically mentions an integration on AVAX only, yet it was attempted to attribute all Pangolin TVL across all chains to their TVS. This is in addition to not actually securing any TVL on Pangolin directly and apparently a trend among a lot of oracle projects to incorrectly attribute TVS to themselves.

