### PR TITLE
update gravita oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -6496,7 +6496,14 @@ const data3: Protocol[] = [
     chains: ["Ethereum"],
     module: "gravita-protocol/index.js",
     twitter: "gravitaprotocol",
-    oracles: ["Chainlink", "RedStone"],
+    oraclesByChain: {
+      ethereum: ["Chainlink","Redstone"],
+      arbitrum: ["Chainlink"],
+      zksync_era: ["Chainlink"],
+      linea: ["Chainlink"],
+      polygon_zkevm: ["Chainlink"],
+      optimism: ["Chainlink"],
+    },
     forkedFrom: ["Liquity"],
     stablecoins: ["grai"],
     audit_links: [


### PR DESCRIPTION
it's me again. did some digging into this one. 
They're creating isolated lending markets for each LSD and allow you to mint GRAI against it. 
Claim to be using Redstone & Chainlink and upon further questioning revealed that Redstone is only used for ETHx, swETH and weETH. 

Those assets are only available on mainnet, hence Redstone can only be used on mainnet in addition to Chainlink.
I split the oracles per chain for that reason. 
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/cf0c8e66-edc3-49be-a848-0230d27bc2ac)


Theoretically Redstone would need to be removed entirely, but i'll let you make that call since i don't want to rustle even more jimmies. Since each LSD is isolated a redstone misreport on a single one can't impact the entire TVL on ETH. 

![image](https://github.com/DefiLlama/defillama-server/assets/139578304/4bf5cdd4-8b55-427c-b008-3887587f30fc)

There is a total of 37M of TVL on ETH, of which Redstone secures 10.6M (weETH), 2.66M (swETH) and 4.5k (ETHx), which amounts to roughly 13.26M. That's 36% of the TVL on ETH. 

Like i said, kept redstone in for mainnet since i don't wanna make that call, but theoretically they'd need to be removed according to your definition of >50% of TVL. I'll leave that to you to decide. 

However, they need to be removed on the other chains whatever you decide on for mainnet. 



