### PR TITLE
update oracles for silo finance

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -14343,7 +14343,10 @@ const data2: Protocol[] = [
     cmcId: "16010",
     category: "Lending",
     chains: ["Ethereum"],
-    oracles: ["DIA"],
+    oraclesByChain: [
+      Arbitrum: ["Chainlink", "TWAP"],
+      Ethereum: ["Chainlink", "TWAP", "DIA"]
+    ],
     forkedFrom: [],
     module: "silo/index.js",
     treasury: "silo-finance.js",


### PR DESCRIPTION
Wrongly attributed TVS to DIA. 
It's only used on Arbitrum. Check the snapshot proposal. 

https://snapshot.silo.finance/#/proposal/0xa6b5051b23999570bfefdacd5ae2a497a9d9e492b9f8126e5b6568b5962ed71a