### PR TITLE
add protocols under pyth

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -59375,7 +59375,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Hedera"],
-    oracles: ["Supra"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/12159
+    oracles: ["Pyth","Supra"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/12159 , https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration
     forkedFrom: [],
     module: "hliquity/index.js",
     twitter: "HLiquity_",
@@ -59397,7 +59397,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Flow"],
-    oracles: [], 
+    oracles: ["Pyth"],  // https://docs.more.markets/borrow/oracles-and-pricing
     forkedFrom: ["Morpho"],
     module: "more-markets/index.js",
     twitter: "More_Protocol",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -59375,7 +59375,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Hedera"],
-    oracles: ["Pyth","Supra"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/12159 , https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration
+    oracles: ["Pyth"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/12159 , https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration
     forkedFrom: [],
     module: "hliquity/index.js",
     twitter: "HLiquity_",


### PR DESCRIPTION
gm llama sirs

adding 2 protocols under Pyth

- HLiquity, Pyth as the primary oracle https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration

- MORE Markets, Pyth as the primary oracle https://docs.more.markets/borrow/oracles-and-pricing

thank you very much