### PR TITLE
Add SOMM, Native USDC and SHD as Kujira IBC Denoms

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -45,5 +45,21 @@
       "symbol": "ETH",
       "to": "coingecko#ethereum"
     }
-  }
+  },
+  "ibc": {
+    "A7A5C44AA67317F1B3FFB27BAFC89C9CC04F61306F6F834F89A74B8F82D252A1": {
+      "decimals": "6",
+      "symbol": "SOMM",
+      "to": "coingecko#sommelier"
+    },
+    "FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9": {
+      "decimals": "6",
+      "symbol": "USDC",
+      "to": "coingecko#usdc-coin"
+    },
+    "590CE97A3681BC2058FED1F69B613040209DF3F17B7BD31DFFB8671C4D2CD99B": {
+      "decimals": "8",
+      "symbol": "SHD",
+      "to": "coingecko#shade-protocol"
+    }
 }


### PR DESCRIPTION
This PR will add:

SOMM - Sommelier Finance
USDC - Circle Native USDC on Cosmos
SHD - Shade Protocol on Secret Network

As IBC denoms from Kujira