### PR TITLE
Update Oracles for USDX Money.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -57473,7 +57473,7 @@ const data3: Protocol[] = [
     module: "usdx/index.js",
     twitter: "usdx_money",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.usdx.money/informaiton/oracles
     listedAt: 1728645744
   },
   {


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for USDX Money.

Oracle Provider(s): RedStone

Implementation Details:
RedStone stablecoin feeds are used as a cross-check during the minting /redemption process of USDX. This integration helps maintain the accuracy and security of our token's value relative to the US dollar.


Documentation/Proof: 
https://docs.usdx.money/informaiton/oracles