### PR TITLE
feat: add dpi arbitrum mapping

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -675,6 +675,11 @@
       "decimals": "18",
       "symbol": "ETHFI",
       "to": "coingecko#ether-fi"
+    },
+    "0x9737C658272e66Faad39D7AD337789Ee6D54F500": {
+      "decimals": "18",
+      "symbol": "DPI",
+      "to": "asset#ethereum:0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b"
     }
   },
   "tezos": {


### PR DESCRIPTION
We are now adding a mapping for $DPI

You can see that the token on Arbitrum is a bridged token from the one on Ethereum (using Chainlink's CCIP)

Source: https://indexcoop.com/blog/dpi-and-mvi-on-arbitrum-faq

_Note: not sure if this is the correct way to do this, please let me know if there is something else to do_