### PR TITLE
Remove Chronicle from Spark

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5124,7 +5124,7 @@ const data3: Protocol[] = [
     module: "spark-fi/index.js",
     twitter: "sparkdotfi",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Chainlink", "Chronicle"],
+    oracles: ["Chainlink"],
     audit_links: ["https://devs.spark.fi/security/security-and-audits"],
     github: ["marsfoundation"],
     listedAt: 1683144119


### PR DESCRIPTION
This one seemed like a no-brainer but apparently not. 
Naturally i've assumed (similar to others) that the MakerDAO AAVE Fork uses the MakerDAO oracles under the hood.
This is mostly untrue and in most instances not even documented. 

These docs say nothing about any oracle they use: https://docs.spark.fi/

Then you dig into their forum and realize, that their Gnosis Chain deployment relies just on Chainlink: https://forum.makerdao.com/t/spark-lend-on-gnosis/21304
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/834682df-e990-4063-b287-328e91957985)

Then you dig into some of the mainnet reconfigurations of a major asset like e.g. wBTC and realize that this also uses Chainlink under the hood. https://forum.makerdao.com/t/spark-parameter-change-mainnet-reactivate-wbtc/22556
![image](https://github.com/DefiLlama/defillama-server/assets/139578304/fdd2840d-e281-4864-a55a-619a2bd292f0)

As far as my forum search has lead me Spark utilizes Chronicle nearly nowhere. 
Chronicle as a project was mentioned a total of three times. 

1. To onboard GNO on Gnosis Chain in ISOLATION MODE (it accounts for 25% of TVL)
2. [As a question](http://forum.makerdao.com/t/spark-lend-on-scroll/22637/2) why their own oracles aren't utilized on other EVM deployments.
3. As an intro by Phoenix Labs (the entity managing Spark) as [their previous contributions](https://forum.makerdao.com/t/introducing-phoenix-labs/20716)

It is quite hilarious that, on the basis of this, 3 Billion in value is being attributed to Chronicle.