### PR TITLE
Feat: add price for USDa and sUSDa on Taiko, Zircuit and ZKsync

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -4945,6 +4945,16 @@
       "to": "coingecko#ethereum",
       "decimals": 18,
       "symbol": "WETH"
+    },
+    "0xff12470a969Dd362EB6595FFB44C82c959Fe9ACc": {
+      "to": "coingecko#usda",
+      "decimals": 18,
+      "symbol": "USDa"
+    },
+    "0x5d5c8Aec46661f029A5136a4411C73647a5714a7": {
+      "to": "coingecko#susda",
+      "decimals": 18,
+      "symbol": "sUSDa"
     }
   },
   "islm": {

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -5445,5 +5445,17 @@
       "decimals": 6,
       "symbol": "USDC"
     }
+  },
+  "zksync": {
+    "0xB8d7d88D042880aE87Bb61DE2dFFF8441768766D": {
+      "to": "coingecko#usda",
+      "decimals": 18,
+      "symbol": "USDa"
+    },
+    "0x4047aE7cc300b5cc5a6fac2417C76eaAD18972F6": {
+      "to": "coingecko#susda",
+      "decimals": 18,
+      "symbol": "sUSDa"
+    }
   }
 }

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -4450,6 +4450,16 @@
       "to": "coingecko#loopring",
       "decimals": 18,
       "symbol": "LRC"
+    },
+    "0xff12470a969Dd362EB6595FFB44C82c959Fe9ACc": {
+      "to": "coingecko#usda",
+      "decimals": 18,
+      "symbol": "USDa"
+    },
+    "0x5d5c8Aec46661f029A5136a4411C73647a5714a7": {
+      "to": "coingecko#susda",
+      "decimals": 18,
+      "symbol": "sUSDa"
     }
   },
   "real": {


### PR DESCRIPTION
Add price data for USDa and sUSDa on Taiko, Zircuit and ZKsync. 

Token | Network | Contract Address
-- | -- | --
USDa | ZIRCUIT | https://explorer.zircuit.com/address/0xff12470a969Dd362EB6595FFB44C82c959Fe9ACc | https://safe.zircuit.com/home?safe=zircuit-mainnet:0x8773c75C83d497135CEf197Bd862930A04DA77FF
USDa | TAIKO | https://taikoscan.io/address/0xff12470a969dd362eb6595ffb44c82c959fe9acc | https://safe.taiko.xyz/home?safe=tko-mainnet:0x8773c75C83d497135CEf197Bd862930A04DA77FF
USDa | ZKSYNC | https://explorer.zksync.io/address/0xB8d7d88D042880aE87Bb61DE2dFFF8441768766D#transactions | https://app.safe.global/home?safe=zksync:0x1026b239E1BBC4719f7834cBCaBb461D5B8a3Edd

Token | Network | Contract Address
-- | -- | --
sUSDa | ZIRCUIT | https://explorer.zircuit.com/address/0x5d5c8Aec46661f029A5136a4411C73647a5714a7
sUSDa | TAIKO | https://taikoscan.io/address/0x5d5c8aec46661f029a5136a4411c73647a5714a7
sUSDa | ZKSYNC | https://explorer.zksync.io/address/0x4047aE7cc300b5cc5a6fac2417C76eaAD18972F6




