### PR TITLE
Fetch yesterday's data for dimensions records

### DIFF
--- a/defi/src/adaptors/db-utils/db2.ts
+++ b/defi/src/adaptors/db-utils/db2.ts
@@ -118,3 +118,15 @@ export async function getAllItemsAfter({ adapterType, timestamp }: { adapterType
 
   return result
 }
+
+export async function getAllDimensionsRecordsOnDate({ adapterType, date }: { adapterType: AdapterType, date: string}) {
+  await init()
+
+  const result: any = await Tables.DIMENSIONS_DATA.findAll({
+    where: { type: adapterType, timeS: date },
+    attributes: ['timestamp', 'id', 'timeS'],
+    raw: true,
+  })
+
+  return result
+}

--- a/defi/src/adaptors/handlers/storeAdaptorData/index.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/index.ts
@@ -29,8 +29,7 @@ export interface IHandlerEvent {
   protocolVersion?: string
 }
 
-// we fetch timestamp two hours ago so indexer is caught up
-const LAMBDA_TIMESTAMP = getTimestampAtStartOfHour(Math.trunc((Date.now()) / 1000)) - 2 * 60 * 60
+const timeStartofTheHourToday = getTimestampAtStartOfHour(Math.trunc((Date.now()) / 1000))
 
 export const handler = async (event: IHandlerEvent) => {
   return handler2({
@@ -49,18 +48,22 @@ export type IStoreAdaptorDataHandlerEvent = {
   maxConcurrency?: number
   isDryRun?: boolean
   isRunFromRefillScript?: boolean
+  yesterdayIdSet?: Set<string>
+  runType?: 'store-all' | 'default'
 }
 
 const ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 export const handler2 = async (event: IStoreAdaptorDataHandlerEvent) => {
   const defaultMaxConcurrency = 21
-  let { timestamp, adapterType, protocolNames, maxConcurrency = defaultMaxConcurrency, isDryRun = false, isRunFromRefillScript = false, } = event
+  let { timestamp, adapterType, protocolNames, maxConcurrency = defaultMaxConcurrency, isDryRun = false, isRunFromRefillScript = false,
+    runType = 'default', yesterdayIdSet = new Set()
+
+  } = event
   if (!isRunFromRefillScript)
     console.info(`- Date: ${new Date(timestamp! * 1e3).toDateString()} (timestamp ${timestamp})`)
   // Timestamp to query, defaults current timestamp - 2 minutes delay
-  const isTimestampProvided = timestamp !== undefined
-  const currentTimestamp = timestamp ?? LAMBDA_TIMESTAMP;
+  const currentTimestamp = timestamp ?? timeStartofTheHourToday;
   // Get clean day
   let toTimestamp = getTimestampAtStartOfDayUTC(currentTimestamp)
   let fromTimestamp = getTimestampAtStartOfDayUTC(toTimestamp - 1)
@@ -68,6 +71,9 @@ export const handler2 = async (event: IStoreAdaptorDataHandlerEvent) => {
   // I didnt want to touch existing implementation that affects other scripts, but it looks like it is off by a day if we store it at the end of the time range (which is next day 00:00 UTC)
   if (isRunFromRefillScript) {
     fromTimestamp = getTimestampAtStartOfDayUTC(timestamp!)
+    toTimestamp = fromTimestamp + ONE_DAY_IN_SECONDS - 1
+  } else if (runType === 'store-all') {
+    fromTimestamp = getTimestampAtStartOfDayUTC(timeStartofTheHourToday - ONE_DAY_IN_SECONDS)
     toTimestamp = fromTimestamp + ONE_DAY_IN_SECONDS - 1
   }
 
@@ -176,19 +182,9 @@ export const handler2 = async (event: IStoreAdaptorDataHandlerEvent) => {
       // Import adaptor
       const adaptor: Adapter = (await importModule(module)).default;
       // if an adaptor is expensive and no timestamp is provided, we try to avoid running every hour, but only from 21:55 to 01:55
-      if (!isRunFromRefillScript && adaptor.isExpensiveAdapter && !isTimestampProvided) {
-        const date = new Date(currentTimestamp * 1000)
-        const hours = date.getUTCHours()
-        if (hours > 5) {
-          console.info(`[${adapterType}] - ${index + 1}/${protocols.length} - ${protocol.module} - skipping because it's an expensive adapter and it's not the right time`)
-          return
-        }
-      }
       const adapterVersion = adaptor.version
-      const isVersion2 = adapterVersion === 2
-      const v1Timestamp = (timestamp !== undefined ? toTimestamp : fromTimestamp)
-      const endTimestamp = (isVersion2 && !timestamp) ? LAMBDA_TIMESTAMP : toTimestamp // if version 2 and no timestamp, use current time as input for running the adapter
-      let recordTimestamp = isVersion2 ? toTimestamp : v1Timestamp // if version 2, store the record at with timestamp end of range, else store at start of range
+      let endTimestamp = toTimestamp
+      let recordTimestamp = toTimestamp
       if (isRunFromRefillScript) recordTimestamp = fromTimestamp // when we are storing data, irrespective of version, store at start timestamp while running from refill script? 
       // I didnt want to touch existing implementation that affects other scripts, but it looks like it is off by a day if we store it at the end of the time range (which is next day 00:00 UTC) - this led to record being stored on the next day of the 24 hour range?
 
@@ -206,19 +202,41 @@ export const handler2 = async (event: IStoreAdaptorDataHandlerEvent) => {
       } else
         throw new Error("Invalid adapter")
 
+
+      if (runType === 'store-all') {
+        let runAtCurrTime = adaptersToRun.some(([_version, adapter]) => Object.values(adapter).some(a => a.runAtCurrTime))
+
+        const date = new Date()
+        const hours = date.getUTCHours()
+
+        if (runAtCurrTime) {
+          recordTimestamp = timeStartofTheHourToday
+          endTimestamp = timeStartofTheHourToday
+
+          if (hours < 19) {
+            console.info(`[${adapterType}] - ${index + 1}/${protocols.length} - ${protocol.module} - skipping because it's not the right time (too early to fetch today's data)`)
+            return
+          }
+        } else if (yesterdayIdSet.has(id)) {
+          console.info(`[${adapterType}] - ${index + 1}/${protocols.length} - ${protocol.module} - skipping because it's already stored`)
+          return
+        } else if (hours < 2) {
+          console.info(`[${adapterType}] - ${index + 1}/${protocols.length} - ${protocol.module} - skipping because it's not the right time (too early to fetch yesterday's data, wait for indexer to catch up)`)
+          return
+        }
+      }
+
       const promises: any = []
       const rawRecords: RawRecordMap = {}
       const adaptorRecords: {
         [key: string]: AdaptorRecord
       } = {}
       for (const [version, adapter] of adaptersToRun) { // the version is the key for the record (like uni v2) not the version of the adapter
-        const runAtCurrTime = Object.values(adapter).some(a => a.runAtCurrTime)
-        // if (runAtCurrTime && Math.abs(LAMBDA_TIMESTAMP - toTimestamp) > 60 * 60 * 3)
-        //   throw new Error('This Adapter can be run only around current time') // allow run current time if within 3 hours
         const chainBlocks = {} // WARNING: reset chain blocks for each adapter, sharing this between v1 & v2 adapters that have different end timestamps have nasty side effects
         const runAdapterRes = await runAdapter(adapter, endTimestamp, chainBlocks, module, version, { adapterVersion })
-        // const runAdapterRes = await runAdapterInSubprocess({ adapter, endTimestamp, chainBlocks, module, version, adapterVersion })
 
+        const recordWithTimestamp = runAdapterRes.find((r: any) => r.timestamp)
+        if (recordWithTimestamp) recordTimestamp = recordWithTimestamp.timestamp
         processFulfilledPromises(runAdapterRes, rawRecords, version, KEYS_TO_STORE)
       }
       const storedData: any = {}

--- a/defi/src/adaptors/handlers/storeAdaptorData/index.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/index.ts
@@ -241,7 +241,7 @@ export const handler2 = async (event: IStoreAdaptorDataHandlerEvent) => {
               await handler2({
                 timestamp: yesterdayEndTimestamp,
                 adapterType,
-                protocolNames: new Set([protocol.module]),
+                protocolNames: new Set([protocol.displayName]),
                 isRunFromRefillScript: true,
               })
             } catch (e) {

--- a/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
@@ -28,14 +28,17 @@ async function run() {
     try {
 
       let yesterdayIdSet: Set<string> = new Set()
+      let todayIdSet: Set<string> = new Set()
 
       try {
         const yesterdayData = await getAllDimensionsRecordsOnDate({ adapterType, date: getYesterdayTimeS() });
+        const todayData = await getAllDimensionsRecordsOnDate({ adapterType, date: getTodayTimeS() });
         yesterdayIdSet = new Set(yesterdayData.map((d: any) => d.id));
+        todayIdSet = new Set(todayData.map((d: any) => d.id));
       } catch (e) {
         console.error("Error in getAllDimensionsRecordsOnDate", e)
       }
-      await handler2({ adapterType, yesterdayIdSet, runType: 'store-all' })
+      await handler2({ adapterType, yesterdayIdSet, runType: 'store-all', todayIdSet, })
 
     } catch (e) {
       console.error("error", e)
@@ -92,5 +95,13 @@ function getYesterdayTimeS() {
   const yyyy = yesterday.getUTCFullYear();
   const mm = String(yesterday.getUTCMonth() + 1).padStart(2, '0');
   const dd = String(yesterday.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function getTodayTimeS() {
+  const today = new Date();
+  const yyyy = today.getUTCFullYear();
+  const mm = String(today.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(today.getUTCDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
 }

--- a/defi/src/api2/scripts/testDimensionsPG.ts
+++ b/defi/src/api2/scripts/testDimensionsPG.ts
@@ -1,5 +1,5 @@
 // import { Op, col, fn } from "sequelize";
-import { init } from "../../adaptors/db-utils/db2";
+import { getAllDimensionsRecordsOnDate, init } from "../../adaptors/db-utils/db2";
 import { Tables } from "../db/tables";
 import { ADAPTER_TYPES } from "../../adaptors/handlers/triggerStoreAdaptorData";
 import { AdapterType, ProtocolType } from "@defillama/dimension-adapters/adapters/types";
@@ -7,20 +7,39 @@ import loadAdaptorsData from "../../adaptors/data"
 
 async function fetchChainIds() {
 
+  const yesterday = new Date();
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const yyyy = yesterday.getUTCFullYear();
+  const mm = String(yesterday.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(yesterday.getUTCDate()).padStart(2, '0');
+  const yesterdayDateString = `${yyyy}-${mm}-${dd}`;
+
+  console.log('yesterday:', yesterdayDateString);
+  const currentHour = new Date().getUTCHours();
+  console.log(`Current UTC hour: ${currentHour}`);
 
   await init();
+  const dataTable: any = []
   for (const adapterType of ADAPTER_TYPES) {
     await fixChainIdsByType(adapterType)
   }
 
+  console.table(dataTable);
+
   async function fixChainIdsByType(adapterType: AdapterType) {
 
     const { protocolAdaptors } = loadAdaptorsData(adapterType)
-    
-    console.log(protocolAdaptors.length, adapterType)
+    const yesterdayData = await getAllDimensionsRecordsOnDate({ adapterType, date: yesterdayDateString });
+    const yesterdayIdSet = new Set(yesterdayData.map((d: any) => d.id));
+    dataTable.push({
+      adapterType,
+      protocolAdaptors: protocolAdaptors.length,
+      yesterdayIdSet: yesterdayIdSet.size,
+      missingYesterdayData: protocolAdaptors.filter((a: any) => !yesterdayIdSet.has(a.id)).length
+    })
   }
 }
 
 fetchChainIds().then(() => {
-  console.log('Connection closed');
+  console.log('Connection closed');  
 })


### PR DESCRIPTION
Change behavior of dimensions v2 adapters. 

Instead of fetching past 24 hour data, always fetch yesterday's data.

Also, if we already have data for yesterday (for both v1 & v2 adapters) we dont update the record. For adapters where we are fetching current data, run them after 19:00 UTC today, this way, we dont end up with overlapping data.

Hopefully this change will lower the stress on our system and more importantly, less bad data (less chance of common time range between two stored datapoints) 