### PR TITLE
Remove DIA from Silo Finance [Arbitrum] entirely

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -14344,7 +14344,7 @@ const data2: Protocol[] = [
     category: "Lending",
     chains: ["Ethereum"],
     oraclesByChain: {
-      arbitrum: ["Chainlink", "TWAP","DIA"],
+      arbitrum: ["Chainlink", "TWAP"],
       ethereum: ["Chainlink", "TWAP"]
     },
     forkedFrom: [],


### PR DESCRIPTION
Gm, there was a previous PR i did [here](https://github.com/DefiLlama/defillama-server/pull/4422) where i said to remove DIA as an oracle for Silo on the Ethereum Markets, as governance only approved Arbitrum markets.

Since then i did a bit more digging into what Silo actually uses on an asset by asset basis. 
Each pool is in effect isolated, so whatever oracles you use, you merely "secure" those pools. 
There are 60M in TVL for Silo on the Arbitrum markets of which all is attributed to DIA. 
However, if you investiage on the [Silo Dahsboard ](https://app.silo.finance/) which pools are actually secured by DIA, we come to a total of 2.68M (4.46% of the entire arbitrum TVL).

The following markets are secured by DIA:
[Silo ](https://app.silo.finance/silo/0xae1Eb69e880670Ca47C50C9CE712eC2B48FaC3b6) - TVL: 135k
[Grail ](https://app.silo.finance/silo/0xB9D098E61eC165D3c530Dd67CE77B18BE426ea91) - TVL: 910k
[Jones ](https://app.silo.finance/silo/0x82622a6bdD2f1FA757a08837633971D42C17241a) - TVL: 1.1M
[Plutus ](https://app.silo.finance/silo/0xa4487d52a5AC147f249D44D5AF8b3C71Eba77478) - TVL: 343k
[RDPX ](https://app.silo.finance/silo/0x950AAEDa8C6E806A8c889B4dBCc0361760b86249) - TVL: 200k (Deprecated since 2 weeks)

As usual, this is heavy stats padding by oracle projects and considering that DIA is only securing roughly 4.46% of the entire Arbitrum TVL of Silo and considering that the secured pools have nothing to do with the remaining 95.54% (as they are silo'd) i'd suggest removing DIA entirely, if there is no easy way to attribute them only the pools they secure.