### PR TITLE
fixed KlimaDAO in wrong category

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -14284,7 +14284,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     audit_note: null,
     gecko_id: "klima-dao",
     cmcId: "12873",
-    category: "Services",
+    category: "RWA",
     chains: ["Polygon"],
     module: "klima-dao/index.js",
     treasury: "klima-dao.js",


### PR DESCRIPTION
KlimaDAO was in the wrong category. Environmental commodities like carbon credits are real world assets.