### PR TITLE
Add Chronicle for Spark

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5265,7 +5265,7 @@ const data3: Protocol[] = [
     module: "spark-fi/index.js",
     twitter: "sparkdotfi",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Chainlink", "Chronicle"],
+    oracles: ["Chainlink", "Chronicle"], // https://github.com/DefiLlama/defillama-server/pull/8015
     audit_links: ["https://devs.spark.fi/security/security-and-audits"],
     github: ["marsfoundation"],
     listedAt: 1683144119,

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5265,7 +5265,7 @@ const data3: Protocol[] = [
     module: "spark-fi/index.js",
     twitter: "sparkdotfi",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "Chronicle"],
     audit_links: ["https://devs.spark.fi/security/security-and-audits"],
     github: ["marsfoundation"],
     listedAt: 1683144119,


### PR DESCRIPTION
Oracle Provider(s): Specify the oracle(s) used: adding Chronicle Oracles for Spark.fi

Implementation Details: Briefly describe how the oracle is integrated into your project:
- Spark.fi Oracle Upgrade for ETH, wstETH, rETH and weETH markets to use Aggor 
- Spark.fi  integration for Chronicle's LIDO_LST/2DAYS Oracle

Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- [LIDO_LST/2DAYS](https://etherscan.io/address/0xaBc99f366D2bE1f4e5b8DFC0F561a751dd836246#readContract)
- [Aggor](https://etherscan.io/address/0xf07ca0e66A798547E4CB3899EC592e1E99Ef6Cb3#code)
- [Aggor2](https://etherscan.io/address/0x00480CD3ed33de45555410BA71b2F932A14b1Cf2#code)
- [Aggor3](https://etherscan.io/address/0x69115a2826Eb47FE9DFD1d5CA8D8642697c8b68A#code)
- [Aggor4](https://etherscan.io/address/0xb20A1374EfCaFa32F701Ab14316fA2E5b3400eD5#code)