### PR TITLE
add dforce and ktx

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -393,12 +393,15 @@ const data: Protocol[] = [
     gecko_id: "dforce-token",
     cmcId: "4758",
     category: "Lending",
-    chains: ["Ethereum", "Binance", "Arbitrum"],
+    chains: ["Ethereum", "Binance", "Arbitrum","Conflux"],
     module: "dforce/index.js",
     twitter: "dForcenet",
     audit_links: ["https://github.com/dforce-network/documents/tree/master/audit_report/Lending"],
     forkedFrom: [],
-    oracles: ["Chainlink"],
+    oraclesByChain: {
+      ethereum: ["Chainlink"],
+      conflux: ["Pyth"],
+    },
     governanceID: ["snapshot:dforcenet.eth"],
     stablecoins: ["dforce-usd"],
     github: ["dforce-network"] //check

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -7236,11 +7236,14 @@ const data3: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Derivatives",
-    chains: ["Binance"],
+    chains: ["Binance","Mantle"],
     module: "ktx/index.js",
     twitter: "KTX_finance",
     forkedFrom: ["GMX V1"],
-    oracles: ["Chainlink"],
+    oraclesByChain: {
+      binance: ["Chainlink"],
+      mantle: ["Pyth"],
+    },
     audit_links: ["https://ktx-public-assets.s3.ap-southeast-1.amazonaws.com/MetaScan_Report_KTX_Finance.pdf"],
     listedAt: 1685029448
   },


### PR DESCRIPTION
gm llama sirs

requesting your review to add KTX and dForce as Pyth oracle users, on Mantle and Conflux respectively

links attached:

https://docs.ktx.finance/background

https://docs.dforce.network/faq-and-guides/faq#how-do-you-source-price-feeds

thank you