### PR TITLE
Updated Kaia details

### DIFF
--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -481,13 +481,13 @@ export const chainCoingeckoIds = {
   },
   "Klaytn": {
     geckoId: "klay-token",
-    github: ['klaytn'],
+    github: ['kaiachain'],
     symbol: "KLAY",
     cmcId: "4256",
     categories: ["EVM"],
     chainId: 8217,
-    twitter: "klaytn_official",
-    url: "https://klaytn.foundation/"
+    twitter: "kaiachain",
+    url: "https://kaia.io/"
   },
   "IoTeX": {
     geckoId: "iotex",


### PR DESCRIPTION
Updated Klaytn details to Kaia.

Details:
Klaytn along with Finschia is now rebranded to Kaia. The Kaia Blockchain is a hard fork of Klaytn. Please refer to this https://klaytn.foundation/say-hello-to-kaia/ and https://kaia.io/ for more details.