### PR TITLE
Remove Chainlink from Kava Ecosystem Projects

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -662,6 +662,7 @@ const data: Protocol[] = [
     module: "kava.js",
     twitter: "KAVA_CHAIN",
     audit_links: ["https://www.certik.org/projects/kava"],
+    oracles: ["Internal"],
   },
   {
     id: "136",
@@ -771,6 +772,7 @@ const data: Protocol[] = [
     module: "hard.js",
     twitter: "hard_protocol",
     audit_links: ["https://www.certik.org/projects/hard"],
+    oracles: ["Internal"],
   },
   {
     id: "141",

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -662,7 +662,6 @@ const data: Protocol[] = [
     module: "kava.js",
     twitter: "KAVA_CHAIN",
     audit_links: ["https://www.certik.org/projects/kava"],
-    oracles: ["Chainlink"],
   },
   {
     id: "136",
@@ -772,7 +771,6 @@ const data: Protocol[] = [
     module: "hard.js",
     twitter: "hard_protocol",
     audit_links: ["https://www.certik.org/projects/hard"],
-    oracles: ["Chainlink"],
   },
   {
     id: "141",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -19302,7 +19302,6 @@ const data2: Protocol[] = [
     module: "kava-liquid/index.js",
     twitter: "KAVA_CHAIN",
     forkedFrom: [],
-    oracles: ["Chainlink"],
     listedAt: 1668080824
   },
   {
@@ -19396,7 +19395,6 @@ const data2: Protocol[] = [
     module: "kava-earn/index.js",
     twitter: "KAVA_CHAIN",
     forkedFrom: [],
-    oracles: ["Chainlink"],
     listedAt: 1668111911
   },
   {
@@ -19418,7 +19416,6 @@ const data2: Protocol[] = [
     module: "kava-boost/index.js",
     twitter: "KAVA_CHAIN",
     forkedFrom: [],
-    oracles: ["Chainlink"],
     listedAt: 1668111919
   },
   {


### PR DESCRIPTION
There was an [announcement ](https://medium.com/@sarah_austin/kava-integrates-chainlink-as-its-official-oracle-network-to-bring-defi-to-cosmos-e31c2c2e929)in 2020 that Chainlink will support Kava. 

However, the [Chainlink Docs](https://docs.chain.link/data-feeds/price-feeds/addresses) still don't list Kava as a supported network. 

Out of interest i've asked around in the Kava discord and it turns out that this integration never materialized. 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/fcab7156-1b34-4537-8936-575c9fc0e486)


There are no Chainlink nodes on Kava, hence all TVS attributed to Chainlink is false. 