### PR TITLE
Add Umbrella Network as oracle for WeFi

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -29046,7 +29046,7 @@ const data2: Protocol[] = [
     cmcId: "24771",
     category: "Lending",
     chains: ["Polygon"],
-    oracles: [],
+    oracles: ["Umbrella Network"],
     forkedFrom: ["Compound V2"],
     module: "paxo-finance/index.js",
     twitter: "wefi_xyz",


### PR DESCRIPTION
Add "Umbrella Network" as oracle for WeFi protocol.

The partnership was announced in this tweet: https://twitter.com/UmbNetwork/status/1712466650547806274