### PR TITLE
Oracle details updated for Netxer finance(Previously Bhvaish Finance)

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -26601,7 +26601,7 @@ const data2: Protocol[] = [
     module: "bhavish/index.js",
     twitter: "NexterDotFi",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"],
     audit_links: ["https://nexter.fi/docs/blocksec-audit-report.pdf", "https://nexter.fi/docs/slowmist-audit-report.pdf"],
     listedAt: 1676983479,
     github: ["Bhavish-finance"]

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -26601,7 +26601,7 @@ const data2: Protocol[] = [
     module: "bhavish/index.js",
     twitter: "NexterDotFi",
     forkedFrom: [],
-    oracles: ["Pyth"],
+    oracles: ["Pyth"], // https://github.com/DefiLlama/defillama-server/pull/5339
     audit_links: ["https://nexter.fi/docs/blocksec-audit-report.pdf", "https://nexter.fi/docs/slowmist-audit-report.pdf"],
     listedAt: 1676983479,
     github: ["Bhavish-finance"]


### PR DESCRIPTION
To obtain the price of assets like Bitcoin and Ethereum, we leverage PYTH's on-chain oracle. We also use this price feed to start and end rounds. 
