### PR TITLE
added supra as oracle to Hliquity

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -59397,7 +59397,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Hedera"],
-    oracles: ["Pyth"], //https://github.com/DefiLlama/DefiLlama-Adapters/pull/12159 , https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration
+    oracles: ["Supra"], // https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration "Supra is the primary oracle, Pyth is the fallback oracle"
     forkedFrom: [],
     module: "hliquity/index.js",
     twitter: "HLiquity_",


### PR DESCRIPTION
**Oracle Integration**
HLiquity uses Supra and Pyth as its oracles to provide reliable price data. **Supra serves as the primary oracle**, pushing data 24/7 with a deviation threshold of 0.5%, ensuring consistent and accurate price updates. **Pyth acts as a fallback oracle**, utilizing its HBAR/USD and USD/CHF reference contracts. 

**Link to their documentation:** https://docs.hliquity.org/deep-dive/stability-pool-and-liquidations#oracle-integration 

Supra is the primary oracle, Pyth is the fallback oracle as stated in their documentation.