### PR TITLE
Modify Category - Ondo Finance

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -26248,7 +26248,7 @@ const data2: Protocol[] = [
     audit_note: null,
     gecko_id: "ondo-finance",
     cmcId: null,
-    category: "RWA",
+    category: "RWA Lending",
     chains: ["Ethereum"],
     module: "ondofinance/index.js",
     twitter: "OndoFinance",


### PR DESCRIPTION
According to the category descriptions linked [here](https://defillama.com/categories) 

We feel as though Ondo better falls into the RWA-Lending category as it tokenizes real world assets for use as collateral. 
As opposed to the tokenization of physical non-traditional-financial assets.

Ty 🫡