### PR TITLE
Add RedStone to Seismic

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -40846,7 +40846,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Blast"],
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.seismic.finance/accepted-collateral-types#oracles-utilized
     forkedFrom: ["AAVE V2"],
     module: "seismic/index.js",
     twitter: "seismicfinance",


### PR DESCRIPTION
Gm Llamas,
Kindly asking to update oracles for Seismic
Oracle Provider(s): RedStone
Implementation Details: RedStone provides price feeds for Seismic to determine value of borrowed assets and collateral
Documentation/Proof: https://docs.seismic.finance/accepted-collateral-types#oracles-utilized