### PR TITLE
edit oracle list: added supra to defi kingdom protocol

### DIFF
--- a/defi/src/cli/users/refillChaintxs.ts
+++ b/defi/src/cli/users/refillChaintxs.ts
@@ -1,72 +1,15 @@
 require("dotenv").config();
-import { queryFlipside } from "../../../dimension-adapters/helpers/flipsidecrypto";
+import protocolAddresses from "../../../dimension-adapters/users/routers/routerAddresses";
+import { isAcceptedChain } from "../../../dimension-adapters/users/utils/convertChain";
 import { PromisePool } from '@supercharge/promise-pool'
-import { storeTxs } from "../../users/storeUsers";
+import { storeChainTxs } from "./queries/txs";
 
-async function storeTxsInDb(chain:string, usersChart:[string, number][]){
+async function main() {
+    const filtered = protocolAddresses.filter(addresses => {
+        return Object.entries(addresses.addresses).some(([chain, addys]) => isAcceptedChain(chain) && addys.length > 0)
+    })
     await PromisePool
-            .withConcurrency(10)
-            .for(usersChart).process(async ([dateString, users]) => {
-                const date = new Date(`${dateString}`)
-                const start = Math.round(date.getTime() / 1e3)
-                const end = start + 24 * 3600
-                if(end > Date.now()/1e3){
-                    return
-                }
-                try{
-                    await storeTxs(start, end, `chain#${chain}`, "all", users) // if already stored -> don't overwrite
-                } catch(e){
-                    if(!String(e).includes("duplicate key value violates unique constraint")){
-                        console.error(`Couldn't store users on ${chain}`, e)
-                    }
-                }
-            })
+        .withConcurrency(5)
+        .for(filtered).process(storeChainTxs)
 }
-
-async function main(){
-    await Promise.all([
-        "arbitrum", "avalanche", "bsc", "ethereum", "gnosis", "optimism", "polygon",
-    ].map(async (chain) => {
-        const usersChart = await queryFlipside(`SELECT
-            date_trunc(day, block_timestamp) as dt, 
-            count(tx_hash) uniques
-        from
-            ${chain}.core.fact_transactions
-        group by dt`)
-        await storeTxsInDb(chain, usersChart)
-
-    }))
-}
-
-async function solana(){
-    const usersChart = await queryFlipside(`SELECT
-        date_trunc(day, block_timestamp) as dt, 
-        count(TX_ID) uniques
-    from
-        solana.core.fact_transactions
-    group by dt`)
-    await storeTxsInDb("solana", usersChart)
-}
-
-async function near(){
-    const usersChart = await queryFlipside(`SELECT
-        date_trunc(day, block_timestamp) as dt, 
-        count(tx_hash) uniques
-    from
-        near.core.fact_transactions
-    group by dt`)
-    await storeTxsInDb("near", usersChart)
-}
-
-async function osmosis(){
-    const usersChart = await queryFlipside(`SELECT
-        date_trunc(day, block_timestamp) as dt, 
-        count(tx_id) uniques
-    from
-        osmosis.core.fact_transactions
-    group by dt`)
-    await storeTxsInDb("osmosis", usersChart)
-}
-Promise.all([main()
-    , solana(), near(), osmosis()
-]).then(()=>console.log("finished!"))
+main()

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -9721,6 +9721,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     audit_links: ["https://solidity.finance/audits/DefiKingdoms/"],
     forkedFrom: ["Uniswap V2"],
     governanceID: ["snapshot:dfkvote.eth"],
+    oracles: ["Supra"],
     github: ["DefiKingdoms"]
   },
   {

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5364,7 +5364,7 @@ const data3: Protocol[] = [
     module: "turbos/index.js",
     twitter: "Turbos_finance",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Supra"],
     listedAt: 1683484936
   },
   {


### PR DESCRIPTION
Hi,
We would like to add the use of Supra's VRF Oracle to Defi Kingdoms. All of DFK's VRF services are supported by Supra. 

Materials
-> https://devs.defikingdoms.com/dfk-chain/ecosystem-partners/supraoracles-vrf
-> https://supraoracles.com/news/supraoracles-partners-with-defi-kingdoms-the-first-multi-chain-play-to-earn-game/
-> https://x.com/SupraOracles/status/1622681593960890368?s=20
-> https://qa-spa.supraoracles.com/academy/what-is-defi-kingdoms-kingdoms/

Rationale
Defi Kingdoms uses Supra's VRF oracle for all of their randomization needs. 

Thank you in advance. Let me know if you need any more info.

Best,
Keith