### PR TITLE
Chore: Update Mento Oracle Providers

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -8614,7 +8614,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     audit_links: ["https://celo.org/audits"],
     stablecoins: ["celo-dollar", "celo-euro"],
     github: ["mento-protocol"],
-    oracles: ['cLabs', 'T-Systems MMS', 'Redstone']
+    oracles: ['cLabs', 'T-Systems MMS', 'RedStone']
   },
   {
     id: "505",

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -8614,7 +8614,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     audit_links: ["https://celo.org/audits"],
     stablecoins: ["celo-dollar", "celo-euro"],
     github: ["mento-protocol"],
-    oracles: ['cLabs'] // Redstone is only used as backup
+    oracles: ['cLabs', 'T-Systems MMS', 'Redstone']
   },
   {
     id: "505",


### PR DESCRIPTION
Hi Llama team,

Can you please review the PR below?
It follows the upgrade that happened in December in our Oracle setup and made RedStone a mainnet Oracle for all our feeds, equal to CLabs and T-Systems MMS:

https://twitter.com/MentoLabs/status/1747559367350661518

Many thanks!