### PR TITLE
Add API3 Oracle to Init Capital

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30130,7 +30130,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Mantle"],
-    oracles: ["API3"], // they mention API3 in the listing process, but no mention of how is securing their TVL, neither there is no mention of oracles in the docs
+    oracles: ["API3"],
     forkedFrom: [],
     module: "init-capital/index.js",
     twitter: "InitCapital_",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30076,7 +30076,7 @@ const data3: Protocol[] = [
     chains: ["Ethereum", "Mantle"],
     oraclesByChain: {
       ethereum: ["Chainlink"], 
-      manta: ["API3"],
+      mantle: ["API3"],
     },
     forkedFrom: ["Compound V2"],
     module: "minterest/index.js",
@@ -30130,7 +30130,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Mantle"],
-    oracles: [], // they mention API3 in the listing process, but no mention of how is securing their TVL, neither there is no mention of oracles in the docs
+    oracles: ["API3"], // they mention API3 in the listing process, but no mention of how is securing their TVL, neither there is no mention of oracles in the docs
     forkedFrom: [],
     module: "init-capital/index.js",
     twitter: "InitCapital_",


### PR DESCRIPTION
Init capital uses API3 feeds for all of their money markets on Mantle : https://init-capital.gitbook.io/init-capital/borrowing/assets-list#stable-assets

<img width="614" alt="ishare-1706145749" src="https://github.com/DefiLlama/defillama-server/assets/31223740/33437a1c-141f-4ec0-a837-d3e6980c8fc9">

In case its not clear, Init is a decentralized lending and borrowing protocol similar to AAVE and Compund but with the ability for other dAPPs to tap into the borrowing and lending side using "Hooks" . As with any lending and borrowing protocol the TVL is secured by Oracles for things like liquidations and API3 is oracle used by init as stated in their docs

For Mintrest there was a typo, Mintrest is not live on manta, it is live on Mantle :)

<img width="373" alt="ishare-1706145979" src="https://github.com/DefiLlama/defillama-server/assets/31223740/643fda0c-57a9-4cf7-9248-bbc76a920355">
