### PR TITLE
add API3 oracle to Juice, Pac finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33697,7 +33697,7 @@ const data3: Protocol[] = [
     module: "juice-finance/index.js",
     twitter: "Juice_Finance",
     forkedFrom: [], 
-    oracles: ["RedStone"],  //https://juice-finance.gitbook.io/juice-finance/juice-finance/quick-links
+    oracles: ["API3", "RedStone"],  //https://juice-finance.gitbook.io/juice-finance/juice-finance/quick-links
     listedAt: 1709308594
   },
   {
@@ -33765,7 +33765,7 @@ const data3: Protocol[] = [
     module: "pac-finance/index.js",
     twitter: "pac_finance",
     forkedFrom: ["AAVE V3"], 
-    oracles: ["Pyth"], // https://docs.pac.finance/
+    oracles: ["API3"], // https://docs.pac.finance/security#oracle
     listedAt: 1709315721
   },
   {


### PR DESCRIPTION
Pac Finance uses API3 for their oracle

docs: https://docs.pac.finance/security#oracle

Juice Finance uses API3 for their ETH feed which is 65% of their TVL and also fallback for their USDB feed

docs: https://juice-finance.gitbook.io/juice-finance/juice-protocol/risks#oracle-risk