### PR TITLE
add redstone oracles to gearbox

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -21394,7 +21394,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     cmcId: "16360",
     category: "Leveraged Farming",
     chains: ["Ethereum"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "RedStone"],
     module: "gearbox/index.js",
     treasury: "gearbox.js",
     twitter: "GearboxProtocol",


### PR DESCRIPTION
Hello, 
requesting to add RedStone as an oracle provider for Gearbox. RedStone feeds protect our leveraged CreditAccounts providing data in pull model for real-time collateral valuation.

Materials:
Our oracle usage is described in https://docs.gearbox.finance/ e.g. here https://docs.gearbox.finance/traders-and-farmers/pro-leverage-bible#where-do-price-feeds-come-from

https://twitter.com/GearboxProtocol/status/1755632665523523707
