### PR TITLE
Add Plume and Corn Maizenet

### DIFF
--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -406,9 +406,8 @@ const chainsByOracle: Record<string, Array<string>> = {
     "Mantle",
     "Scroll",
     "Berachain",
-    "Superseed",
     "Plume",
-    "Corn Maizenet"
+    "Corn"
   ],
   "eOracle": [
     "Base",

--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -406,7 +406,9 @@ const chainsByOracle: Record<string, Array<string>> = {
     "Mantle",
     "Scroll",
     "Berachain",
-    "Superseed"
+    "Superseed",
+    "Plume",
+    "Corn Maizenet"
   ],
   "eOracle": [
     "Base",


### PR DESCRIPTION
Add Plume and Corn Maizenet as chains for Chronicle
- https://docs.plumenetwork.xyz/plume/nexus-data-highway/overview#oracle-partners-powering-the-nexus
- https://docs.usecorn.com/docs/developers/Infrastructure/Oracles