### PR TITLE
Add RedStone to Native

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -2299,6 +2299,7 @@ const data3: Protocol[] = [
     chains: ["Binance", "Ethereum"],
     oraclesByChain: {
       zklink: ["RedStone"], //https://docs.native.org/aqua/smart-contracts/smart-contract-addresses
+    },
     forkedFrom: [],
     module: "native/index.js",
     twitter: "native_fi",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -2297,7 +2297,8 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Dexes",
     chains: ["Binance", "Ethereum"],
-    oracles: [],
+    oraclesByChain: {
+      zklink: ["RedStone"], //https://docs.native.org/aqua/smart-contracts/smart-contract-addresses
     forkedFrom: [],
     module: "native/index.js",
     twitter: "native_fi",


### PR DESCRIPTION
Gm Llamas, 
Kindly asking to update oracles for Native
Oracle Provider(s): RedStone
Implementation Details: RedStone provides price feeds for Native on zkLink
Documentation/Proof: https://docs.native.org/aqua/smart-contracts/smart-contract-addresses

