### PR TITLE
Add token mappings for IBC tokens on Pryzm

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -2252,6 +2252,56 @@
       "decimals": "6",
       "symbol": "STARS",
       "to": "coingecko#stargaze"
+    },
+    "DE63D8AC34B752FB7D4CAA7594145EDE1C9FC256AC6D4043D0F12310EB8FC255": {
+      "decimals": "18",
+      "symbol": "INJ",
+      "to": "coingecko#injective-protocol"
+    },
+    "13B2C536BB057AC79D5616B8EA1B9540EC1F2170718CAFF6F0083C966FFFED0B": {
+      "decimals": "6",
+      "symbol": "OSMO",
+      "to": "coingecko#osmosis"
+    },
+    "BF28D9C17E0306B194D50F51C3B2590BEAD15E04E03ADD34C3A26E62D85C9676": {
+      "decimals": "6",
+      "symbol": "TIA",
+      "to": "coingecko#celestia"
+    },
+    "B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395": {
+      "decimals": "6",
+      "symbol": "LUNA",
+      "to": "coingecko#terra-luna-2"
+    },
+    "BFAAB7870A9AAABF64A7366DAAA0B8E5065EAA1FCE762F45677DC24BE796EF65": {
+      "decimals": "6",
+      "symbol": "USDC",
+      "to": "coingecko#usd-coin"
+    },
+    "B9E4FD154C92D3A23BEA029906C4C5FF2FE74CB7E3A058290B77197A263CF88B": {
+      "decimals": "6",
+      "symbol": "axlUSDC",
+      "to": "coingecko#axlusdc"
+    },
+    "120DC39B61CC121E91525C1D51624E41BBE74C537D7B0BE50BBFF9A00E37B6EE": {
+      "decimals": "18",
+      "symbol": "stDYDX",
+      "to": "coingecko#stride-staked-dydx"
+    },
+    "FA78980867B7E87F382CDA00275C55DDC248CABC7DEE27AC6868CCF97DD5E02F": {
+      "decimals": "6",
+      "symbol": "stTIA",
+      "to": "coingecko#stride-staked-tia"
+    },
+    "F8CA5236869F819BC006EEF088E67889A26E4140339757878F0F4E229CDDA858": {
+      "decimals": "18",
+      "symbol": "DYDX",
+      "to": "coingecko#dydx-chain"
+    },
+    "EA6E1E8BA2EB9F681C4BD12C8C81A46530A62934F2BD561B120A00F46946CE87": {
+      "decimals": "6",
+      "symbol": "dATOM",
+      "to": "coingecko#drop-staked-atom"
     }
   },
   "zeta": {


### PR DESCRIPTION
This PR intends to add IBC tokens available on the Pryzm chain, in order to be used in TVL calculation for Pryzm Protocol. The respective PR on the adapters repo is https://github.com/DefiLlama/DefiLlama-Adapters/pull/12872