### PR TITLE
remove "Kamino Liquidity" from Pyth TVS

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -15299,7 +15299,7 @@ const data2: Protocol[] = [
     cmcId: null,
     category: "Liquidity manager",
     chains: ["Solana"],
-    oracles: ["Pyth"],
+    oracles: [],
     forkedFrom: [],
     module: "kamino/index.js",
     twitter: "Kamino_Finance",


### PR DESCRIPTION
This is a PR to remove the Liquidity Product of the Project Kamino from Pyth TVS. 

[According to their documentation,](https://docs.kamino.finance/products/liquidity) using Kamino Liquidtiy, you can pool assets and receive kTokens for them that are in effect simply LP tokens (no oracle involvement, also not found in their documentation). 

These tokens are then useable in their lending product [Kamino Lend](https://defillama.com/protocol/kamino-lend). 
Not only, is the TVS being double counted here, as Kamino Liquidity kTokens are all TVL for Kamino Liquidity and effectively nearly all TVL in Kamino Lend (because the kTokens are simply deposited there), but i couldn't find any evidence for Kamino Liquidity actually utilizing oracles for the creation of these kTokens.

The only thing that utilizes oracles is Kamino Lend (to price these LP tokens) and as such Pyth should be kept as an oracle on Kamino Lend, but removed as an oracle on Kamino Liquidity. 