### PR TITLE
add api3 oracle to lendle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -13415,7 +13415,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Mantle"],
-    oracles: ["Pyth"],
+    oracles: ["API3","Pyth"],
     forkedFrom: ["AAVE V2"],
     module: "lendle/index.js",
     twitter: "lendlexyz",


### PR DESCRIPTION
[Lendle.xyz](https://www.lendle.xyz) has integrated API3 oracles for their mETH market.
- Docs: https://docs.lendle.xyz/using-the-lendle-application/markets/borrow/liquidations-and-flashloans#oracles
- Announcement: https://twitter.com/API3ECO/status/1737473083336728910

 mETH is currently the biggest market on lendle securing over 2.4 million in value and containing most of the protocols TVL. In addition it has the highest APR on the platform compared to other assets
<img width="483" alt="ishare-1704410417" src="https://github.com/DefiLlama/defillama-server/assets/31223740/082144c2-cb06-4955-9bf0-15c9b5686c6b"> 


as such API3 is crucial in its operation