### PR TITLE
fix otherProtocols order in parent protocol api

### DIFF
--- a/defi/src/api2/utils/craftParentProtocolV2.ts
+++ b/defi/src/api2/utils/craftParentProtocolV2.ts
@@ -36,7 +36,7 @@ export async function craftParentProtocolV2({
 
   const res = await craftParentProtocolInternal({ parentProtocol, childProtocolsTvls, skipAggregatedTvl, isHourlyTvl, fetchMcap: getCachedMCap, parentRaises:[] })
 
-  res.otherProtocols = childProtocols?.[0]?.otherProtocols ?? []
+  res.otherProtocols = childProtocols?.[0]?.otherProtocols ?? null
 
   const debug_totalTime = performance.now() - debug_t0
   const debug_dbTime = debug_t1 - debug_t0

--- a/defi/src/api2/utils/craftParentProtocolV2.ts
+++ b/defi/src/api2/utils/craftParentProtocolV2.ts
@@ -36,11 +36,7 @@ export async function craftParentProtocolV2({
 
   const res = await craftParentProtocolInternal({ parentProtocol, childProtocolsTvls, skipAggregatedTvl, isHourlyTvl, fetchMcap: getCachedMCap, parentRaises:[] })
 
-  res.otherProtocols = [parentProtocol.name, ...childProtocolsTvls.sort((a: any, b: any) => {
-    if (a.deprecated && !b.deprecated) return 1
-    if (!a.deprecated && b.deprecated) return -1
-    return b.tvl - a.tvl
-  }).map((p: any) => p.name)]
+  res.otherProtocols = childProtocols?.[0]?.otherProtocols ?? []
 
   const debug_totalTime = performance.now() - debug_t0
   const debug_dbTime = debug_t1 - debug_t0


### PR DESCRIPTION
order of otherProtocols is different in parent protocol https://api.llama.fi/updatedProtocol/stakestone when compare to child protocol https://api.llama.fi/updatedProtocol/stonebtc