### PR TITLE
add api3 oracle to mendi finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16144,7 +16144,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["API3","Chainlink"],
+    oracles: ["API3","Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/7002
     github: ["mendi-finance"],
     listedAt: 1692625594
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16144,7 +16144,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["API3","Pyth"],
+    oracles: ["API3","Chainlink"],
     github: ["mendi-finance"],
     listedAt: 1692625594
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16144,7 +16144,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["Pyth"],
+    oracles: ["API3","Pyth"],
     github: ["mendi-finance"],
     listedAt: 1692625594
   },


### PR DESCRIPTION
API3 is used a primary oracle in mendi markets including ezETH which is the biggest market on mendi.

docs: https://docs.mendi.finance/protocol/oracles
accepted proposal: https://gov.mendi.finance/t/mip-3-mendi-finance-to-continue-using-api3-for-ezeth-price-data-and-benefit-from-oev/59/4

![ishare-1716394950](https://github.com/DefiLlama/defillama-server/assets/31223740/c28b2c27-4824-4c5a-a18f-97fdc3385a48)


Chainlink is the other primary oracle as per documentation so added them as well. 

A misreport on any of these oracles can cause > 50% the protocol TVL to be drained since this is a compoundV2 forks and markets aren't siloed. 