### PR TITLE
chore: add DTX chains info

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -36779,7 +36779,7 @@ const data3: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Derivatives",
-    chains: ["Blast"],
+    chains: ["Blast", "Taiko"],
     oracles: ["Pyth"], // https://blastscan.io/address/0x69633b5ada326ba7a782a4c8ac69e812619414c2#internaltx and feed https://blastscan.io/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729
     forkedFrom: [],
     module: "dtx/index.js",


### PR DESCRIPTION
We want to add another supported chain to our info. 
Our category should be "Dexes" on the Taiko network and "Derivatives" on the Blast network
Thx for supporting