### PR TITLE
chore (Tempest Finance): Add RedStone as oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61004,7 +61004,7 @@ const data3: Protocol[] = [
     module: "tempest-finance/index.js",
     twitter: "tempest_fi",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["RedStone"],
     audit_links: ["https://github.com/Tempest-Finance/core-public"],
     github: ["Tempest-Finance"],
     listedAt: 1732137329


### PR DESCRIPTION
Dear Llamas,

We submit a PR adding RedStone as an Oracle for Tempest.
RedStone is securing both the Deposit and Withdrawal modules.
Link to Docs -> https://tempestfinance.gitbook.io/tempest-finance-docs/introduction/faq