### PR TITLE
Add Vega Protocol as a Pyth oracle user

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -6355,7 +6355,7 @@ const data3: Protocol[] = [
     module: "vega-protocol/index.js",
     twitter: "vegaprotocol",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"], // https://docs.vega.xyz/mainnet/tutorials/using-data-sources#using-a-pyth-price-feed
     listedAt: 1684246282,
     github: ["vegaprotocol"]
   },


### PR DESCRIPTION
Adding Pyth as an oracle source for vega protocol.

For info this is a link to the documentation: https://docs.vega.xyz/mainnet/tutorials/using-data-sources#using-a-pyth-price-feed
