### PR TITLE
fix: use correct name for bsc

### DIFF
--- a/coins/src/adapters/yield/mean-finance/index.ts
+++ b/coins/src/adapters/yield/mean-finance/index.ts
@@ -7,7 +7,7 @@ export function meanFinance(timestamp: number = 0) {
     getTokenPrices("polygon", timestamp),
     getTokenPrices("arbitrum", timestamp),
     getTokenPrices("ethereum", timestamp),
-    // getTokenPrices("bnb", timestamp),
+    getTokenPrices("bsc", timestamp),
     getTokenPrices("xdai", timestamp),
   ]);
 }


### PR DESCRIPTION
We found the issue with why BNB chain was failing. I'm assuming that using `bnb` worked at some point, but then it stopped working