### PR TITLE
Revert "added redstone oracles to mento, moola, and pangolin"

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -8139,7 +8139,6 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     twitter: "Moola_Market",
     forkedFrom: ["Aave"],
     audit_links: ["https://drive.google.com/file/d/1qd1h0dujnp4Xxrl68ZTIMzbt4aXzMWY7/view"],
-    oracles: ["RedStone"],
   },
   {
     id: "490",
@@ -8446,7 +8445,6 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "mento/index.js",
     twitter: "CeloOrg",
     audit_links: ["https://celo.org/audits"],
-    oracles: ["RedStone"],
     stablecoins: ["celo-dollar", "celo-euro"],
   },
   {


### PR DESCRIPTION
Reverts DefiLlama/defillama-server#3315

This is more of a question. The initial PR links to a repo where Redstone shows a [custom oracle implemention](https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/on-chain-relayer/contracts/custom-integrations/mento) **in their own github orga**.

When checking for the oracle implementation on e.g. Mento (which you can find [here](https://github.com/mento-protocol/mento-core/blob/develop/contracts/oracles/SortedOracles.sol)) there is no mention of redstone anywhere. 

Additionally i've took the liberty to ask around in their respective discords (both Moola and Mento alike) and got this answer: 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/70b051c4-8b4b-49e7-b96f-fe3b30cd8a15)

There is also no mention of 'Redstone' anywhere in the Mento docs [here](https://docs.mento.org/mento/protocol-concepts/oracles).

Question 1: Is redstone being used, and if so, can we get some proof in the repo of the respective project and not your own repo? 
Question 2: How is Redstone being used? If merely as a backup/fallback (as suggested by them over their discord), it doesn't count towards TVS according to the [Defillama TVS definitions](https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254) and would need to be removed here. 

Appreciate your time. 

@hatskier @Define101 