### PR TITLE
update craftChainsResponse to include defillama_id in it's response

### DIFF
--- a/defi/src/getChains.ts
+++ b/defi/src/getChains.ts
@@ -6,12 +6,12 @@ import { IChain, } from "./types";
 import { importAdapter } from "./utils/imports/importAdapter";
 import { excludeProtocolInCharts, isExcludedFromChainTvl } from "./utils/excludeProtocols";
 
-async function _checkModuleDoubleCounted(protocol: Protocol){
+async function _checkModuleDoubleCounted(protocol: Protocol) {
   const module = await importAdapter(protocol);
   return module.doublecounted
 }
 
-async function _getLastHourlyRecord(protocol: Protocol){
+async function _getLastHourlyRecord(protocol: Protocol) {
   return getLastRecord(hourlyTvl(protocol.id))
 }
 
@@ -19,41 +19,48 @@ export async function craftChainsResponse(excludeDoublecountedAndLSD = false, us
   checkModuleDoubleCounted = _checkModuleDoubleCounted,
   getLastHourlyRecord = _getLastHourlyRecord,
   protocolList = protocols,
-} = {}){
-  const chainTvls = {} as {[chain:string]:number}
+} = {}) {
+  const chainTvls = {} as { [chain: string]: { tvl: number, defillama_id: string } }
   await Promise.all(
     protocolList.map(async (protocol) => {
-      if(excludeProtocolInCharts(protocol) || isExcludedFromChainTvl(protocol.category)){
+      if (excludeProtocolInCharts(protocol) || isExcludedFromChainTvl(protocol.category)) {
         return undefined;
       }
       const lastTvl = await getLastHourlyRecord(protocol)
-      if(lastTvl === undefined){
-          return
+      if (lastTvl === undefined) {
+        return
       }
-      const excludeTvl = excludeDoublecountedAndLSD && (protocol.category === "Liquid Staking" || isDoubleCounted(await checkModuleDoubleCounted(protocol), protocol.category)  === true)
+      const excludeTvl = excludeDoublecountedAndLSD && (protocol.category === "Liquid Staking" || isDoubleCounted(await checkModuleDoubleCounted(protocol), protocol.category) === true)
       if (excludeTvl) return;
       let chainsAdded = 0
-      Object.entries(lastTvl).forEach(([chain, chainTvl])=>{
-          const chainName = getChainDisplayName(chain, useNewChainNames)
-          if(chainCoingeckoIds[chainName] === undefined){
-              return
-          }
-          chainTvls[chainName] = (chainTvls[chainName] ?? 0) + chainTvl
-          chainsAdded += 1;
+      Object.entries(lastTvl).forEach(([chain, chainTvl]) => {
+        const chainName = getChainDisplayName(chain, useNewChainNames)
+        if (chainCoingeckoIds[chainName] === undefined) {
+          return
+        }
+        if (!chainTvls[chainName]) {
+          chainTvls[chainName] = { tvl: 0, defillama_id: chain }
+        }
+        chainTvls[chainName].tvl += chainTvl as number
+        chainsAdded += 1;
       })
-      if(chainsAdded === 0){ // for fetch adapters
+      if (chainsAdded === 0) { // for fetch adapters
         const chainName = protocol.chain
-        chainTvls[chainName] = (chainTvls[chainName] ?? 0) + lastTvl.tvl
+        if (!chainTvls[chainName]) {
+          chainTvls[chainName] = { tvl: 0, defillama_id: chainName }
+        }
+        chainTvls[chainName].tvl += lastTvl.tvl
       }
     })
   );
-  const chainData: IChain[] = Object.entries(chainTvls).map(([chainName, chainTvl])=>({
+  const chainData: IChain[] = Object.entries(chainTvls).map(([chainName, chainData]) => ({
     gecko_id: chainCoingeckoIds[chainName]?.geckoId ?? null,
-    tvl: chainTvl,
+    tvl: chainData.tvl,
     tokenSymbol: chainCoingeckoIds[chainName]?.symbol ?? null,
     cmcId: chainCoingeckoIds[chainName]?.cmcId ?? null,
     name: chainName,
     chainId: chainCoingeckoIds[chainName]?.chainId ?? null,
+    defillama_id: chainData.defillama_id,
   }))
   return chainData
 }


### PR DESCRIPTION
Endpoint /v2/chains do not include an id that can be used for the /prices/current/{coins} endpoint as the chain id for the {chain}:{address} pattern. This PR fills this gap adding defillama_id.