### PR TITLE
chore: update Arrakis urls

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -11574,7 +11574,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     name: "Arrakis V1",
     address: null,
     symbol: "-",
-    url: "https://www.arrakis.finance",
+    url: "https://app.arrakis.fi/vaults",
     description:
       "Arrakis is a protocol that specializes in concentrated & active liquidity management. By creating a curated marketplace of novel tokenized LP strategies, Arrakis facilitates deep liquidity and optimizes LP earnings across its vaults.",
     chain: "Ethereum",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -29098,7 +29098,7 @@ const data2: Protocol[] = [
     name: "Arrakis V2",
     address: null,
     symbol: "-",
-    url: "https://beta.arrakis.finance/vaults",
+    url: "https://app.arrakis.fi/v2-vaults",
     description: "Arrakis V2 is a next-generation market-making infrastructure built on top of Uniswap V3. Its unique functionalities allow the creation and automated execution of sophisticated market-making strategies on Uniswap V3 that previously were only feasible on CEXs.",
     chain: "Ethereum",
     logo: `${baseIconsUrl}/arrakis-v2.jpg`,


### PR DESCRIPTION
Recently Arrakis moved away from the `beta` website.
Trying to update the old directories the point to the right URL, so that wallets such as Rabby don't label the new one as "low popularity".