### PR TITLE
Add RedStone as an Oracle for Juice Finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33682,7 +33682,7 @@ const data3: Protocol[] = [
     module: "juice-finance/index.js",
     twitter: "Juice_Finance",
     forkedFrom: [], 
-    oracles: ["Pyth"],  //https://juice-finance.gitbook.io/juice-finance/technical-documents-and-section/technical-and-contracts-synopsis/pythpriceprovide
+    oracles: ["RedStone"],  //https://juice-finance.gitbook.io/juice-finance/juice-finance/quick-links
     listedAt: 1709308594
   },
   {


### PR DESCRIPTION
Gm,
We kindly ask to update Oracles for the JuiceFinance protocol:

Oracle Provider(s): RedStone

Implementation Details: RedStone provides all the price feeds for Juice Finance

Documentation/Proof: https://juice-finance.gitbook.io/juice-finance/juice-finance/quick-links

Announcement: https://twitter.com/redstone_defi/status/1767219012147311017