### PR TITLE
add new pyth users

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12179,7 +12179,7 @@ const data3: Protocol[] = [
       linea: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
       manta: ["RedStone"], //https://docs.zerolend.xyz/security/oracles/using-redstone-oracles
       ethereum: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
-      zkSync: ["Pyth"], //https://docs.zerolend.xyz/security/oracles/using-pyth-oracles (Please check)
+      zkSync: ["Pyth"], //https://docs.zerolend.xyz/security/oracles#using-pyth-oracles
       xlayer: ["API3"] // https://docs.zerolend.xyz/security/oracles#oracles-operated-by-api3
     },
     forkedFrom: ["AAVE V3"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12179,7 +12179,7 @@ const data3: Protocol[] = [
       linea: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
       manta: ["RedStone"], //https://docs.zerolend.xyz/security/oracles/using-redstone-oracles
       ethereum: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
-      zkSync: ["Pyth"], //https://docs.zerolend.xyz/security/oracles/using-pyth-oracles
+      zkSync: ["Pyth"], //https://docs.zerolend.xyz/security/oracles/using-pyth-oracles (Please check)
       xlayer: ["API3"] // https://docs.zerolend.xyz/security/oracles#oracles-operated-by-api3
     },
     forkedFrom: ["AAVE V3"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -40325,7 +40325,7 @@ const data3: Protocol[] = [
     module: "flat-money/index.js",
     twitter: "0xflatmoney",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"], // https://docs.flat.money/pyth-network-price-oracle 
     listedAt: 1713802587
   },
   {
@@ -43599,7 +43599,7 @@ const data3: Protocol[] = [
     chains: ["Aptos"],
     module: "superposition/index.js", 
     forkedFrom: [],
-    oracles: [], 
+    oracles: ["Pyth"], // https://docs.concordia.systems/platform-spec/pricing-engine 
     twitter: "superp_fi",
     listedAt: 1716371512
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -43599,7 +43599,7 @@ const data3: Protocol[] = [
     chains: ["Aptos"],
     module: "superposition/index.js", 
     forkedFrom: [],
-    oracles: ["Pyth"], // https://docs.concordia.systems/platform-spec/pricing-engine 
+    oracles: [],
     twitter: "superp_fi",
     listedAt: 1716371512
   },


### PR DESCRIPTION
gm

requesting your review to add Pyth users

Flat Money
https://docs.flat.money/pyth-network-price-oracle 

Superposition
for context, Superposition is powered by Concordia, which uses Pyth for its pricing engine

https://docs.concordia.systems/platform-spec/pricing-engine 

Also there seems to be an issue with Zerolend. It's using Pyth for zkSync but can't seem to find it on the Pyth page https://defillama.com/oracles/Pyth

Could you take a look please?

Thank you very much