### PR TITLE
Add Chronicle powering Dolomite on Berachain

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -18745,6 +18745,7 @@ const data2: Protocol[] = [
       polygon_zkevm: ["Chainlink"],
       xlayer: ["Chainlink"],
       mantle: ["Chronicle"], // https://github.com/DefiLlama/defillama-server/pull/7767
+      berachain:["Chronicle"]
     },
     audit_links: [
       "https://github.com/dolomite-exchange/dolomite-margin/blob/master/docs/Dolomite%20Margin%20-%20Cyfrin%20-%202023-08-23.pdf",


### PR DESCRIPTION
Add Chronicle as the Oracle powering Dolomite on Berachain

Proof: Using the getOracleByToken function we can see that sUSDa, USDC, HONEY, USDT, UNIBTC, STONE, etc are all using Chronicle: https://beratrail.io/address/0xa150Ef2D5827dB283321D15d62d5D07fB41d636E/contract/80094/readContract

