### PR TITLE
Add RedStone Oracles to Premia

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -17754,7 +17754,7 @@ const data3: Protocol[] = [
     category: "Options",
     chains: ["Arbitrum"],
     module: "premia-v3/index.js",
-    oracles: [],
+    oracles: ["RedStone"],
     forkedFrom: [],
     twitter: "PremiaFinance",
     parentProtocol: "parent#premia",


### PR DESCRIPTION
gm,
we would like to request adding RedStone as an Oracle for Premia

Materials:
https://twitter.com/PremiaFinance/status/1703773649847693581 
https://docs.premia.blue/the-premia-protocol/concepts/oracles 

Thanks
Matt
