### PR TITLE
add Pyth to jupiter

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31324,7 +31324,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Solana"],
-    oracles: ["Edge"], // https://station.jup.ag/guides/perpetual-exchange/how-it-works#oracle
+    oracles: ["Edge","Pyth"], // https://station.jup.ag/guides/perpetual-exchange/how-it-works#oracle
     forkedFrom: [],
     module: "jupiter-perpetual.js",
     twitter: "JupiterExchange",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -24324,7 +24324,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Solana"],
-    oracles: ["Scope", "Pyth", "Switchboard"],
+    oracles: ["Pyth"],
     forkedFrom: [],
     module: "kamino-lending/index.js",
     twitter: "KaminoFinance",


### PR DESCRIPTION
test 

write reasons why kamino should only have pyth as its main oracle etc

