### PR TITLE
Update oracles for Juice Finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33697,7 +33697,7 @@ const data3: Protocol[] = [
     module: "juice-finance/index.js",
     twitter: "Juice_Finance",
     forkedFrom: [], 
-    oracles: ["API3"],  //https://juice-finance.gitbook.io/juice-finance/juice-finance/quick-links API3 has the ETH feed
+    oracles: ["RedStone"],  //https://juice-finance.gitbook.io/juice-finance/juice-protocol/borrowing/liquidations#oracles RedStone has ETH & USDB feeds
     listedAt: 1709308594
   },
   {


### PR DESCRIPTION
Gm, 
We kindly ask to update oracles for Juice Finance to RedStone. 

Implementation Details: RedStone provides price feeds for ETH & USDB (87% of TVL)

Documentation/Proof: https://juice-finance.gitbook.io/juice-finance/juice-protocol/borrowing/liquidations#oracles

