### PR TITLE
Update ZeroLend Oracles on Manta to RedStone

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12155,7 +12155,10 @@ const data3: Protocol[] = [
     chains: ["zkSync Era"],
     module: "zerolend/index.js",
     twitter: "zerolendxyz",
-    oracles: ["Pyth"],
+    oraclesByChain: {
+      manta: ["RedStone"],
+      zkSync: ["Pyth"]
+    },
     forkedFrom: ["AAVE V3"],
     audit_links: ["https://github.com/zerolend/audits/blob/main/mundus/zerolend_report_depcheck_final.pdf"],
     github: ["zerolend"],


### PR DESCRIPTION
Gm,
We kindly ask to update Oracles for ZeroLend protocol:

Oracle Provider(s): RedStone on Manta network

Implementation Details: RedStone provides all the price feeds for ZeroLend on Manta

Documentation/Proof: https://docs.zerolend.xyz/security/oracles/using-redstone-oracles