### PR TITLE
Reclassify Lombard Oracles

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -54379,7 +54379,7 @@ const data3: Protocol[] = [
     category: "Restaked BTC",
     chains: ["Bitcoin"],
     module: "lombard/index.js",
-    oracles: ["RedStone"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/11458
+    oracles: [],
     forkedFrom: [],
     twitter: "Lombard_Finance",
     parentProtocol: "parent#lombard-finance",


### PR DESCRIPTION
Hello Defillama team, I took the time to do some due diligence for this project.

The [docs](https://docs.lombard.finance/technical-documentation/oracles) don't give any information about how the oracles are used and instead link to this [redstone explanation](https://docs.solv.finance/solvbtc-liquid-staking-tokens/price-oracle) which describes how the feed is constructed

I went through the [Submitted PR](https://github.com/DefiLlama/DefiLlama-Adapters/pull/11458) by the lombard team and the section on Oracle states: 

"Redstone ensures our 1:1 ratio. Redstone tracks our staked BTC deposited into Lombard Deposit Addresses and the corresponding LBTC minted on destination chains (only ETH for now)". 

This is again describing how the datafeed is constructed. In no fashion is the datafeed actually used to secure the LBTC assets. I've checked for oracle references in lombard contracts but there isn't any place the oracle is used