### PR TITLE
Update oracles for Sturdy, Ionic & Ironclad

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31912,7 +31912,9 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Ethereum"],
-    oracles: [], 
+    oraclesByChain: {
+      mode: ["RedStone"], //https://docs.sturdy.finance/overview/security-and-audits
+    },
     forkedFrom: ["AAVE V2"],
     module: "sturdy-v2/index.js",
     twitter: "SturdyFinance",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30525,7 +30525,9 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Mode"],
-    oracles: ["Pyth"],  // https://twitter.com/modenetwork/status/1754878770840752421
+    oraclesByChain: {
+      mode: ["RedStone"] //https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
+    },
     forkedFrom: ["Compound V2"],
     module: "ionic/index.js",
     twitter: "ionicmoney",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34627,7 +34627,7 @@ const data3: Protocol[] = [
     chains: ["Mode"],
     module: "ironclad/index.js",
     twitter: "IroncladFinance",
-    oracles: ["Pyth"], // https://github.com/DefiLlama/DefiLlama-Adapters/pull/9221 
+    oracles: ["RedStone"], // https://docs.ironclad.finance/resources/protocol-security#base-oracle-provider
     forkedFrom: ["AAVE V2"], 
     listedAt: 1709767737
   },


### PR DESCRIPTION
Gm,
We kindly ask to update Oracles for the 

1) Sturdy protocol: 
     Implementation: RedStone provides all the price feeds for Sturdy on the MODE chain
     Documentation/Proof: https://docs.sturdy.finance/overview/security-and-audits
2) Ionic protocol:
      Implementation: RedStone provides all the price feeds for Ionic on the MODE chain
     Documentation/Proof: https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
3) Ironclad:
     Implementation: RedStone provides all the price feeds for Ironclad
     Documentation/Proof: https://docs.ironclad.finance/resources/protocol-security#base-oracle-provider
     
For your convenience  the links to docs are also included in the data file.    