### PR TITLE
add api3 user

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -26906,7 +26906,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Linea"],
-    oracles: ["Pyth"], // https://github.com/DefiLlama/defillama-server/pull/5205
+    oracles: ["Pyth","API3"], // https://github.com/DefiLlama/defillama-server/pull/5205
     forkedFrom: [],
     module: "metavault-derivatives-v2/index.js",
     twitter: "MetavaultTRADE",


### PR DESCRIPTION
Hey Llamas. 

Metavault Perps v2 is utilizing a double oracle approach with pulling prices from Pyth and checking them against API3. 
Traders hence can only open a position if Pyth & API3 are within a certain range from each other.

https://x.com/MetavaultTRADE/status/1734226620591043063?s=20

Thank you!

