### PR TITLE
Added USDT on TON

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -7022,6 +7022,11 @@
       "symbol": "jUSDT",
       "to": "coingecko#tether"
     },
+    "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs": {
+      "decimals": "6",
+      "symbol": "USDT",
+      "to": "coingecko#tether"
+    },
     "EQB-MPwrd1G6WKNkLz_VnV6WqBDd142KMQv-g1O-8QUA3728": {
       "decimals": "6",
       "symbol": "jUSDC",


### PR DESCRIPTION
Currently significant part of TON TVL is missing due to USDT has been added to the core assets but [coins api](https://coins.llama.fi/prices/current/ton:EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs) has a lack of support for USDT.