### PR TITLE
Update tokenMapping for hyUSD (Base)

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -265,6 +265,11 @@
       "decimals": "18",
       "symbol": "rcbETH",
       "to": "coingecko#ethereum"
+    },
+    "0xcc7ff230365bd730ee4b352cc2492cedac49383e": {
+      "decimals": "18",
+      "symbol": "hyUSD",
+      "to": "coingecko#high-yield-usd-base"
     }
   },
   "aptos": {


### PR DESCRIPTION
This change adds hyUSD (minted [here](https://register.app/#/overview?token=0xCc7FF230365bD730eE4B352cC2492CEdAC49383e&chainId=8453)) to DefiLlama's coin price API