### PR TITLE
Add Superchain Category

### DIFF
--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -3093,7 +3093,7 @@ export const chainCoingeckoIds = {
     cmcId: null,
     categories: ["EVM", "Superchain"],
     parent: {
-      chain: "Optimism",
+      chain: "Base",
       types: ["L3"]
     },
     twitter: "HamOnWarpcast",

--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -2271,7 +2271,7 @@ export const chainCoingeckoIds = {
     categories: ["EVM","Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
-      types: ["L2"]
+      types: ["L2", "gas"]
     },
     chainId: 255,
     github: ["kroma-network"],
@@ -2590,7 +2590,7 @@ export const chainCoingeckoIds = {
     categories: ["EVM","Superchain"],
     parent: {
       chain: "Ethereum",
-      types: ["L2"]
+      types: ["L2", "gas"]
     },
     chainId: 252,
     twitter: "fraxfinance",
@@ -2987,7 +2987,7 @@ export const chainCoingeckoIds = {
     categories: ["EVM","Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
-      types: ["L2"]
+      types: ["L2", "gas"]
     },
     twitter: "BuildOnCyber",
     url: "https://cyber.co/",

--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -112,7 +112,7 @@ export const chainCoingeckoIds = {
     geckoId: "optimism",
     symbol: "OP",
     cmcId: "11840",
-    categories: ["EVM", "Rollup"],
+    categories: ["EVM", "Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
       types: ["L2", "gas"]
@@ -2145,7 +2145,7 @@ export const chainCoingeckoIds = {
     symbol: null,
     cmcId: null,
     github: ["base-org"],
-    categories: ["EVM", "Rollup"],
+    categories: ["EVM", "Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
       types: ["L2", "gas"]
@@ -2268,7 +2268,12 @@ export const chainCoingeckoIds = {
     geckoId: "kroma",
     symbol: "KRO",
     cmcId: null,
-    categories: ["EVM"],
+    categories: ["EVM","Rollup", "Superchain"],
+    parent: {
+      chain: "Ethereum",
+      types: ["L2"]
+    },
+    chainId: 255,
     github: ["kroma-network"],
   },
   "Manta": {
@@ -2448,7 +2453,7 @@ export const chainCoingeckoIds = {
     geckoId: "mode",
     symbol: "MODE",
     cmcId: null,
-    categories: ["EVM", "Rollup"],
+    categories: ["EVM", "Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
       types: ["L2", "gas"]
@@ -2582,7 +2587,12 @@ export const chainCoingeckoIds = {
     geckoId: "fraxtal",
     symbol: "FXTL",
     cmcId: null,
-    categories: ["EVM"],
+    categories: ["EVM","Superchain"],
+    parent: {
+      chain: "Ethereum",
+      types: ["L2"]
+    },
+    chainId: 252,
     twitter: "fraxfinance",
     url: "https://frax.finance",
   },
@@ -2761,9 +2771,13 @@ export const chainCoingeckoIds = {
     geckoId: null,
     symbol: null,
     cmcId: null,
-    categories: ["EVM"],
+    categories: ["EVM", "Rollup", "Superchain"],
+    parent: {
+      chain: "Ethereum",
+      types: ["L2", "gas"]
+    },
     chainId: 7777777,
-    twitter: "ourZORA",
+    twitter: "zora",
     url: "https://zora.co"
   },
   "DeFiChain EVM": {
@@ -2970,7 +2984,7 @@ export const chainCoingeckoIds = {
     geckoId: null,
     symbol: null,
     cmcId: null,
-    categories: ["EVM","Rollup"],
+    categories: ["EVM","Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
       types: ["L2"]
@@ -3077,9 +3091,9 @@ export const chainCoingeckoIds = {
     geckoId: null,
     symbol: null,
     cmcId: null,
-    categories: ["EVM", "Arbitrum Orbit"],
+    categories: ["EVM", "Superchain"],
     parent: {
-      chain: "Arbitrum",
+      chain: "Optimism",
       types: ["L3"]
     },
     twitter: "HamOnWarpcast",
@@ -3133,7 +3147,7 @@ export const chainCoingeckoIds = {
     geckoId: null,
     symbol: null,
     cmcId: null,
-    categories: ["EVM","Rollup"],
+    categories: ["EVM","Rollup", "Superchain"],
     parent: {
       chain: "Ethereum",
       types: ["L2"]


### PR DESCRIPTION
Adds Superchain category to relevant chains. Sourced from the[ public tracker](https://docs.google.com/spreadsheets/d/1CRXo9YcP9fzJZxmKmEbNcPkZebgpUBMKo63HUhDKy2U/edit?gid=0#gid=0) (in the interim until the superchain-registry is oeprational)

Other changes:
- Recategorize Ham as Superchain ([Source](https://medium.com/@hamlabs/announcing-ham-chain-5597a1082769))
- Update Zora's Twitter Account ([Source](https://x.com/zora))
- Added Chain IDs when missing

Other open qustions:
- Some chains didn't have "Rollup" as a category, I tried to not change this, but wondering what the definition is (i.e. does it require Ethereum L1 DA?)