### PR TITLE
Update oracles for Yei Finance.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -45861,7 +45861,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Pyth"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds Pyth used for USDC, USDT & SEI price https://seitrace.com/address/0xEAb459AD7611D5223A408A2e73b69173F61bb808
+    oracles: ["RedStone"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds#redstone
     listedAt: 1717532780,
   },
   {

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -45861,7 +45861,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["RedStone"], //https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds#redstone
+    oracles: ["RedStone"], //https://github.com/DefiLlama/defillama-server/pull/7905
     listedAt: 1717532780,
   },
   {


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Yei Finance on Sei.

Oracle Provider(s): RedStone

Implementation Details: Yei Finance switched to RedStone push feeds as the primary solution for asset pricing on all liquidity pools last week.

Documentation/Proof:
https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds#redstone