### PR TITLE
Update oracles for Yei Finance and Bitlen Finance.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -41613,7 +41613,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["BSquared"],
-    oracles: ["Supra"], //https://supra.com/docs/data-feeds/pull-model/networks/
+    oracles: ["RedStone"], //https://docs.bitlen.io/borrowing/oracle
     forkedFrom: ["INIT Capital"],
     module: "bitlen/index.js",
     twitter: "BitLen_Finance",
@@ -45835,7 +45835,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Pyth"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds Pyth used for USDC, USDT & SEI price https://seitrace.com/address/0xEAb459AD7611D5223A408A2e73b69173F61bb808
+    oracles: ["RedStone"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds
     listedAt: 1717532780,
   },
   {

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -45835,7 +45835,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["RedStone"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds
+    oracles: ["Pyth"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds Pyth used for USDC, USDT & SEI price https://seitrace.com/address/0xEAb459AD7611D5223A408A2e73b69173F61bb808
     listedAt: 1717532780,
   },
   {


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Yei Finance on Sei and Bitlen Finance

Oracle Provider(s): RedStone

Implementation Details: Yei Finance uses RedStone USDT, USDC feeds as primary which is >50% of their TVL. This info is clearly stated in their docs ("RedStone USDT and USDC push feeds are used as primary oracle for these assets.") and confirmed by their team.

Bitten Finance uses RedStone as the primary solution for asset pricing.

Documentation/Proof:
[Yei Finance] https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds
[Bitlen Finance] https://docs.bitlen.io/borrowing/oracle