### PR TITLE
add Stork as a primary oracle to Helix

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -53899,7 +53899,7 @@ const data3: Protocol[] = [
     module: "injective-orderbook/index.js",
     twitter: "HelixApp_",
     forkedFrom: [],
-    oracles: ["Pyth", "Band"], // band oracle was confirmed by helix team
+    oracles: ["Pyth", "Band", "Stork"], // band oracle was confirmed by helix team
     parentProtocol: "parent#helix",
     listedAt: 1724923885
   },


### PR DESCRIPTION
added Stork as a primary oracle to Helix

docs: https://helixapp.zendesk.com/hc/en-us/articles/8790962218383-Which-oracle-provider-does-Helix-use
