### PR TITLE
Add Redstone to Spark.fi oracle data

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5270,7 +5270,7 @@ const data3: Protocol[] = [
     module: "spark-fi/index.js",
     twitter: "sparkdotfi",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Chainlink", "Chronicle", "RedStone"],
+    oracles: ["Chainlink", "Chronicle", "RedStone"], // https://github.com/DefiLlama/defillama-server/pull/9240
     audit_links: ["https://devs.spark.fi/security/security-and-audits"],
     github: ["marsfoundation"],
     listedAt: 1683144119,

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -5270,7 +5270,7 @@ const data3: Protocol[] = [
     module: "spark-fi/index.js",
     twitter: "sparkdotfi",
     forkedFrom: ["AAVE V3"],
-    oracles: ["Chainlink", "Chronicle"], // https://github.com/DefiLlama/defillama-server/pull/8015
+    oracles: ["Chainlink", "Chronicle", "RedStone"],
     audit_links: ["https://devs.spark.fi/security/security-and-audits"],
     github: ["marsfoundation"],
     listedAt: 1683144119,


### PR DESCRIPTION
Spark is integrating Redstone oracles in its next spell update going live Monday, Feb 10, 2025.

RedStone oracles are integrated into the Aggor (aggregated oracle) used by Spark, for the following assets:
ETH/USD:
- WETH
- wstETH (with exchange rate provider)
- weETH (with exchange rate provider)
- rETH (with exchange rate provider)

BTC/USD:
- cbBTC

Proof:
- https://github.com/marsfoundation/spark-spells/pull/80/files#diff-0fd45385ef094b8973c5b4a1d3af9e5a8e93ab775462c494faf15bdcf4e9f37d
- https://github.com/marsfoundation/spark-spells/pull/80/files#diff-0628c3ab1637c1629905d16a817b74263f1c220c9ea476e244337481cbfc53ce

Excerpt from spell description:
#### WETH ([0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))

| description | value before | value after |
| --- | --- | --- |
| oracle | [0xf07ca0e66A798547E4CB3899EC592e1E99Ef6Cb3](https://etherscan.io/address/0xf07ca0e66A798547E4CB3899EC592e1E99Ef6Cb3) | [0x2750e4CB635aF1FCCFB10C0eA54B5b5bfC2759b6](https://etherscan.io/address/0x2750e4CB635aF1FCCFB10C0eA54B5b5bfC2759b6) |
| oracleDescription | null | Aggregated price feed ETH/USD from Chronicle, Chainlink, and RedStone oracles |
| oracleLatestAnswer | 3104.38063228 | 3110.43126457 |

#### wstETH ([0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0))

| description | value before | value after |
| --- | --- | --- |
| oracle | [0xf77e132799DBB0d83A4fB7df10DA04849340311A](https://etherscan.io/address/0xf77e132799DBB0d83A4fB7df10DA04849340311A) | [0xE98d51fa014C7Ed68018DbfE6347DE9C3f39Ca39](https://etherscan.io/address/0xE98d51fa014C7Ed68018DbfE6347DE9C3f39Ca39) |
| oracleLatestAnswer | 3700.88418905 | 3708.09744413 |



#### weETH ([0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee](https://etherscan.io/address/0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee))

| description | value before | value after |
| --- | --- | --- |
| oracle | [0x28897036f8459bFBa886083dD6b4Ce4d2f14a57F](https://etherscan.io/address/0x28897036f8459bFBa886083dD6b4Ce4d2f14a57F) | [0xBE21C54Dff3b2F1708970d185aa5b0eEB70556f1](https://etherscan.io/address/0xBE21C54Dff3b2F1708970d185aa5b0eEB70556f1) |
| oracleLatestAnswer | 3286.9666244 | 3293.37312822 |


#### rETH ([0xae78736Cd615f374D3085123A210448E74Fc6393](https://etherscan.io/address/0xae78736Cd615f374D3085123A210448E74Fc6393))

| description | value before | value after |
| --- | --- | --- |
| oracle | [0x11af58f13419fD3ce4d3A90372200c80Bc62f140](https://etherscan.io/address/0x11af58f13419fD3ce4d3A90372200c80Bc62f140) | [0xFDdf8D19D092839A26b31365c927cA236B5086cf](https://etherscan.io/address/0xFDdf8D19D092839A26b31365c927cA236B5086cf) |
| oracleLatestAnswer | 3499.60533012 | 3506.4262801 |


#### cbBTC ([0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf](https://etherscan.io/address/0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf))

| description | value before | value after |
| --- | --- | --- |
| oracle | [0xb9ED698c9569c5abea716D1E64c089610a3768B6](https://etherscan.io/address/0xb9ED698c9569c5abea716D1E64c089610a3768B6) | [0x4219aA1A99f3fe90C2ACB97fCbc1204f6485B537](https://etherscan.io/address/0x4219aA1A99f3fe90C2ACB97fCbc1204f6485B537) |
| oracleDescription | null | Aggregated price feed BTC/USD from Chronicle, Chainlink, and RedStone oracles |
| oracleLatestAnswer | 102238.7 | 102733.52699733 |

