### PR TITLE
Update oracles for Native Lend and Skate Fi

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -7690,6 +7690,7 @@ const data3: Protocol[] = [
     chains: ["Ethereum", "Binance", "Polygon", "Arbitrum"],
     module: "range/index.js",
     twitter: "Range_Protocol",
+    oracles: ["RedStone"], //https://docs.skatechain.org/skate-fi/vertex#oracles
     forkedFrom: [],
     audit_links: [
       "https://github.com/Range-Protocol/contracts/blob/master/audits/Certik-Audit.pdf",
@@ -44554,7 +44555,7 @@ const data3: Protocol[] = [
     chains: ["Arbitrum"],
     module: "native-lend/index.js",
     twitter: "native_fi",
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.native.org/native-dev/getting-started/lend
     forkedFrom: [],
     parentProtocol: "parent#native",
     listedAt: 1716459034,


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Skate Fi on mantle and Native Lend.

Oracle Provider(s): RedStone

Implementation Details: Skate Fi uses RedStone feeds on Mantle for asset pricing.

Native Lend uses RedStone as the primary solution for asset pricing.

Documentation/Proof:
[Native Lend] https://docs.native.org/native-dev/getting-started/lend#:~:text=worry%20about%20inventory.-,Oracles,-Native%20uses%20RedStone
[SkateFi] https://docs.skatechain.org/skate-fi/vertex#oracles