### PR TITLE
add switchboard end users

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -7629,7 +7629,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "solend/index.js",
     twitter: "solendprotocol",
     audit_links: ["https://github.com/solendprotocol/solana-program-library/tree/master/token-lending/audit"],
-    oracles: ["Pyth"],
+    oracles: ["Pyth", "Switchboard"],
     github: ["solendprotocol"]
   },
   {
@@ -7871,7 +7871,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
       "https://drive.google.com/file/d/1iRy6v6_CsJKXOBSk_6mg4kmqvBL-Aqlj/view?usp=sharing",
       "https://drive.google.com/file/d/1HHHveh99XGfvkyqBZWvzzdNMot2ETm9q/view?usp=sharing",
     ],
-    oracles: ["Pyth"],
+    oracles: ["Pyth", "Switchboard'],
     github: ["port-finance"]
   },
   {
@@ -9298,7 +9298,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "larix.js",
     twitter: "ProjectLarix",
     audit_links: ["https://docs.projectlarix.com/how-to-prove/audit"],
-    oracles: ["Pyth"],
+    oracles: ["Pyth", "Switchboard"],
     openSource: false,
   },
   {
@@ -11102,7 +11102,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     module: "francium.js",
     twitter: "Francium_Defi",
     audit_links: ["https://www.certik.org/projects/francium"],
-    oracles: ["Pyth"],
+    oracles: ["Pyth", "Switchboard"],
     openSource: false,
   },
   {

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -13011,7 +13011,7 @@ const data2: Protocol[] = [
     category: "Derivatives",
     chains: ["Avalanche"],
     module: "hubble-exchange/index.js",
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "Switchboard"],
     forkedFrom: [],
     twitter: "HubbleExchange",
     audit_links: ["https://docs.hubble.exchange/audit-reports"],
@@ -18946,7 +18946,7 @@ const data2: Protocol[] = [
     module: "mercurical-vaults/index.js",
     twitter: "MeteoraAG",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Switchboard"],
     audit_links: [
       "https://drive.google.com/file/d/1CjdMl7LhJisnI1LTrAFt2Bvi5ahqq1yc/view",
       "https://drive.google.com/file/d/1cJ2ZH23yj9uO1otR2pLDQ1MP3OJm84IW/view"
@@ -26893,7 +26893,7 @@ const data2: Protocol[] = [
     chains: ["Solana"],
     module: "marginfi/index.js",
     twitter: "marginfi",
-    oracles: ["Pyth"],
+    oracles: ["Pyth", "Switchboard"],
     forkedFrom: [],
     parentProtocol: "parent#marginfi",
     listedAt: 1677103747


### PR DESCRIPTION
Here's a query of on-chain transactions where protocols are utilizing / reading from Switchboard: [https://flipsidecrypto.xyz/switchboard/q/_cI9g_PQOIxj/v2_unique_pid_count](https://flipsidecrypto.xyz/switchboard/q/_cI9g_PQOIxj/v2_unique_pid_count)