### PR TITLE
add eOracle to mendi finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16432,7 +16432,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["API3", "Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/7002
+    oracles: ["API3", "eOracle"], // https://github.com/DefiLlama/defillama-server/pull/7002
     github: ["mendi-finance"],
     listedAt: 1692625594,
   },


### PR DESCRIPTION
eOracle was added as a secondary oracle to mendi finance, Chainlink was removed. 

docs: https://docs.mendi.finance/protocol/oracles
accepted proposal: https://gov.mendi.finance/t/mip-9-integrating-eoracle-to-the-mendi-protocol-on-the-weth-and-weeth-markets/237

A misreport by eOracle can cause > 50% the protocol TVL to be drained since this is a compoundV2 forks and markets aren't siloed.


