### PR TITLE
Update oracle for ListaDAO.ts

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -15295,7 +15295,7 @@ const data2: Protocol[] = [
     chains: ["Binance"],
     // oracle dev docs: https://docs.bsc.lista.org/for-developer/collateral-debt-position/multi-oracle#intro-of-resilient-oracle
     // announcement: https://medium.com/listadao/lista-dao-upgrades-from-redstone-to-the-chainlink-standard-for-verifiable-market-data-d9988f94109d
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "RedStone"],//https://docs.bsc.lista.org/for-developer/collateral-debt-position/multi-oracle#intro-of-resilient-oracle
     forkedFrom: ["MakerDAO"],
     module: "helio-money/index.js",
     twitter: "LISTA_DAO",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for ListaDAO

Oracle Provider(s): RedStone

Implementation Details: ListaDAO (lisUSD to be exact) uses RedStone as the only oracle for SolvBTC.BBN and wstETH. Since the protocol has one core pool (not isolated ones), the mispricing of RedStone could cause a full drain of the protocol (similar to Compound v2 forks).

Documentation/Proof:
https://docs.bsc.lista.org/for-developer/collateral-debt-position/multi-oracle#intro-of-resilient-oracle
