### PR TITLE
chore: Dyson Finance update oracles

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -22463,7 +22463,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Dexes",
     chains: ["Linea"],
-    oracles: [],
+    oracles: ["Pyth"],
     module: "dyson/index.js",
     twitter: "DysonFinance",
     forkedFrom: ["Uniswap V2"],


### PR DESCRIPTION
This is an update to use Pyth as the oracle for Dyson Finance.