### PR TITLE
Added API3 as an oracle for Tropykus zkEVM

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -8000,7 +8000,7 @@ const data3: Protocol[] = [
     module: "tropykus-zkevm/index.js",
     twitter: "tropykus",
     forkedFrom: ["AAVE V2"],
-    oracles: [],
+    oracles: ["API3"],
     parentProtocol: "parent#tropykus-finance",
     listedAt: 1685700448
   },


### PR DESCRIPTION
We just added API3 as the oracle provider for Tropykus zkEVM