### PR TITLE
Refactor protocol metadata keys from siblingProtocols to linkedProtocols

### DIFF
--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -69,7 +69,7 @@ async function run() {
       Object.keys(summaries).forEach((summaryKey) => {
         if (!summaries[summaryKey]?.totalAllTime) return;
         if (!protocolSummaryMetadata[protocolId]) protocolSummaryMetadata[protocolId] = new Set()
-          protocolSummaryMetadata[protocolId].add(summaryKey)
+        protocolSummaryMetadata[protocolId].add(summaryKey)
       })
     }
 
@@ -516,7 +516,8 @@ function mergeChildRecords(protocol: any, childProtocolData: any[]) {
   childProtocolData.forEach(({ records, info: childData }: any) => {
 
     const versionKey = childData.name ?? childData.displayName ?? childData.versionKey
-    childData.siblingProtocols = info.childProtocols.filter((name: any) => name !== versionKey)
+    childData.linkedProtocols = info.childProtocols.concat([info.name])
+
     if (!versionKey) console.log('versionKey is missing', childData)
 
     // update child  metadata and chain info

--- a/defi/src/api2/routes/dimensions.ts
+++ b/defi/src/api2/routes/dimensions.ts
@@ -104,7 +104,7 @@ export async function getOverviewProcess2({
   response.change_7dover7d = getPercentage(summary.total7d, summary.total14dto7d)
   response.change_30dover30d = getPercentage(summary.total30d, summary.total60dto30d)
 
-  const protocolInfoKeys = ['defillamaId', 'name', 'disabled', 'displayName', 'module', 'category', 'logo', 'chains', 'protocolType', 'methodologyURL', 'methodology', 'latestFetchIsOk', 'childProtocols', 'parentProtocol', 'slug', 'siblingProtocols',]
+  const protocolInfoKeys = ['defillamaId', 'name', 'disabled', 'displayName', 'module', 'category', 'logo', 'chains', 'protocolType', 'methodologyURL', 'methodology', 'latestFetchIsOk', 'childProtocols', 'parentProtocol', 'slug', 'linkedProtocols',]
   const protocolDataKeys = ['total24h', 'total48hto24h', 'total7d', 'total14dto7d', 'total60dto30d', 'total30d', 'total1y', 'totalAllTime', 'average1y', 'change_1d', 'change_7d', 'change_1m', 'change_7dover7d', 'change_30dover30d', 'breakdown24h', 'total14dto7d', 'total7DaysAgo', 'total30DaysAgo']  // TODO: missing breakdown24h/fix it?
 
   response.protocols = Object.entries(protocolSummaries).map(([_id, { summaries, info }]: any) => {


### PR DESCRIPTION
Update protocol metadata to replace `siblingProtocols` with `linkedProtocols` for improved clarity and consistency.