### PR TITLE
Udate Oracles for Yei Finance and Segment Finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -32029,6 +32029,7 @@ const data3: Protocol[] = [
     chains: ["Binance"],
     oraclesByChain: {
       bsc: ["Chainlink"],
+      bob: ["RedStone"], //https://docs.segment.finance/protocol/price-feeds
       //  op_bnb: ["Binance Oracle"]
     },
     forkedFrom: ["Compound V2"],
@@ -45832,7 +45833,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds
     listedAt: 1717532780,
   },
   {


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Yei Finance on Sei and Segment Finance on BOB.

Oracle Provider(s): RedStone

Implementation Details: Yei Finance uses RedStone USDT,USDC feeds as primary which is >50% of their TVL.
Segment Finance uses RedStone WBTC, ETH, USDC, USDT, STONE feeds on BOB as primary which is >50% of their TVL.

Documentation/Proof:
[Yei Finance] https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds
 [Segment Finance] https://docs.segment.finance/protocol/price-feeds