### PR TITLE
Possibly fixing stablecoins typo for Balanced

### DIFF
--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -3433,7 +3433,7 @@ const parentProtocols: IParentProtocol[] = [
     chains: [],
     twitter: "BalancedDAO",
     github: ["balancednetwork"],
-    stablecoins: ["usd-balance"]
+    stablecoins: ["usd-balanced"]
   },
   {
     id: "parent#baptswap",


### PR DESCRIPTION
Updated stablecoins: ["usd-balanced"]

Currently, the Stablecoin Info page for Balanced is showing the wrong stablecoin (usd-balance)

Should be showing **bnUSD**

