### PR TITLE
Update Oracles for ZeroLend.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12358,7 +12358,7 @@ const data3: Protocol[] = [
     twitter: "zerolendxyz",
     oraclesByChain: {
       blast: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
-      base: ["Chainlink"], //https://docs.zerolend.xyz/security/oracles/chainlink
+      base: ["RedStone"], //https://docs.zerolend.xyz/security/oracles/redstone
       linea: ["Chainlink"], //https://docs.zerolend.xyz/security/oracles/chainlink
       manta: ["RedStone"], //https://docs.zerolend.xyz/security/oracles/using-redstone-oracles
       ethereum: ["Chainlink"], // https://docs.zerolend.xyz/security/oracles/chainlink


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for ZeroLend on Base

Oracle Provider(s): RedStone

Implementation Details: ZeroLend is using RedStone LBTC price feed on Base, which is majority of their TVL there (above 50%)

Documentation/Proof:
https://docs.zerolend.xyz/security/oracles/redstone