### PR TITLE
added Supra as oracle to Turbos

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -972,7 +972,7 @@ const data: Protocol[] = [
     treasury: "idle-dao.js",
     twitter: "idlefinance",
     audit_links: ["https://docs.idle.finance/developers/security/audits"],
-    oracles: ["Chainlink"],
+    oracles: [],
     governanceID: [
       "snapshot:staking.idlefinance.eth", 
       "snapshot:idlefinance.eth",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5366,7 +5366,7 @@ const data3: Protocol[] = [
     module: "turbos/index.js",
     twitter: "Turbos_finance",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Supra"],
     listedAt: 1683484936
   },
   {


### PR DESCRIPTION
Hi,
We would like to add the use of Supra's Oracle to Turbos Finance. Supra offers Turbos Finance access to its oracle toolkits, which help enhance the platform’s functionality. Supra provides data oracles to Turbos Finance for pricing feeds, which are essential for Turbos’ perpetual trading.

You can see Supra listed as a partner on their website: https://www.turbos.finance/

Materials
-> https://supraoracles.com/news/supraoracles-partners-with-turbos-finance-a-decentralized-perpetual-exchange-in-the-sui-ecosystem/

Rationale
Supra provides data oracles to Turbos Finance for pricing feeds, which are essential for Turbos’ perpetual trading.

Thank you in advance. Let me know if you need any more info.

Best,
Keith