### PR TITLE
avoid returning an array containing a null element when there is no assets history data

### DIFF
--- a/defi/l2/storeToDb.ts
+++ b/defi/l2/storeToDb.ts
@@ -124,8 +124,9 @@ function findDailyEntries(raw: ChartData[], period: number = secondsInADay): Cha
     clean.push({ data: raw[index].data, timestamp: timestamp.toString() });
     timestamp += period;
   }
-
-  clean.push(raw[raw.length - 1]);
+  if (raw.length > 0) {
+    clean.push(raw[raw.length - 1]);
+  }
 
   return clean;
 }


### PR DESCRIPTION
The Bitcoin chain page currently crashes because of a chain assets chart data table containing [null]. This fixes it by avoiding returning a null element when there is no data. A similar PR has been made on the frontend to prevent the frontend from crashing in case this happens -> https://github.com/DefiLlama/defillama-app/pull/1677