### PR TITLE
Updated Category to Yield

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -62561,7 +62561,7 @@ const data3: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Managed Token Pools",
+    category: "Yield",
     chains: ["Ethereum", "Avalanche", "Base"],
     oracles: [], 
     forkedFrom: [],


### PR DESCRIPTION
Hi, I've a little request we recently listed our project Upshift 
https://defillama.com/protocol/upshift

We want it to come under the category Yield  or Yield Aggregator
I've raised a pr as well for this  PR : https://github.com/DefiLlama/defillama-server/pull/8746

But it changed to Managed Token Pool  Category which we don't want 

Clarification for above

- Morpho Blue is similar to Upshift where we have curators and that is currently labeled as ‘Lending’
- Sommelier which lists vaults managed by Seven Seas is listed as ‘Yield Aggregator’
- EtherFi Liquid vaults are all managed by third party providers such as Veda and Into the Block and are under ‘Yield Aggregator’
- Kelp Gain, which is one of the vaults we built in Upshift, is listed as a ‘Yield Aggregator’
- Syrup is effectively a managed lending vault similar to our Upshift Lend vaults and is labeled as Lending

**Given Upshift does both lending pools and curated pools like Sommelier, we should not fall under Managed Accounts - we should call under either Yield or Yield Aggregator** 
