### PR TITLE
Update Repl category to Restaking

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -28860,7 +28860,7 @@ const data3: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Liquid Staking",
+    category: "Restaking",
     chains: ["Filecoin"],
     oracles: [],
     forkedFrom: [],


### PR DESCRIPTION
Liquid FIL is pledged with the Filecoin blockchain when participating in mining, and this is the native staking mechanism on Filecoin. Users that stake FIL natively can opt-in to the Repl protocol to restake their FIL to obtain pFIL, in order to use it for additional use cases such as securing other L2s. With such a mechanism, Filecoin can lend its security to its L2s by providing pledged FIL equivalent with pFIL. If would this be more appropriate to label Repl's category as a restaking protocol in the filecoin ecosystem.

Moving forward, we also plan to integrate other DePIN liquid staking tokens into the protocol by enabling them to be restaked on Repl to earn additional rewards.