### PR TITLE
add API3 and Redstone to Orbit Lending 

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33863,7 +33863,7 @@ const data3: Protocol[] = [
     module: "orbitlending-io/index.js",
     twitter: "OrbitLending",
     forkedFrom: ["Compound V2"],
-    oracles: ["Pyth"], // https://book.orbitlending.io/protocol-design/price-oracle
+    oracles: ["API3","Redstone","Pyth"], // https://book.orbitlending.io/protocol-design/price-oracle
     audit_links: [],
     listedAt: 1709316471
   },


### PR DESCRIPTION
API3 is the primary oracle for the ETH/USD feed for Orbit Protocol which is 85% of orbit TVL.
Docs: https://book.orbitlending.io/protocol-design/price-oracle#api3

Redstone is the primary oracle for USDB feed for Orbit Protocol which is 14% of orbit TVL. 
Docs: https://book.orbitlending.io/protocol-design/price-oracle#redstone

A potential misreport of any of these oracle could cause the protocol to lose >50% TVL since this is a compoundv2 fork and the markets are not isolated 