### PR TITLE
Corrected typos

### DIFF
--- a/coins/src/adapters/readme.md
+++ b/coins/src/adapters/readme.md
@@ -56,6 +56,6 @@ getTokenPrices() uses a variety of functions and libraries to find token prices:
 3. getTokenAndRedirectData() fetches information from the DefiLlama coins database, about coins deposited to the Euler markets.
 4. multiCall()is a function from the DefiLlama SDK which allows us to fetch on-chain data from many functions at once. There are lots of examples on how to use the DefiLlama SDK in the DefiLlama/DefiLlama-Adapters repo.
 
-The last part of the adapter code to run is formWrites(). This function is used to create the array returned by the adapter. At this stage of the adapter it is crucial to handle any errors effectively so that faulty data doesnt enter the database. Notice on lines 57 and 64 where unexpected data is excluded from the writes list by returning from the map function. 
+The last part of the adapter code to run is formWrites(). This function is used to create the array returned by the adapter. At this stage of the adapter it is crucial to handle any errors effectively so that faulty data doesn't, does not enter the database. Notice on lines 57 and 64 where unexpected data is excluded from the writes list by returning from the map function. 
 
 To test the Euler adapter, we can run 'LOCAL_TEST=true ts-node coins/src/test.ts euler'. If the command successfully logs an array of database writes containing expected data, we're ready to make a PR!

--- a/defi/src/adaptors/cli/backfillUtilities/README.md
+++ b/defi/src/adaptors/cli/backfillUtilities/README.md
@@ -32,8 +32,8 @@ The previous commands will run the backfill in the cloud. If you would like to r
 > If the flag `runAtCurrTime` is set to true in the adapter, you won't be able to backfill but by doing the first step (export the adapter) and the last step (enable the protoxol in `config.ts`) it should show up the next day after the scheduled job stores the daily volume of all adapters (daily at 00:00:01 UTC).
 
 ### Improvements
-- Currently is not possible to backfill a sigle chain so it will rewrite previous chains when backfilling a new one. This can be manually avoided but ideally should be changed the backfill script to allow backfilling a single chain.
+- Currently is not possible to backfill a single, sigil chain so it will rewrite previous chains when backfilling a new one. This can be manually avoided but ideally should be changed the backfill script to allow backfilling a single chain.
 - Backfilling an adapter with a chain with the flag `runAtCurrTime` enabled and other chain with a specific start time will make the first chain backfill with the same value from the specific start time of the other chain.
 - When multiple chains. The backfill starts with the oldest start time for all chains. This results in extra queries that we already know there's no data available.
 
-Decided to push later in time this improvements and prioritize other developements. Let me know if u think it's a problem and should be improved!
+Decided to push later in time this improvements and prioritize other developments. Let me know if u think it's a problem and should be improved!


### PR DESCRIPTION
Changes made in:

- /high-usage/defiCode/adaptors/cli/backfillUtilities/README.md ("sigle" → "single, sigil")

- /high-usage/defiCode/adaptors/cli/backfillUtilities/README.md ("developements" → "developments")

- /coins/src/adapters/readme.md ("doesnt" → "doesn't, does not")

- /defi/src/adaptors/cli/backfillUtilities/README.md ("sigle" → "single, sigil")

- /defi/src/adaptors/cli/backfillUtilities/README.md ("developements" → "developments")
