### PR TITLE
Add eOracle as the oracle for Elara

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61045,7 +61045,7 @@ const data3: Protocol[] = [
     module: "elara/index.js",
     twitter: "ElaraLabs",
     forkedFrom: ["Compound V2"],
-    oracles: ["eOracle"],
+    oracles: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9127
     audit_links: ["https://github.com/ElaraFinance/elara-audits/blob/main/24-09-2024_Quantstamp_ElaraV1.pdf"],
     listedAt: 1732186221
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61045,7 +61045,7 @@ const data3: Protocol[] = [
     module: "elara/index.js",
     twitter: "ElaraLabs",
     forkedFrom: ["Compound V2"],
-    oracles: [eOracle],
+    oracles: ["eOracle"],
     audit_links: ["https://github.com/ElaraFinance/elara-audits/blob/main/24-09-2024_Quantstamp_ElaraV1.pdf"],
     listedAt: 1732186221
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61045,7 +61045,7 @@ const data3: Protocol[] = [
     module: "elara/index.js",
     twitter: "ElaraLabs",
     forkedFrom: ["Compound V2"],
-    oracles: [],
+    oracles: [eOracle],
     audit_links: ["https://github.com/ElaraFinance/elara-audits/blob/main/24-09-2024_Quantstamp_ElaraV1.pdf"],
     listedAt: 1732186221
   },


### PR DESCRIPTION
Elara uses eOracle on their main market, which is Compound V2 fork.
Docs can be found here https://learn.elara.finance/protocol/contract-addresses
To verify the oracle contract being used by the unitroller you can make a cast call as follows
`cast call 0x695aCEf58D1a10Cf13CBb4bbB2dfB7eDDd89B296 "oracle()" -r https://zircuit-mainnet.drpc.org/`
The price feeds on this oracle contract were updated on this transaction https://explorer.zircuit.com/tx/0x945a2a2a0ea44b62d57796b993ad242610b834eeed9c5b680d77dfdae84bd0ac
eOracle's zircuit price feeds can be found here https://docs.eoracle.io/docs/eoracle-price-feeds/feed-addresses/zircuit