### PR TITLE
add LL token to tokenMapping.json

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -352,6 +352,11 @@
       "decimals": "18",
       "symbol": "LQRD",
       "to": "coingecko#liquiddriver"
+    },
+    "0x0921799cb1d702148131024d18fcde022129dc73": {
+      "decimals": "18",
+      "symbol": "LL",
+      "to": "coingecko#lightlink"
     }
   },
   "meter": {
@@ -1416,6 +1421,11 @@
       "decimals": "18",
       "symbol": "CSIX.b",
       "to": "coingecko#carbon-browser"
+    },
+    "0xd9d7123552fa2bedb2348bb562576d67f6e8e96e": {
+      "decimals": "18",
+      "symbol": "LL",
+      "to": "coingecko#lightlink"
     }
   },
   "linea": {


### PR DESCRIPTION
PR to add LightLink token to coins api.

ETH: https://etherscan.io/address/0x0921799CB1d702148131024d18fCdE022129Dc73
Phoenix: https://phoenix.lightlink.io/token/0xd9d7123552fA2bEdB2348bB562576D67f6E8e96E
Coin Gecko: https://www.coingecko.com/en/coins/lightlink