### PR TITLE
Remove Indigo from Chainlink TVS

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -20886,7 +20886,7 @@ const data2: Protocol[] = [
     audit_links: [
       "https://docs.indigoprotocol.io/resources/audit"
     ],
-    oracles: ["Chainlink"],
+    oracles: [],
     listedAt: 1669327585,
     stablecoins: ["iusd"],
     wrongLiquidity: true, // coingecko has the wrong address for it


### PR DESCRIPTION
Well, Chainlink doesn't operate on Cardano.
Should be simple enough.