### PR TITLE
add Pyth to Ionic

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30528,7 +30528,7 @@ const data3: Protocol[] = [
     category: "Lending",
     chains: ["Mode"],
     oraclesByChain: {
-      mode: ["RedStone"] //https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
+      mode: ["RedStone","Pyth"] //https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
     },
     forkedFrom: ["Compound V2"],
     module: "ionic/index.js",


### PR DESCRIPTION
Hi all,

requesting your review to add Pyth back to Ionic

Doc
https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types

Oracle implementation
https://github.com/ionicprotocol/contracts/blob/development/contracts/oracles/default/PythPriceOracle.sol

Thank you
