### PR TITLE
fix: lombard coin gecko and category

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -54354,9 +54354,9 @@ const data3: Protocol[] = [
     logo: `${baseIconsUrl}/lombard.jpg`,
     audits: "2",
     audit_note: null,
-    gecko_id: null,
+    gecko_id: "lombard-staked-btc",
     cmcId: null,
-    category: "Bridge",
+    category: "Liquid Staking",
     chains: ["Bitcoin"],
     module: "lombard/index.js",
     oracles: ["RedStone"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/11458


### PR DESCRIPTION
Added Coin Gecko.

Moved to liquid staking. Lombard is a Bitcoin Liquid staking platform. While users can move BTC liquidity cross-chain, the main attribute of Lombard is our liquid staking token (LBTC).

We are the only pure BTC LST, which makes it a bit harder to classify us since we are both clearly adopting BTC liquidity, but more importantly staking BTC.

The defi community sees us as liquid staking if this helps align :) :

https://x.com/Pell_Network/status/1834583754477891623
https://x.com/StakingRewards/status/1833834254599426181
https://x.com/ZircuitL2/status/1833536163468218765
https://x.com/MitosisOrg/status/1833520897573196164
https://x.com/symbioticfi/status/1831754460986785856


