### PR TITLE
fix: ZEND token address

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -1815,12 +1815,12 @@
       "symbol": "UNO",
       "to": "coingecko#nostra-uno"
     },
-    "0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed": {
+    "0x0585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34": {
       "decimals": "18",
       "symbol": "ZEND",
       "to": "coingecko#zklend-2"
     },
-    "0x5ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed": {
+    "0x00585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34": {
       "decimals": "18",
       "symbol": "ZEND",
       "to": "coingecko#zklend-2"

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -8493,7 +8493,7 @@ const data3: Protocol[] = [
   {
     id: "3079",
     name: "zkLend",
-    address: "starknet:0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed",
+    address: "starknet:0x0585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34",
     symbol: "ZEND",
     url: "https://zklend.com/",
     description:


### PR DESCRIPTION
Issue: https://github.com/DefiLlama/defillama-server/issues/6415

Currently, `0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed` is registered as ZENd address, but it is not the correct ZEND address. It is the class hash of that contract on Starknet, which is totally different. 

[0x00585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34](https://starkscan.co/contract/0x00585c32b625999e6e5e78645ff8df7a9001cf5cf3eb6b80ccdd16cb64bd3a34) is the correct token address.

So this PR changes the token address to the correct one.