### PR TITLE
Remove Oracles from Kyberswap Classic

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -491,7 +491,6 @@ const data: Protocol[] = [
     twitter: "KyberNetwork",
     audit_links: ["https://chainsecurity.com/security-audit/kyber-network-dynamic-market-maker-dmm/"],
     parentProtocol: "parent#kyberswap",
-    oracles: ["Chainlink", "Band"],
   },
   {
     id: "128",


### PR DESCRIPTION
Kyberswap doesn't utilize Oracles directly for their DEX. Which i also confirmed on their discord: 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/5a85ccc4-7272-4dad-bbda-edec61ec076b)

I've also checked their Chainlink announcement here: 
https://blog.kyber.network/kyberswap-integrates-chainlink-price-feeds-to-facilitate-its-defi-and-dao-operations-72c60bdc01ae

This clearly states that Chainlink oracles are merely used to convert wbtc & eth fees into KNC. This doesn't secure any value on the DEX itself. 

Band doesn't even pop up in their docs anymore and it also doesn't matter since oracles are not utilized to secure TVL in general by Kyberswap. 