### PR TITLE
feat(abracadabra): Add pricing for MagicCurveLP on Kava

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -63,6 +63,7 @@ export default {
   curve10: require("./markets/curve"),
   curve11: require("./markets/curve"),
   curve12: require("./markets/curve"),
+  curve13: require("./markets/curve"),
   balancer1: require("./markets/balancer"),
   balancer2: require("./markets/balancer"),
   balancer3: require("./markets/balancer"),

--- a/coins/src/adapters/markets/curve/contracts.json
+++ b/coins/src/adapters/markets/curve/contracts.json
@@ -133,5 +133,10 @@
     "addressProvider": "0x0000000022d53366457f9d5e68ec105046fc4383",
     "gasTokenDummy": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
     "wrapped": "0x471ece3750da237f93b8e339c536989b8978a438"
+  },
+  "kava": {
+    "addressProvider": "0x0000000022D53366457F9d5E68Ec105046FC4383",
+    "gasTokenDummy": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "wrapped": "0xc86c7C0eFbd6A49B35E8714C5f59D99De09A225b"
   }
 }

--- a/coins/src/adapters/markets/curve/index.ts
+++ b/coins/src/adapters/markets/curve/index.ts
@@ -91,3 +91,10 @@ export function curve12(timestamp: number = 0) {
     getGaugePrices("xdai", timestamp),
   ]);
 }
+export function curve13(timestamp: number = 0) {
+  console.log("starting curve13");
+  return Promise.all([
+    getTokenPrices2("kava", defaultRegistries, timestamp),
+    getGaugePrices("kava", timestamp),
+  ]);
+}

--- a/coins/src/adapters/yield/misc4626/tokens.json
+++ b/coins/src/adapters/yield/misc4626/tokens.json
@@ -31,5 +31,8 @@
   "optimism": {
     "auraBPT-rETH-ETH-vault": "0x61ac9315a1ae71633e95fb35601b59180ec8d61d",
     "auraECLP-wstETH-WETH-vault": "0x9f43f726df654e033b04c39989af90ab44875feb"
+  },
+  "kava": {
+    "mCurveLP-MIM-USDT": "0x729D8855a1D21aB5F84dB80e00759E7149936e30"
   }
 }


### PR DESCRIPTION
Added support for MaigcCurveLP on Kava. Also added price for Curve on Kava as MagicCurveLP is an ERC4626 of a Curve pool (does this need to happen in a separate PR?). Untested as I do not know how, so may not work.