### PR TITLE
Update Oracles for Dolomite on Berachain.ts

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -18745,6 +18745,7 @@ const data2: Protocol[] = [
       polygon_zkevm: ["Chainlink"],
       xlayer: ["Chainlink"],
       mantle: ["Chronicle"], // https://github.com/DefiLlama/defillama-server/pull/7767
+      BeraChain: ["RedStone], //https://docs.dolomite.io/smart-contract-addresses/module-general
     },
     audit_links: [
       "https://github.com/dolomite-exchange/dolomite-margin/blob/master/docs/Dolomite%20Margin%20-%20Cyfrin%20-%202023-08-23.pdf",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Dolomite on Berachain.

Oracle Provider(s): RedStone

Implementation Details: Dolomite is using RedStone as the primary oracle on all main pools on Berachain.

Documentation/Proof:
https://docs.dolomite.io/smart-contract-addresses/module-general
https://x.com/redstone_defi/status/1876644979961208862