### PR TITLE
add eoracle to ionic oracles on mode

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31172,7 +31172,7 @@ const data3: Protocol[] = [
     category: "Lending",
     chains: ["Mode"],
     oraclesByChain: {
-      mode: ["API3", "RedStone", "Pyth"], //https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
+      mode: ["API3", "RedStone", "Pyth", "eOracle"], //https://doc.ionic.money/ionic-documentation/ionic-protocol/oracles#oracle-types
       base: ["eOracle"], // https://doc.ionic.money/ionic-documentation/resources/market-addresses#base
     },
     forkedFrom: ["Compound V2"],


### PR DESCRIPTION
Ionic uses eOracle price feed for the new uniBTC market on Mode :
uniBTC token address on Mode https://modescan.io/token/0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a
Here is the transaction where they set the oracle contract for underlying asset ie uniBTC address https://modescan.io/tx/0x0f951a3fc1696395fd130e89565971ed864dcab11dde59e47ec179405556b41e/eventlog
Here is the transaction where they set the price feed address on the oracle contract https://modescan.io/tx/0x6a114432410282d6cbc07c921e26a65a90ea4e44def21860bef7e75de2249b41
You can find the eOracle feed addresses on mode here https://docs.eoracle.io/docs/eoracle-price-feeds/feed-addresses/mode.
A misreport on any of this feed can cause > 50% the protocol TVL to be drained since this is a compoundV2 forks and markets aren't siloed.
