### PR TITLE
add pyth to tren + neutral trade

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -64441,7 +64441,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Managed Token Pools",
     chains: ["Solana"],
-    oracles: [], 
+    oracles: ["Pyth"], 
     forkedFrom: [],
     module: "neutral-trade/index.js",
     twitter: "TradeNeutral",
@@ -64485,7 +64485,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Arbitrum"],
-    oracles: [], 
+    oracles: ["Pyth","Chainlink"],  // https://docs.tren.finance/protocol/asset-risk/oracle-risk
     forkedFrom: [],
     module: "tren-finance/index.js",
     twitter: "TrenFinance",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -64441,7 +64441,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Managed Token Pools",
     chains: ["Solana"],
-    oracles: ["Pyth"], 
+    oracles: ["Pyth"], // https://docs.neutral.trade/additional-info/pyth-oracles
     forkedFrom: [],
     module: "neutral-trade/index.js",
     twitter: "TradeNeutral",


### PR DESCRIPTION
gm llama sirs

adding Tren that uses both Pyth and Chainlink, as well as Neutral Trade that uses Pyth

Tren
https://docs.tren.finance/protocol/asset-risk/oracle-risk

Neutral Trade
https://docs.neutral.trade/additional-info/pyth-oracles

thank you