### PR TITLE
Add CVX1 token to tokenMapping.json

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -345,6 +345,11 @@
       "decimals": "18",
       "symbol": "apxETH",
       "to": "coingecko#dinero-apxeth"
+    },
+    "0x6c9815826fdf8c7a45ccfed2064dbab33a078712": {
+      "decimals": "18",
+      "symbol": "CVX1",
+      "to": "coingecko#convex-finance"
     }
   },
   "fantom": {


### PR DESCRIPTION
## Description

`CVX1` is a token that can be always, at a 1:1 ratio : 
- Minted by exchanging `CVX`
- Burnt in exchange of `CVX`

The underlying price of `CVX1` is so the price of `CVX`.

CVX1 is a product of Convergence Finance : https://app.cvg.finance/

If needed, here are more informations about `CVX1`=> https://medium.com/cvgfinance/focus-on-cvgcvx-9db67f9bbc32