### PR TITLE
Remove Oracles from Dyfn Network

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -4479,7 +4479,6 @@ const data: Protocol[] = [
     chains: ["Polygon"],
     module: "dfyn/index.js",
     twitter: "_Dfyn",
-    oracles: ["Chainlink", "DIA"],
     forkedFrom: ["Uniswap V2"],
     treasury: "dfyn.js",
     governanceID: ["snapshot:dfyn.eth"]


### PR DESCRIPTION
This one was a bit tougher to crack. So Dyfn is effectively just a univ2 fork that utilizes no oracles. 
They additionally have a prediction market that utilizes oracles. Docs to that can be found [here](https://docs.dfyn.network/prediction-markets/prediction-markets-faqs#how-is-the-price-of-an-asset-determined). 
For some reason the entire TVL of the DEX here was attributed towards these oracles even tough it's only the prediciton market that ulitizes them. 

If you check the prediction market [contract](https://polygonscan.com/address/0x150B4fD25c7c0c65301e86B599822f2feeCC29E7#code), it has last been used over 550 days ago and barely has 1.5k TVL in it. 

This follows the typical scheme of oracle projects simply creating PRs to ramp up their TVS numbers. 
I'd suggest ignoring the prediction market aspect and simply treating Dyfn as the DEX it is and thus removing the oracles. 