### PR TITLE
fix: wrong manta TIA API id

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -8534,7 +8534,7 @@
     "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa": {
       "decimals": "6",
       "symbol": "TIA",
-      "to": "coingecko#tia"
+      "to": "coingecko#celestia"
     },
     "0x2fe3ad97a60eb7c79a976fc18bb5ffd07dd94ba5": {
       "decimals": "18",


### PR DESCRIPTION
fix: token(0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa) wrong coingecko API id

https://www.coingecko.com/en/coins/celestia
https://www.coingecko.com/en/coins/tia

<img width="1588" alt="image" src="https://github.com/DefiLlama/defillama-server/assets/150323222/5e3a3f48-b085-435d-bede-5721b213ad15">
