### PR TITLE
Add `USDRIF` price adaptor

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -105,5 +105,6 @@ export default {
   pancakeStable: require("./markets/pancakeStable"),
   etherfi: require("./yield/etherfi"),
   wcgUSD: require("./other/wcgUSD"),
+  usdrif: require("./other/usdrif"),
   xailocker: require("./liquidStaking/xailocker"),
 };

--- a/coins/src/adapters/other/usdrif.ts
+++ b/coins/src/adapters/other/usdrif.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+import getWrites from "../utils/getWrites";
+
+const chain = "rootstock";
+
+const usdRIFToken = {
+  address: "0x3a15461d8ae0f0fb5fa2629e9da7d66a794a6e37",
+  symbol: "USDRIF",
+  decimals: 18,
+};
+
+export function usdrif(timestamp: number = 0) {
+  return getTokenPrice(timestamp);
+}
+
+async function getTokenPrice(timestamp: number) {
+
+  const response = await axios.get(`https://api.geckoterminal.com/api/v2/networks/rootstock/tokens/${usdRIFToken.address}/pools`)
+
+  const [pool] = response.data.data;
+  const price = pool.attributes.token_price_usd;
+  const pricesObject: { [key: string]: any } = {};
+  
+  pricesObject[usdRIFToken.address] = {
+    token: usdRIFToken.address,
+    price,
+    symbol: usdRIFToken.symbol,
+    decimals: usdRIFToken.decimals,
+  };
+
+  return getWrites({
+    chain,
+    timestamp,
+    pricesObject,
+    projectName: "usdrif",
+  });;
+}


### PR DESCRIPTION
## Description

This PR adds [USDRIF](https://rootstock.blockscout.com/token/0x3A15461d8AE0f0Fb5fA2629e9dA7D66A794a6E37) price adaptor to enable [coin prices api](https://docs.llama.fi/coin-prices-api) for [rif-us-dollar](https://defillama.com/stablecoin/rif-us-dollar)

Defillama page: https://defillama.com/stablecoin/rif-us-dollar
USDRIF: https://rootstock.blockscout.com/token/0x3A15461d8AE0f0Fb5fA2629e9dA7D66A794a6E37

## Why

Because coingecko has not enabled price for: https://www.coingecko.com/en/coins/rif-us-dollar
The purpose of this adaptor is to enable price for USDRIF in the prices api at: https://stablecoins.llama.fi/stablecoins?includePrices=true

Currently the price field is coming as null
Response from: https://stablecoins.llama.fi/stablecoins?includePrices=true
```
{
            "id": "159",
            "name": "RIF US Dollar",
            "symbol": "USDRIF",
            "gecko_id": "rif-us-dollar",
            "pegType": "peggedUSD",
            "priceSource": null,
            "pegMechanism": "crypto-backed",
            "circulating": {
                "peggedUSD": 905337.1442592843
            },
            "circulatingPrevDay": {
                "peggedUSD": 888045.3340625383
            },
            "circulatingPrevWeek": {
                "peggedUSD": 889040.0100984059
            },
            "circulatingPrevMonth": {
                "peggedUSD": 896595.7853950679
            },
            "chainCirculating": {
                "Rootstock": {
                    "current": {
                        "peggedUSD": 905337.1442592843
                    },
                    "circulatingPrevDay": {
                        "peggedUSD": 888045.3340625383
                    },
                    "circulatingPrevWeek": {
                        "peggedUSD": 889040.0100984059
                    },
                    "circulatingPrevMonth": {
                        "peggedUSD": 896595.7853950679
                    }
                }
            },
            "chains": [
                "Rootstock"
            ],
            "price": null
        },

```

## End Goal of this PR.

Show USDRIF price at: https://defillama.com/stablecoin/rif-us-dollar

## Testing

Testing needs to be done on this PR as i do not have AWS credentials on local. 

Feel free to mention if anything needs to be changed or any other PR is required to enable USDRIF price at: https://defillama.com/stablecoin/rif-us-dollar