### PR TITLE
update yei finance oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -45906,7 +45906,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["RedStone"], //https://github.com/DefiLlama/defillama-server/pull/7905
+    oracles: ["API3"],
     listedAt: 1717532780,
   },
   {

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -45906,7 +45906,7 @@ const data3: Protocol[] = [
     module: "yei-fi/index.js",
     twitter: "YeiFinance",
     forkedFrom: ["AAVE V3"],
-    oracles: ["API3"],
+    oracles: ["API3"], // https://github.com/DefiLlama/defillama-server/pull/8796
     listedAt: 1717532780,
   },
   {


### PR DESCRIPTION
Yei finance have updated their oracle to use API3 as the primary oracle for all their markets.

Proof in documentation: 
https://docs.yei.finance/welcome-to-yei/security-and-risk/oracles-and-data-feeds#multi-oracle-strategy

Quote from documentation:

> We choose API3 as our primary oracle for providing the main data source, while additional oracles offer supplementary validation.

How to verify:
Head over to https://app.yei.finance/ and click on `details` of any of the market. Then click on the hyperlink next to the oracle price, this will take you to the block explorer. For example, this is the link to the SEI/USD oracle hyperlink: 

https://seitrace.com/address/0x241B320946Caa015324C9b614D077B4619a4d3d3?chain=pacific-1

go to Contracts -> Read Contracts . Call the `getPrice` function and then the `getAPI3Price` function . Both will return the same answer since API3 is the primary oracle