### PR TITLE
Reclassify SolvBTC Oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -43633,8 +43633,8 @@ const data3: Protocol[] = [
     category: "Bridge", // move to bridge, since there is solv BTC on any l2 btc already, so double counted
     chains: ["Ethereum"],
     oraclesByChain: {
-      ethereum: ["RedStone"], // https://docs.solv.finance/solv-documentation/getting-started-3/price-oracles , https://prnt.sc/uR2ablagNhD0
-      bsc: ["RedStone"], //
+      ethereum: [], 
+      bsc: [],
     },
     forkedFrom: [],
     module: "solvbtc/index.js",


### PR DESCRIPTION
Hello Defillama team, I took the time to do some due diligence for this project.

According to the [docs](https://docs.solv.finance/solvbtc-liquid-staking-tokens/price-oracle) Redstone oracles maintain price security for SolvBTC and its Liquid Staking Tokens (LSTs), ensuring their peg to the underlying asset prices but upon further investigation this isn't entirely correct as there are other checks notably the solv gaurdians who decide what prices land on chain 

here is a chat with the solv team:

![ishare-1730199263](https://github.com/user-attachments/assets/6d01027e-9a9b-43cd-8590-a4df4487f913)

![ishare-1730199281](https://github.com/user-attachments/assets/819c7633-bc03-47d4-ba91-3a4df84f5404)

here are the provided links: 

https://solvprotocol.medium.com/introducing-solvs-360-risk-control-safeguarding-crypto-assets-for-all-494a302a8824

https://solvprotocol.medium.com/introducing-solv-guard-enhancing-security-for-yield-vaults-c4fe66463379

specifically the solv gaurd introduces "vault gaurdians" who dictate alot that happens with the LST, LSD vaults including accepting prices posted by oracles.

What this means is that a redstone misreport will not be accepted by the guardian because they would choose not to post it. According to the definition of https://github.com/DefiLlama/DefiLlama-Adapters/discussions/6254 and the question "If the oracle malfunctioned, would those assets be lost?" the answer here is no
