### PR TITLE
fix: handle failing erc4626

### DIFF
--- a/coins/src/adapters/utils/erc4626.ts
+++ b/coins/src/adapters/utils/erc4626.ts
@@ -16,37 +16,37 @@ export async function calculate4626Prices(
   timestamp: number,
   tokens: string[],
   hardCodedAssets?: string[],
-): Promise<(Result4626 | null)[]> {
+): Promise<Result4626[]> {
   const block: number | undefined = await getBlock(chain, timestamp);
-  const { sharesDecimals, assets, symbols, ratios } = await getTokenData(
+  const tokenData = await getTokenData(
     block,
     chain,
     tokens,
     hardCodedAssets,
   );
   const assetsInfo: CoinData[] = await getTokenAndRedirectData(
-    assets,
+    tokenData.map(({ asset }) => asset),
     chain,
     timestamp,
   );
 
-  const result: (Result4626 | null)[] = [];
-  for (let i = 0; i < tokens.length; i++) {
+  const result: Result4626[] = [];
+  for (const { token, asset, ratio, shareDecimals, symbol } of tokenData) {
     const assetInfo = assetsInfo.find(
-      ({ address }) => assets[i].toLowerCase() === address.toLowerCase(),
+      ({ address }) => asset.toLowerCase() === address.toLowerCase(),
     );
     if (!assetInfo) continue;
 
     const assetMagnitude = magnitude(assetInfo.decimals);
     let assetPriceBN = 0;
     assetPriceBN = assetInfo.price
-    if (ratios[i] !== null) {
-      const sharePrice = assetPriceBN * ratios[i] / +assetMagnitude
+    if (ratio !== null) {
+      const sharePrice = assetPriceBN * ratio / +assetMagnitude
       result.push({
-        token: tokens[i].toLowerCase(),
+        token: token.toLowerCase(),
         price: sharePrice,
-        decimals: sharesDecimals[i],
-        symbol: symbols[i],
+        decimals: shareDecimals,
+        symbol,
       });
     }
   }
@@ -63,47 +63,47 @@ async function getTokenData(
   chain: any,
   tokens: string[],
   hardCodedAssets?: string[],
-) {
+): Promise<{ token: string, asset: string, shareDecimals: number, symbol: string, ratio: number }[]> {
   const targets = tokens.map((target: string) => ({ target }));
   const multiCallForAbi = (abi: any) =>
-    multiCall({ calls: targets, chain, block, abi });
+    multiCall({ calls: targets, chain, block, abi, permitFailure: true });
   let assetsPromise;
   if (!hardCodedAssets) assetsPromise = multiCallForAbi(abi.asset);
   const [sharesDecimalsPromise, symbolsPromise] = [
     multiCallForAbi("erc20:decimals"),
     multiCallForAbi("erc20:symbol"),
   ];
-  const sharesDecimals = await sharesDecimalsPromise;
+  const { output: sharesDecimals } = await sharesDecimalsPromise;
   const ratiosPromise = multiCall({
     calls: tokens.map((target: string, i: number) => ({
       target,
-      params: magnitude(sharesDecimals.output[i].output),
+      params: magnitude(sharesDecimals[i].output),
     })),
     chain,
     block,
     abi: abi.convertToAssets,
+    permitFailure: true,
   });
-  const [assets, symbols, ratios] = await Promise.all([
+  const [{ output: assets }, { output: symbols }, { output: ratios }] = await Promise.all([
     hardCodedAssets
       ? {
-          output: hardCodedAssets.map((output: string) => ({
-            output,
-          })),
-        }
+        output: hardCodedAssets.map((output: string) => ({
+          output,
+        })),
+      }
       : assetsPromise,
     symbolsPromise,
     ratiosPromise,
   ]);
-  return {
-    sharesDecimals: sharesDecimals.output.map(({ output }: any) => output),
-    assets: assets.output.map(({ output }: any) =>
-      output == "0x0000000000000000000000000000000000000000"
-        ? wrappedGasTokens[chain]
-        : output,
-    ),
-    symbols: symbols.output.map(({ output }: any) => output),
-    ratios: ratios.output.map(({ output }: any) => output),
-  };
+  return tokens
+    .map((token, i) => ({
+      token,
+      shareDecimals: sharesDecimals[i].success ? sharesDecimals[i].output : null,
+      asset: assets[i].success ? assets[i].output : null,
+      symbol: symbols[i].success ? (symbols[i].output == "0x0000000000000000000000000000000000000000" ? wrappedGasTokens[chain] : symbols[i].output) : null,
+      ratio: ratios[i].success ? ratios[i].output : null,
+    }))
+    .filter(({ shareDecimals, asset, symbol, ratio }) => shareDecimals !== null && asset !== null && symbol !== null && ratio !== null)
 }
 
 function magnitude(decimals: number) {

--- a/coins/src/adapters/yield/mean-finance/mean-finance.ts
+++ b/coins/src/adapters/yield/mean-finance/mean-finance.ts
@@ -1,6 +1,6 @@
 import { addToDBWritesList } from "../../utils/database";
 import { Write } from "../../utils/dbInterfaces";
-import { calculate4626Prices, Result4626 } from "../../utils/erc4626";
+import { calculate4626Prices } from "../../utils/erc4626";
 import { fetch } from "../../utils";
 
 export default async function getTokenPrices(chain: string, timestamp: number) {
@@ -23,8 +23,7 @@ export async function unwrap4626(
   const writes: Write[] = [];
   if (tokens.length > 0) {
     const prices = await calculate4626Prices(chain, timestamp, tokens, hardCodedAssets);
-    const validPrices = prices.filter((priceData): priceData is Result4626 => !!priceData)
-    for (const { token, price, decimals, symbol } of validPrices) {
+    for (const { token, price, decimals, symbol } of prices) {
       addToDBWritesList(
         writes,
         chain,


### PR DESCRIPTION
We realized one of the 4626 adapter tokens we supported was failing due to a problem with the underlying vault. This was causing all calls to fail, so we realized we needed to change the approach. The idea is simple though, if a token fails to report any of the properties, we will simply ignore it and return prices for the rest

I wasn't sure if it made sense to log a warning, but I can do it if you would like me to