### PR TITLE
Update data3.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34528,7 +34528,7 @@ const data3: Protocol[] = [
     chains: ["Blast"],
     module: "blastoff/index.js",
     twitter: "blastozone",
-    oracles: [], 
+    oracles: ["RedStone"], //https://docs.blastoff.zone/partnerships/technical-integrations
     audit_links: [],
     forkedFrom: [], 
     github: ["BlastOffOrg"],


### PR DESCRIPTION


Gm Llamas 
we kindly ask to add BlastOFF as RedStone oracles user.

Oracle Provider(s): RedStone

Implementation Details: BlastOFF uses our feeds to allow users to participate in IDO with ETH or USD in the same pool to calculate their $ participation value in IDO.

Documentation/Proof: https://docs.blastoff.zone/partnerships/technical-integrations

Announcement: https://x.com/redstone_defi/status/1763317803422273638?s=20