### PR TITLE
update Jupiter perps oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31315,7 +31315,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Solana"],
-    oracles: ["Edge"], // https://station.jup.ag/guides/perpetual-exchange/how-it-works#oracle
+    oracles: ["Edge", "Pyth"], // https://station.jup.ag/guides/perpetual-exchange/how-it-works#oracle
     forkedFrom: [],
     module: "jupiter-perpetual.js",
     twitter: "JupiterExchange",


### PR DESCRIPTION
gm llama sirs,

a small update on the oracle section of Jupiter perps 

Jupiter perps currently leverages their own oracle (built with Edge) to update prices and open/close positions

However, Jupiter perps still relies on Pyth oracle:

- As a reference price check (sanity check) against their oracle, ensuring that the deviation is not too big.
- As a fallback price if their oracle's prices are stale.

In other words, if e.g. Jupiter's oracle price deviates too much from the Pyth oracle, there will be no trades executed on their perps

This signifies that the Pyth oracle is still a critical part of the Jupiter perps infrastructure as a supporting oracle

https://station.jup.ag/guides/perpetual-exchange/how-it-works#oracle
