### PR TITLE
Change 'substanceX' to 'Substance Exchange'

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -25215,11 +25215,11 @@ const data3: Protocol[] = [
   },
   {
     id: "3835",
-    name: "SubstanceX",
+    name: "Substance Exchange",
     address: null,
     symbol: "-",
     url: "https://app.substancex.io/perpetual/",
-    description: "SubstanceX is a derivatives protocol that leads the shift towards decentralized trading. SubstanceX offers futures and options, and achieves a pop-up-free trading experience through 1-click technology.",
+    description: "Substance Exchange (SubstanceX) is a derivatives protocol that leads the shift towards decentralized trading. SubstanceX offers futures and options, and achieves a pop-up-free trading experience through 1-click technology.",
     chain: "Arbitrum",
     logo: `${baseIconsUrl}/substancex.jpg`,
     audits: "0",


### PR DESCRIPTION
Hello, we'd like to change the protocol name from the abbreviated 'substanceX' to the formal 'Substance Exchange' now. Thank you so much!