### PR TITLE
Add eOracle to mendi finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16422,7 +16422,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["API3", "Chainlink", "eOracle"], // https://github.com/DefiLlama/defillama-server/pull/7002
+    oracles: ["API3", "Chainlink", "eOracle"], // https://github.com/DefiLlama/defillama-server/pull/7002 , https://github.com/DefiLlama/defillama-server/pull/8792
     github: ["mendi-finance"],
     listedAt: 1692625594,
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16422,7 +16422,7 @@ const data3: Protocol[] = [
     module: "mendi-finance/index.js",
     twitter: "MendiFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["API3", "Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/7002
+    oracles: ["API3", "Chainlink", "eOracle"], // https://github.com/DefiLlama/defillama-server/pull/7002
     github: ["mendi-finance"],
     listedAt: 1692625594,
   },


### PR DESCRIPTION
eOracle was added as a primary oracle on mendi finance for the weETH and WETH markets.

docs: https://docs.mendi.finance/protocol/oracles
proposal: https://gov.mendi.finance/t/mip-9-integrating-eoracle-to-the-mendi-protocol-on-the-weth-and-weeth-markets/237
snapshot: https://snapshot.box/#/s:mendifinance.eth/proposal/0x63c5a914ba319526f1f21b1b6dec8aab32703f29f214132bf489361ab7b0f836

A misreport by eOracle can cause > 50% the protocol TVL to be drained since this is a compoundV2 forks and markets aren't siloed.