### PR TITLE
Add RedStone to LayerBank on Manta

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12314,7 +12314,12 @@ const data3: Protocol[] = [
     module: "lineabank/index.js",
     twitter: "LayerBankFi",
     forkedFrom: ["Compound V2"],
-    oracles: ["Pyth"],
+    oraclesByChain: {
+      manta: ["RedStone"],
+      scroll: ["Pyth"],
+      linea: ["Pyth"],
+      mode: ["Pyth"]
+    },
     listedAt: 1689773129,
     audit_links: ["https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-LineaBank-v1.0.pdf"],
     github: ["layerbank"]

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12318,7 +12318,7 @@ const data3: Protocol[] = [
       manta: ["RedStone"],
       scroll: ["Pyth"],
       linea: ["Pyth"],
-      mode: ["Pyth"]
+      mode: ["RedStone"]
     },
     listedAt: 1689773129,
     audit_links: ["https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-LineaBank-v1.0.pdf"],


### PR DESCRIPTION
gm,
We kindly ask to update the oracle section for LayerBank on the Manta network. 

Links to the LayerBank docs: 
https://docs.layerbank.finance/protocol/lending/oracles

LayerBank’s Validator pointing to RedStone’s Oracle Contract: 
https://pacific-explorer.manta.network/address/0xF2C1E27A4Bf0D81Bb4A6E6e3E5DCD1DC6ED3A7fA?tab=read_contract#7dc0d1d0 