### PR TITLE
add ivm coin on iota

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -9325,6 +9325,11 @@
       "decimals": "18",
       "symbol": "WETH",
       "to": "coingecko#weth"
+    },
+    "0x892aD291737249abe79C657C4A5a57e11C174566": {
+      "decimals": "18",
+      "symbol": "IVM",
+      "to": "coingecko#iota-velocimeter"
     }
   },
   "kinto": {


### PR DESCRIPTION
Noticed that the coins api would return nothing for ivm https://coins.llama.fi/prices/current/iotaevm:0x892aD291737249abe79C657C4A5a57e11C174566, which means the TVL on defillama for velocimeter v4 isn't accurate.