### PR TITLE
Adding Binance Oracle to Kinza Finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12147,7 +12147,7 @@ const data3: Protocol[] = [
     twitter: "VenusProtocol",
     audit_links: ["https://docs-v4.venus.io/links/security-and-audits#isolated-pools"],
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Binance Oracle"],
     parentProtocol: "parent#venus-finance",
     listedAt: 1689719707
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -10510,7 +10510,7 @@ const data3: Protocol[] = [
     chains: ["Binance"],
     module: "kinza/index.js",
     twitter: "kinzafinance",
-    oracles: [],
+    oracles: ["Binance Oracle"],
     forkedFrom: ["AAVE V3"],
     treasury: "kinza.js",
     github: ["Kinza-Finance"],


### PR DESCRIPTION
Binance Oracle now supports Kinza Finance. Please find the official announcement here https://twitter.com/kinzafinance/status/1684248232644481025?s=20