### PR TITLE
feat: add pyth network to interest protocol sui

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -7034,7 +7034,7 @@ const data3: Protocol[] = [
     chains: ["Sui"],
     module: "interest-protocol/index.js",
     twitter: "interest_dinero",
-    oracles: [],
+    oracles: ["Pyth"],
     audit_links: [
       "https://github.com/interest-protocol/sui-defi/blob/main/audits/Interest%20Protocol%20DEX%20Smart%20Contract%20Audit%20Report.pdf"
     ],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -7034,7 +7034,7 @@ const data3: Protocol[] = [
     chains: ["Sui"],
     module: "interest-protocol/index.js",
     twitter: "interest_dinero",
-    oracles: ["Pyth"],
+    oracles: ["Pyth"], // https://twitter.com/interest_dinero/status/1756237453910835644
     audit_links: [
       "https://github.com/interest-protocol/sui-defi/blob/main/audits/Interest%20Protocol%20DEX%20Smart%20Contract%20Audit%20Report.pdf"
     ],


### PR DESCRIPTION
We updated the oracle provider for Interest Protocol on Sui as we use them to secure our protocol.

Ann here: https://twitter.com/interest_dinero/status/1756237453910835644