### PR TITLE
Add RedStone to Gravita on Eth mainnet

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -6498,7 +6498,7 @@ const data3: Protocol[] = [
     module: "gravita-protocol/index.js",
     twitter: "gravitaprotocol",
     oraclesByChain: {
-      ethereum: ["Chainlink"], // Redstone currently only secures certain assets on mainnet not total 50% of the tvl on mainnet, it can be added in at a later time: https://github.com/DefiLlama/defillama-server/pull/5430
+      ethereum: ["Chainlink", "RedStone"],
       arbitrum: ["Chainlink"],
       zksync_era: ["Chainlink"],
       linea: ["Chainlink"],


### PR DESCRIPTION
Hey,
revisiting this conversation as the markets using RedStone now account for more than 50% of the TVL on Ethereum mainnet. 
As per DeFiLlama’s api:
weETH                     $14.10 M
swETH                     $2.32 M
osETH                      $209.91k
ethx                          $5.94k
Total:                       $16.69M


Out of the total: $30.90 M 
Redstone TVS: 54%

Therefore, we are proposing to add RedStone as an oracle provider for Gravita on Ethereum Mainnet.

Cheers, 
Matt
