### PR TITLE
Update oracles for Term Structure

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -46871,7 +46871,7 @@ const data3: Protocol[] = [
     module: "term-structure/index.js",
     twitter: "TermStructLabs",
     forkedFrom: [],
-    oracles: ["Chainlink"], // https://docs.ts.finance/protocol-spec/primary-markets/liquidation-mechanism#fully-on-chain-liquidation
+    oracles: ["Chainlink", "RedStone"], // https://docs.ts.finance/protocol-spec/primary-markets/liquidation-mechanism#fully-on-chain-liquidation
     audit_links: ["https://github.com/term-structure/audits"],
     github: ["term-structure"],
     listedAt: 1718906602


### PR DESCRIPTION
Hi,

We would like to submit an update oracles information for the Term Structure. Below are the details of the changes:

Oracle Provider(s): RedStone

Implementation Details: Term Structure now utilizes RedStone Price Feeds for determining the values of loans collateralized by LRTs and LSTs

Documentation/Proof:
[https://docs.ts.finance/protocol-spec/primary-markets/liquidation-mechanism#fully-on-chain-liquidation](https://docs.ts.finance/protocol-spec/primary-markets/liquidation-mechanism#fully-on-chain-liquidation)