### PR TITLE
Update oracles for Vivacity and LayerBank.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12344,6 +12344,8 @@ const data3: Protocol[] = [
       scroll: ["Pyth"],
       linea: ["Pyth"],
       mode: ["RedStone"]     // https://docs.layerbank.finance/protocol/lending/oracles
+      BSquared: ["RedStone"]     // https://docs.layerbank.finance/protocol/lending/oracles
+      BOB: ["RedStone"]     // https://docs.layerbank.finance/protocol/lending/oracles
     },
     listedAt: 1689773129,
     audit_links: ["https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-LineaBank-v1.0.pdf"],
@@ -27500,7 +27502,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "RWA Lending",
     chains: ["Canto"],
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.vivacity.finance/reference/architecture#price-oracles
     forkedFrom: [],
     module: "vivacity/index.js",
     twitter: "vivacityfinance",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for LayerBank on BSquared and BOB and for Vivacity on Canto.

Oracle Provider(s): RedStone

Implementation Details: LayerBank uses RedStone Price Feeds for pricing collateral on all existing markets on Bsquared, and BOB. Vivacity uses RedStone Price Feeds for pricing crypto native assets (>50% of their TVL)

Documentation/Proof: 
[LayerBank] https://docs.layerbank.finance/protocol/lending/oracles [Vivacity]
https://docs.vivacity.finance/reference/architecture#price-oracles