### PR TITLE
Add MUXLP to coins API

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -132,4 +132,5 @@ export default {
   chai: require("./yield/chai"),
   ondo: require("./rwa/ondo"),
   mooBvm: require("./other"),
+  mux: require("./yield/mux"),
 };

--- a/coins/src/adapters/yield/mux/index.ts
+++ b/coins/src/adapters/yield/mux/index.ts
@@ -1,0 +1,69 @@
+import { addToDBWritesList } from "../../utils/database";
+import { Write } from "../../utils/dbInterfaces";
+import axios from "axios";
+
+/*//////////////////////////////////////////////////////////////////////////////
+                                   Constants                                             
+//////////////////////////////////////////////////////////////////////////////*/
+
+const MUXLP_ADDRESSES: Record<string, string> = {
+  arbitrum: "0x7CbaF5a14D953fF896E5B3312031515c858737C8",
+  avax: "0xAf2D365e668bAaFEdcFd256c0FBbe519e594E390",
+  bsc: "0x07145Ad7C7351c6FE86b6B841fC9Bed74eb475A7",
+  fantom: "0xDDAde9a8dA4851960DFcff1AE4A18EE75C39eDD2",
+  optimism: "0x0509474f102b5cd3f1f09e1E91feb25938eF0f17",
+};
+
+/*//////////////////////////////////////////////////////////////////////////////
+                                    Helpers                                            
+//////////////////////////////////////////////////////////////////////////////*/
+
+async function fetchFromMuxAPI() {
+  try {
+    const response = await axios.get(
+      "https://app.mux.network/api/liquidityAsset"
+    );
+    const { muxLPPrice } = response.data;
+    return parseFloat(muxLPPrice);
+  } catch (err) {
+    return undefined;
+  }
+}
+
+/*//////////////////////////////////////////////////////////////////////////////
+                                      Main                                          
+//////////////////////////////////////////////////////////////////////////////*/
+
+export function mux(timestamp: number = 0) {
+  console.log("starting mux");
+  return Promise.all(
+    Object.keys(MUXLP_ADDRESSES).map((c) => getTokenPrices(c, timestamp))
+  );
+}
+
+async function getTokenPrices(
+  chain: string,
+  timestamp: number
+): Promise<Write[]> {
+  const writes: Write[] = [];
+  const token: string = MUXLP_ADDRESSES[chain];
+  const price: number | undefined = await fetchFromMuxAPI();
+  const decimals: number = 18;
+  const symbol: string = "MUXLP";
+  const adapter: string = "mux-protocol";
+  const confidence: number = 1;
+
+  addToDBWritesList(
+    writes,
+    chain,
+    token,
+    price,
+    decimals,
+    symbol,
+    timestamp,
+    adapter,
+    confidence
+  );
+
+  return writes;
+}


### PR DESCRIPTION
# Protocol
MUX Leveraged Trading Protocol - A decentralized leveraged trading protocol that offers zero price impact trading, up to 100x leverage, no counterparty risks for traders and an optimized on-chain trading experience. Traders will trade against the MUX native pool (MUXLP pool) on the Leveraged Trading Protocol.

# Description
The universal liquidity pool on MUX holds a portfolio of assets, and each asset has a targeted weight in the pool. Pooled assets will be utilized for MUX margin trading to earn fees.
Users can provide liquidity by buying MUXLP with assets allowed by the portfolio. MUXLP tokens are minted when buy orders are filled and burnt when sold. The MUXLP token price is calculated by dividing the MUXLP pool value by the total MUXLP supply. After buying MUXLP tokens, users can stake the tokens to earn protocol income and MUX rewards.

# Links
- App: https://app.mux.network/#/liquidity/stats?chainId=42161
- MuxLP docs: https://docs.mux.network/protocol/liquidity
- Contract address accross chains: https://docs.mux.network/protocol/contracts/contracts-protocol
- Coin Price API: https://app.mux.network/api/liquidityAsset