### PR TITLE
Fetch all SNS

### DIFF
--- a/defi/src/governance/icp/sns.ts
+++ b/defi/src/governance/icp/sns.ts
@@ -81,9 +81,7 @@ async function get_sns_metadata(retiresLeft = 3): Promise<SnsMetadata[]> {
     try {
 
         var { data, status } = await axios.get(
-            // ICRC1_LEDGER_API_BASE_URL + "?offset=0&limit=100"
-            ICRC1_LEDGER_API_BASE_URL
-            ,
+            ICRC1_LEDGER_API_BASE_URL + "?offset=0&limit=100",
             {
                 headers: {
                     Accept: 'application/json',


### PR DESCRIPTION
Currently, it only fetches 5 sns as it's the default value if no param is provided, we should fetch all which can be done using the param limit = 100.