### PR TITLE
Update Oracles for Cygnus and Lets Get Hai.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34281,7 +34281,7 @@ const data3: Protocol[] = [
     module: "cygnus-finance/index.js",
     twitter: "CygnusFi",
     forkedFrom: [],
-    oracles: ["RedStone"], // https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work#:~:text=Cygnus%20uses%20RedStone%20Oracles
+    oracles: ["Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/8247
     audit_links: [
       "https://github.com/peckshield/publications/blob/master/audit_reports/PeckShield-Audit-Report-Cygnus-v1.0.pdf",
     ],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34281,7 +34281,7 @@ const data3: Protocol[] = [
     module: "cygnus-finance/index.js",
     twitter: "CygnusFi",
     forkedFrom: [],
-    oracles: ["Chainlink"], // https://twitter.com/chainlink/status/1707711868570140778
+    oracles: ["RedStone"], // https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work#:~:text=Cygnus%20uses%20RedStone%20Oracles
     audit_links: [
       "https://github.com/peckshield/publications/blob/master/audit_reports/PeckShield-Audit-Report-Cygnus-v1.0.pdf",
     ],
@@ -36323,7 +36323,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Optimism"],
-    oracles: [],
+    oracles: ["RedStone"], // https://docs.letsgethai.com/detailed/intro/hai.html#redstone-oracles:~:text=friendly%20stablecoin%20system.-,RedStone%20Oracles,-HAI%20uses%20RedStone
     forkedFrom: [],
     module: "hai/index.js",
     twitter: "letsgethai",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Cygnus and Lets Get Hai.

Oracle Provider(s): RedStone

Implementation Details: 
Cygnus is using RedStone pull model as the primary solution for asset pricing on TON, BASE, Bsquared.
HAI is using RedStone Push model as one of its primary solutions for crypto assets pricing on Optimism.

Documentation/Proof:
[Cygnus] https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work#:~:text=Cygnus%20uses%20RedStone%20Oracles

[HAI] https://docs.letsgethai.com/detailed/intro/hai.html#redstone-oracles:~:text=friendly%20stablecoin%20system.-,RedStone%20Oracles,-HAI%20uses%20RedStone