### PR TITLE
removed chainlink from Idle

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -972,7 +972,7 @@ const data: Protocol[] = [
     treasury: "idle-dao.js",
     twitter: "idlefinance",
     audit_links: ["https://docs.idle.finance/developers/security/audits"],
-    oracles: ["Chainlink"],
+    oracles: [],
     governanceID: [
       "snapshot:staking.idlefinance.eth", 
       "snapshot:idlefinance.eth",


### PR DESCRIPTION
I spoke with the team at Idle, and here is a screenshot of them declaring that they do not use chainlink as an oracle.

<img width="1015" alt="Screenshot 2023-12-06 at 4 35 06 AM" src="https://github.com/DefiLlama/defillama-server/assets/51958351/57cc8d77-6105-41d4-813a-a4804d12925a">