### PR TITLE
pumpBTC.bera wrong decimal

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -61,7 +61,7 @@
       "to": "coingecko#susda"
     },
     "0x1fCca65fb6Ae3b2758b9b2B394CB227eAE404e1E": {
-      "decimals": "18",
+      "decimals": "8",
       "symbol": "pumpBTC.bera",
       "to": "coingecko#pumpbtc"
     }


### PR DESCRIPTION
<img width="203" alt="image" src="https://github.com/user-attachments/assets/d9e5ac4e-e1f0-4ffb-b50f-cdbee1630be7" />

https://etherscan.io/address/0x1fCca65fb6Ae3b2758b9b2B394CB227eAE404e1E#readProxyContract