### PR TITLE
add switchboard oracle to Carrot protocol 

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -59738,7 +59738,7 @@ const data3: Protocol[] = [
     module: "carrot/index.js",
     twitter: "DeFiCarrot",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Switchboard"],
     audit_links: ["https://deficarrot.com/assets/carrot_final_report.pdf"],
     listedAt: 1731107322
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -59738,7 +59738,7 @@ const data3: Protocol[] = [
     module: "carrot/index.js",
     twitter: "DeFiCarrot",
     forkedFrom: [],
-    oracles: ["Switchboard"],
+    oracles: ["Switchboard", "Pyth"],
     audit_links: ["https://deficarrot.com/assets/carrot_final_report.pdf"],
     listedAt: 1731107322
   },


### PR DESCRIPTION
Updated the Carrot protocol to list Switchboard as an oracle.

It is specific to Solana.

The oracle feed is here: https://ondemand.switchboard.xyz/solana/mainnet/feed/GQbKvThYgyvdp8T8MoE8KKD2NngXumQ8mDkCLxmhvJKm