### PR TITLE
Update Harbor Market gecko-id

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31851,7 +31851,7 @@ const data3: Protocol[] = [
     logo: `${baseIconsUrl}/harbor-market.jpg`,
     audits: "0",
     audit_note: null,
-    gecko_id: "harbor-2",
+    gecko_id: "harbor-3",
     cmcId: null,
     category: "Lending",
     chains: ["Binance"],


### PR DESCRIPTION
The currently used gecko-id for Harbor Market is incorrectly set to harbor-2. The correct gecko-id I'd like it to be set to is harbor-3.