### PR TITLE
Update Oracles for Cygnus Finance and Ton Hedge.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -17128,7 +17128,7 @@ const data3: Protocol[] = [
     category: "Lending",
     chains: ["Polygon"],
     module: "cygnusdao/index.js",
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "RedStone"], //https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle, https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle
     forkedFrom: [],
     twitter: "CygnusDAO",
     github: ["CygnusDAO"],
@@ -51057,7 +51057,7 @@ const data3: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Options",
-    oracles: [],
+    oracles: ["RedStone"], //https://ton-hedge.gitbook.io/ton-hedge-docs/trading-options
     forkedFrom: [],
     chains: ["TON"],
     module: "tonhedge/index.js",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Cygnus and Ton Hedge.

Oracle Provider(s): RedStone

Implementation Details:
Cygnus is using RedStone pull model as the primary solution for asset pricing within their restaking product on TON, BASE, Bsquared. Cygnus is also using RedStone stablecoin feeds on TON and BSquared for cgUSD's peg.

Ton Hedge is using RedStone feeds as the primary pricing solution.


Documentation/Proof:
[Cygnus] https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work#:~:text=Cygnus%20uses%20RedStone%20Oracles, https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle

[Ton Hedge] https://ton-hedge.gitbook.io/ton-hedge-docs/trading-options