### PR TITLE
Reclassify Puffer Oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31577,7 +31577,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Ethereum"],
-    oracles: ["RedStone"], // https://github.com/DefiLlama/defillama-server/pull/7986
+    oracles: [""],
     forkedFrom: [],
     module: "puffer/index.js",
     twitter: "puffer_finance",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31577,7 +31577,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Ethereum"],
-    oracles: [""],
+    oracles: [],
     forkedFrom: [],
     module: "puffer/index.js",
     twitter: "puffer_finance",


### PR DESCRIPTION
Hello Defillama team, I took the time to do some due diligence for this project.

According to the [docs](https://docs.puffer.fi/protocol/validator-tickets#pricing-validator-tickets) the pricing is done via Redstone oracles for the VTs but upon further investigation the current pricing mechanisms of VTs happen via a primary check of gaurdians who choose the redstone price that is posted at the 12 hour interval.

What this means is that a redstone misreport will not be accepted by the guardian because they would choose not to post it. According to the definition of [TVS](https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254)  and the question "If the oracle malfunctioned, would those assets be lost?" the answer here is no

I checked with the puffer team and they agree with my conclusion

![ishare-1730197922](https://github.com/user-attachments/assets/19c64774-6277-4b9a-9f0c-08a907d9f53c)

![ishare-1730198056](https://github.com/user-attachments/assets/74fd9e58-01e2-4a80-af62-603f93873bbb)
