### PR TITLE
Add RedStone to Merchant Moe Liquidity Book

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -38577,7 +38577,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Dexes",
     chains: ["Mantle"],
-    oracles: [],
+    oracles: ["RedStone"],
     forkedFrom: ["Joe V2.1"],
     module: "merchant-moe-lb/index.js",
     twitter: "MerchantMoe_xyz",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -38577,7 +38577,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Dexes",
     chains: ["Mantle"],
-    oracles: ["RedStone"],
+    oracles: ["RedStone"], //https://docs.merchantmoe.com/liquidity-book/vaults#h_e0c60a9c6a
     forkedFrom: ["Joe V2.1"],
     module: "merchant-moe-lb/index.js",
     twitter: "MerchantMoe_xyz",


### PR DESCRIPTION
Gm,
Kindly asking to update oracles for Merchant Moe Liquidity Book

Oracle Provider(s): RedStone

Implementation Details: RedStone provides price feeds for assets in MM LB's vaults, including USDT (~90% of MM LB TVL)

Documentation/Proof: https://docs.merchantmoe.com/liquidity-book/vaults#h_e0c60a9c6a