### PR TITLE
Update oracle for Evaa

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33483,7 +33483,7 @@ const data3: Protocol[] = [
     module: "evaa/index.js",
     twitter: "evaaprotocol",
     forkedFrom: [], 
-    oracles: [],
+    oracles: ["RedStone"], //https://evaa.gitbook.io/intro/details-of-protocol/risks/protocol-risks#oracle-risk 
     github: ["evaafi"],
     listedAt: 1709220208
   },


### PR DESCRIPTION
Gm,
Kindly asking to update oracles for Evaa Protocol:

Oracle Provider(s): RedStone

Implementation Details: RedStone provides all price feeds for Evaa

Documentation/Proof: https://evaa.gitbook.io/intro/details-of-protocol/risks/protocol-risks#oracle-risk 