### PR TITLE
Update tokenMapping.json correctly

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -161,7 +161,7 @@
       "symbol": "USDT",
       "to": "coingecko#tether"
     },
-    "0xae78736cd615f374d3085123a210448e74fc6393": {
+    "0x53878B874283351D26d206FA512aEcE1Bef6C0dD": {
       "decimals": "18",
       "symbol": "rETH",
       "to": "coingecko#rocket-pool-eth"


### PR DESCRIPTION
I think the original address is wrong (it's not for scroll, but mainnet). Take a look at the json file

https://scroll-tech.github.io/token-list/scroll.tokenlist.json