### PR TITLE
add catton and resolv to pyth

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61486,7 +61486,7 @@ const data3: Protocol[] = [
     module: "catton/index.js",
     twitter: "Cattontw",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"], // https://x.com/Cattontw/status/1862096754847650156
   },
   {
     id: "5410",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -1769,7 +1769,7 @@ const data4: Protocol[] = [
     module: "resolv/index.js",
     twitter: "ResolvLabs",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"], // https://docs.resolv.xyz/litepaper/for-developers/smart-contracts
     stablecoins: ["resolv-usd"],
     github: ["resolv-im"],
     listedAt: 1737626553


### PR DESCRIPTION
gm llama sirs,

adding Catton and Resolv that have been leveraging Pyth oracle

Catton
https://x.com/Cattontw/status/1862096754847650156

Resolv
Resolv is currently using Pyth for both its USR and wstUSR, and the only oracle used for minting USR and RLP

https://docs.resolv.xyz/litepaper/for-developers/smart-contracts

https://docs.resolv.xyz/litepaper/for-developers/token-supply-operations/usr

https://docs.resolv.xyz/litepaper/for-developers/token-supply-operations/rlp

thank you