### PR TITLE
update oracles for kinetix derivs v2

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31385,7 +31385,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Kava"],
-    oracles: ["Pyth", "API3"],
+    oracles: ["Pyth", "API3"], // https://github.com/DefiLlama/defillama-server/pull/5845
     forkedFrom: [],
     module: "kinetix-derivatives-v2/index.js",
     twitter: "KinetixFi",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31385,7 +31385,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Kava"],
-    oracles: [], 
+    oracles: ["Pyth", "API3"],
     forkedFrom: [],
     module: "kinetix-derivatives-v2/index.js",
     twitter: "KinetixFi",


### PR DESCRIPTION
Similar to kinetix dervis (v1), kinetix dervis v2 are powered by Pyth & API3. 
Tweet can be found here: https://x.com/KinetixFi/status/1755722584119750867?s=20