### PR TITLE
Add USK on Telos

### DIFF
--- a/coins/src/adapters/rwa/kuma.ts
+++ b/coins/src/adapters/rwa/kuma.ts
@@ -12,6 +12,9 @@ const config: { [chain: string]: { [symbol: string]: string } } = {
   },
   linea: {
     USK: "0x7a6aa80b49017f3e091574ab5c6977d863ff3865"
+  },
+  telos: {
+    USK: "0x09B88f74Fb9E243c4A3F4D2FfE3d1BA4287a476c"
   }
 };
 


### PR DESCRIPTION
I also noticed that while we have the USK oracle defined here, and it seems to be writing the prices as expected, the TVL calculation sometimes doesn't seem to take them into account, leading to spikes in our DefiLlama listing. Any idea on how to prevent this from happening? Adapter code: https://github.com/DefiLlama/DefiLlama-Adapters/blob/b91efa646707c6653227a5f5677b456e0447ee2c/projects/kuma/index.js

Example of the issue happening for USK on Ethereum (but same applies for the other USKs so my hunch is something wrong with the oracle / price calculation - but I wasn't able to reproduce the problem). Even right now it's not counting USK on Ethereum or Linea, just EGK on Ethereum and FRK on Polygon.

![CleanShot 2024-06-04 at 11 35 52@2x](https://github.com/DefiLlama/defillama-server/assets/6652670/2cbde38d-16dd-40ae-9d90-07c5c1065f0f)
![CleanShot 2024-06-04 at 11 37 47@2x](https://github.com/DefiLlama/defillama-server/assets/6652670/c26dc13b-6ffc-48eb-a27f-dc41c93e3cc3)
![CleanShot 2024-06-04 at 12 58 44@2x](https://github.com/DefiLlama/defillama-server/assets/6652670/2f296c6c-c3d9-4d98-953c-f480307763bc)
![CleanShot 2024-06-04 at 13 05 21@2x](https://github.com/DefiLlama/defillama-server/assets/6652670/4847c9f8-4800-4ebd-bf00-b6bc48c4a061)

Edit: just ran it again to confirm total numbers, and now in my instance it did pull the price correctly (not for Telos obviously, as this price hasn't been added yet) - but it's still off on the official listing.
![CleanShot 2024-06-04 at 13 04 35@2x](https://github.com/DefiLlama/defillama-server/assets/6652670/3dd898cb-cc9a-4371-ac3b-2a6d7b61cf09)


