### PR TITLE
fix: use lowercase for db lookup etc

### DIFF
--- a/coins/src/adapters/moneyMarkets/aave/aave.ts
+++ b/coins/src/adapters/moneyMarkets/aave/aave.ts
@@ -186,6 +186,10 @@ export async function getStataAssetPrices(
   ).output;
 
   return stataTokens.map((token: string, ix) => {
-    return { address: token, underlying: underlyings[ix], rate: rates[ix] };
+    return {
+      address: token.toLowerCase(),
+      underlying: underlyings[ix].toLowerCase(),
+      rate: rates[ix],
+    };
   });
 }


### PR DESCRIPTION
I cannot manage to run the test locally atm, so sadly there's no option for me to test if it actually works