### PR TITLE
Update M0 description

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -57605,7 +57605,7 @@ const data3: Protocol[] = [
     module: "m0/index.js",
     twitter: "m0foundation",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Chronicle"],
     audit_links: ["https://docs.m0.org/portal/technical/audits"],
     listedAt: 1728953339
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -57605,7 +57605,7 @@ const data3: Protocol[] = [
     module: "m0/index.js",
     twitter: "m0foundation",
     forkedFrom: [],
-    oracles: ["Chronicle"],
+    oracles: ["Chronicle"], // https://www.m0.org/press-releases/chronicle-launches-real-world-asset-oracle-with-initial-integration-on-m-0-building-infrastructure-for-transformation-of-digital-money
     audit_links: ["https://docs.m0.org/portal/technical/audits"],
     listedAt: 1728953339
   },


### PR DESCRIPTION
- Adding Chronicle as powering M0
- M0 uses [Chronicle's RWA Oracle](https://www.m0.org/press-releases/chronicle-launches-real-world-asset-oracle-with-initial-integration-on-m-0-building-infrastructure-for-transformation-of-digital-money)