### PR TITLE
feat: update APX Finance oracles

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -9135,9 +9135,7 @@ const data2: Protocol[] = [
     cmcId: "16334",
     category: "Derivatives",
     chains: ["Binance"],
-    oraclesByChain: {
-      bsc: ["Binance Oracle"],
-    },
+    oracles: ["Pyth", "Binance Oracle"],
     forkedFrom: [],
     module: "apollox/index.js",
     twitter: "APX_Finance",

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -9135,7 +9135,7 @@ const data2: Protocol[] = [
     cmcId: "16334",
     category: "Derivatives",
     chains: ["Binance"],
-    oracles: ["Pyth", "Binance Oracle"],
+    oracles: ["Pyth"], // https://apollox-finance.gitbook.io/apollox-finance/welcome/trading-on-v2/powered-by-pyth-oracle-and-chainlink
     forkedFrom: [],
     module: "apollox/index.js",
     twitter: "APX_Finance",


### PR DESCRIPTION
Proof：
https://medium.com/apx-finance/apx-v2-integrates-with-pyth-network-for-enhanced-real-time-price-accuracy-and-security-31d0ba5fb2b0

![image](https://github.com/user-attachments/assets/55bd299c-11c5-4c1c-aea3-6a0fa98e340e)
This says that Pyth is a primary oracle, chainlink is backup oracle.You can also check with pyth, this information is visible in the contract

You can also check this: https://www.apollox.finance/en/futures/v2/BTCUSD (Pyth logo on APX website)

btw, you can also check with Pyth team

Thanks very much!