### PR TITLE
Update VirtuSwap metadata

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -28119,7 +28119,7 @@ const data3: Protocol[] = [
     category: "Dexes",
     chains: ["Polygon"],
     oracles: [], 
-    forkedFrom: ["Uniswap V2"],
+    forkedFrom: [],
     module: "virtuswap/index.js", 
     twitter: "VirtuSwap", 
     audit_links: ["https://github.com/Virtuswap/v1-core/tree/main/audits"],


### PR DESCRIPTION
Remove "Forked from Uniswap V2", because our protocol has different interface than Uniswap V2.