### PR TITLE
TLX Finance category changed from Synthetics to Derivatives

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -41484,7 +41484,7 @@ const data3: Protocol[] = [
     audit_note: null,
     gecko_id: "tlx",
     cmcId: null,
-    category: "Synthetics",
+    category: "Derivatives",
     chains: ["Optimism"],
     oracles: ["Pyth"], // https://docs.tlx.fi/basics/how-leveraged-tokens-work/synthetix-perps-engine
     forkedFrom: [],


### PR DESCRIPTION
Changes the TLX Finance category from Synthetics to Derivatives, as this is the more appropriate category.