### PR TITLE
Ethos markets smart contract audits

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2857,7 +2857,7 @@ const data4: Protocol[] = [
     chains: ["Base"],
     module: "ethos-markets/index.js",
     twitter: "ethos_network",
-    audit_links: [],
+    audit_links: ["https://whitepaper.ethos.network/security/smart-contract-audits"],
     oracles: [],
     forkedFrom: [],
     listedAt: 1738204217


### PR DESCRIPTION
Ethos Markets went in yesterday; was missing smart contract audits. See: https://github.com/DefiLlama/DefiLlama-Adapters/pull/13302