### PR TITLE
`USDRIF` Adaptor chain name fix

### DIFF
--- a/coins/src/adapters/other/usdrif.ts
+++ b/coins/src/adapters/other/usdrif.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import getWrites from "../utils/getWrites";
 
-const chain = "rootstock";
+const chain = "rsk";
 
 const usdRIFToken = {
   address: "0x3a15461d8ae0f0fb5fa2629e9da7d66a794a6e37",
@@ -33,5 +33,5 @@ async function getTokenPrice(timestamp: number) {
     timestamp,
     pricesObject,
     projectName: "usdrif",
-  });;
+  });
 }


### PR DESCRIPTION
## Description:

This PR fixes the price not showing issue at: https://defillama.com/stablecoin/rif-us-dollar

## Relavent pull requests:
https://github.com/DefiLlama/defillama-server/pull/8492

## Why

Because the chain name `rsk` is used instead of `rootstock`.

Reference:

https://github.com/DefiLlama/peggedassets-server/blob/148b8a424ee6c7d84e12fcb21fb97e0b77e8cc13/src/peggedData/peggedData.ts#L3194