### PR TITLE
Update Oracles for Shoebill Finance.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -19011,7 +19011,8 @@ const data3: Protocol[] = [
     oraclesByChain: {
       wemix: ["Pyth"], // https://github.com/DefiLlama/defillama-server/pull/5434#issuecomment-1889510580
       manta: ["RedStone"], //https://twitter.com/redstone_defi/status/1763580020751245496 , https://github.com/DefiLlama/defillama-server/pull/6353#discussion_r1550765182
-      bsquared: ["Supra"],
+      bsquared: ["Supra", "RedStone"], //https://docs.shoebill.finance/risk/oracle
+      BOB: ["RedStone"], //https://docs.shoebill.finance/risk/oracle
       Klaytn: ["Witnet"],
       metis: ['Chainlink'],
       mode: ['RedStone']

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -19011,8 +19011,8 @@ const data3: Protocol[] = [
     oraclesByChain: {
       wemix: ["Pyth"], // https://github.com/DefiLlama/defillama-server/pull/5434#issuecomment-1889510580
       manta: ["RedStone"], //https://twitter.com/redstone_defi/status/1763580020751245496 , https://github.com/DefiLlama/defillama-server/pull/6353#discussion_r1550765182
-      bsquared: ["Supra", "RedStone"], //https://docs.shoebill.finance/risk/oracle
-      BOB: ["RedStone"], //https://docs.shoebill.finance/risk/oracle
+      bsquared: ["Supra"], //https://docs.shoebill.finance/risk/oracle
+      bob: ["RedStone"], //https://docs.shoebill.finance/risk/oracle
       Klaytn: ["Witnet"],
       metis: ['Chainlink'],
       mode: ['RedStone']


### PR DESCRIPTION
Gm,
Kindly asking to update oracles for Shoebill Finance on BSquared and BOB.

Oracle Provider(s): RedStone

Implementation Details: Shoebill Finance integrated our feeds for major assets on these networks

Documentation/Proof: https://docs.shoebill.finance/risk/oracle