### PR TITLE
Update Mean finance oracles per chain basis and add API3

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -10997,7 +10997,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     gecko_id: null,
     cmcId: null,
     category: "Services",
-    chains: ["Ethereum"],
+    chains: ["Ethereum", "Arbitrum", "Polygon", "Optimism", "BSC"],
     module: "meanfinance/index.js",
     twitter: "mean_fi",
     audit_links: ["https://github.com/Mean-Finance/dca-v2-core/tree/main/audits"],

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -11001,7 +11001,13 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "meanfinance/index.js",
     twitter: "mean_fi",
     audit_links: ["https://github.com/Mean-Finance/dca-v2-core/tree/main/audits"],
-    oracles: ["Chainlink", "TWAP"],
+    oraclesByChain: [
+      Arbitrum: ["Chainlink", "TWAP"],
+      Polygon: ["API3", "TWAP"],
+      Optimism: ["Chainlink", "TWAP"],
+      Ethereum: ["Chainlink", "TWAP"],
+      BSC: ["Chainlink", "TWAP"] 
+    ],
   },
   {
     id: "628",


### PR DESCRIPTION
Mean finance is using API3 as the [primary oracle on Polygon](https://medium.com/api3/mean-finance-partners-with-api3-for-first-party-data-feed-solution-d514d5e9d28a), This PR adjusts the oracle used on all the chains Mean finance is operating on