### PR TITLE
Configure Balanced and Balanced Dollar

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -7417,7 +7417,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     gecko_id: null,
     cmcId: null,
     category: "Dexes", // tvl also counts lending/cdp product
-    chains: ["Icon", "Archway"],
+    chains: ["Icon", "Avalanche", "Archway", "BSC"],
     module: "balanced/index.js",
     twitter: "BalancedDAO",
     audit_links: ["https://docs.balanced.network/security#smart-contract-audits"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -28020,7 +28020,7 @@ const data3: Protocol[] = [
     id: "3956",
     name: "Balanced Dollar",
     address: "icon:cxf61cd5a45dc9f91c15aa65831a30a90d59a09619",
-    symbol: "BALN",
+    symbol: "bnUSD",
     url: "https://balanced.network",
     description: "The Balanced Dollar (bnUSD) is a decentralised stablecoin that tracks the price of 1 USD. It uses cryptocurrency as collateral to guarantee its value, with support for assets from a variety of blockchains. bnUSD is not experimental or algorithmic: it’s over-collateralised, so the total supply cannot exceed the value that backs it.",
     chain: "Icon",


### PR DESCRIPTION
- Corrected Balanced Dollar symbol to 'bnUSD'
- Added two connected chains, as tracked in the adapter, Avalanche and BSC