### PR TITLE
Change Phoenix Trade to Phoenix

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -10501,7 +10501,7 @@ const data3: Protocol[] = [
   },
   {
     id: "3170",
-    name: "Phoenix Trade", // previous name: "Ellipsis Labs", 
+    name: "Phoenix", // previous name: "Ellipsis Labs", 
     address: null,
     symbol: "-",
     url: "https://phoenix.trade",


### PR DESCRIPTION
protocol's name is phoenix and not phoenix trade

also it seems like the update broke volume for phoenix being displayed on the defillama website? is this just a transient break or should we look for what happened