### PR TITLE
Add: SolvBTC-ENA on BSC

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -392,6 +392,11 @@
       "decimals": "18",
       "symbol": "sFRAX",
       "to": "ethereum:0xa663b02cf0a4b149d2ad41910cb81e23e1c41c32"
+    },
+    "0x53e63a31fd1077f949204b94f431bcab98f72bce" :{
+      "decimals": "18",
+      "symbol": "SolvBTC.ENA ",
+      "to": "coingecko#solv-btc"
     }
   },
   "stacks": {


### PR DESCRIPTION
- Add SolvBTC-ENA, which pegs to SolvBTC

---

[**SolvBTC-ENA Intro**](https://solvprotocol.medium.com/bitcoin-meets-defi-a-deep-dive-into-the-solvbtc-ethena-vault-43abc8597a47)
SolvBTC.ena serves as a liquid yield token, integrated with various DeFi protocols, offering maximum flexibility and accessibility for a thriving BTCFi ecosystem. Key integrations include:
- DEXs: Provides SolvBTC.ena holders with instant liquidity and access to high-quality yields without requiring KYC.
- Lending Protocols: Allows SolvBTC.ena holders to lend their tokens, earning extra yield while enabling borrowers to access leveraged yield positions.
- Yield-Trading Protocols: Enables users to trade the future yields of SolvBTC.ena, manage yield exposure fluctuations, and optimize returns.

Through these integrations, Solv is not only providing immediate value to SolvBTC.ena holders but also laying the groundwork for deeper Bitcoin integration into DeFi.