### PR TITLE
feat: add vASTR token

### DIFF
--- a/coins/src/adapters/other/manualInput.ts
+++ b/coins/src/adapters/other/manualInput.ts
@@ -103,6 +103,12 @@ const contracts: { [chain: string]: TokenInfo[] } = {
       decimals: 18,
       redirect: "coingecko#matic-network",
     },
+    {
+      symbol: "vASTR",
+      address: "0x7746ef546d562b443AE4B4145541a3b1a3D75717",
+      decimals: 18,
+      redirect: "coingecko#bifrost-voucher-astr",
+    },
   ],
   polygon: [
     {


### PR DESCRIPTION
here is the token info about vASTR

```
{
      symbol: "vASTR",
      address: "0x7746ef546d562b443AE4B4145541a3b1a3D75717",
      decimals: 18,
      redirect: "coingecko#bifrost-voucher-astr",
}
```

Explorer Link: https://astar-zkevm.blockscout.com/address/0x7746ef546d562b443AE4B4145541a3b1a3D75717

Coingecko Link: https://www.coingecko.com/en/coins/bifrost-voucher-astr