### PR TITLE
add pyth oracle to protocols

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -65043,7 +65043,22 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Sonic"],
-    oracles: ["API3","Pyth"], // https://machfi.gitbook.io/machfi-documentation/contracts/audit
+    oracles: ["API3"], // https://machfi.gitbook.io/machfi-documentation/contracts/audit
+    oraclesBreakdown: [
+      {
+        name: "API3",
+        type: "Primary",
+        proof: [
+          "https://machfi.gitbook.io/machfi-documentation/protocol/mechanics/risk-management#oracle-risk"
+        ],
+      },
+      {
+        name: "Pyth",
+        type: "Secondary",
+        proof: [
+          "https://machfi.gitbook.io/machfi-documentation/protocol/mechanics/risk-management#oracle-risk"
+        ],
+      },
     forkedFrom: ["Compound V2"],
     module: "machfi/index.js",
     twitter: "machfi_xyz",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -65043,7 +65043,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Sonic"],
-    oracles: ["API3"], // https://github.com/DefiLlama/defillama-server/pull/9183
+    oracles: ["API3","Pyth"], // https://machfi.gitbook.io/machfi-documentation/contracts/audit
     forkedFrom: ["Compound V2"],
     module: "machfi/index.js",
     twitter: "machfi_xyz",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2448,6 +2448,7 @@ const data4: Protocol[] = [
     chains: ["Scroll"],
     module: "quill-fi/index.js",
     twitter: "QuillFi",
+    oracles: ["Pyth","Chainlink"], // https://docs.quill.finance/faq/liquidations-oracle-and-redemptions
     forkedFrom: ["Liquity V2"],
     stablecoins: ["quill-usd"],
     listedAt: 1738101111
@@ -3272,7 +3273,7 @@ const data4: Protocol[] = [
     chains: ["Eclipse"],
     module: "neptune-protocol/index.js",
     twitter: "Neptune_Stable",
-    oracles: [],
+    oracles: ["Pyth"], // https://docs.hydrogenlabs.xyz/neptune-protocol/protocol-design/security
     forkedFrom: ["Hedge"],  
     audit_links: ["https://docs.hydrogenlabs.xyz/neptune-protocol/protocol-design/security"],
     listedAt: 1738617883
@@ -3572,7 +3573,7 @@ const data4: Protocol[] = [
     chains: ["Soneium"],
     module: "wavex/index.js",
     twitter: "waveX_fi",
-    oracles: [],
+    oracles: ["Pyth", "Chainlink"], // https://docs.wavex.fi/docs/key-features-of-wavex#transparent-and-secure-on-chain-transactions
     forkedFrom: ["GMX V2"],
     listedAt: 1738844419
   },
@@ -3764,7 +3765,7 @@ const data4: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Berachain"],
-    oracles: [],
+    oracles: ["Pyth"], // https://beraborrow.gitbook.io/docs/audits/audits
     forkedFrom: [],
     module: "beraborrow/index.js",
     twitter: "beraborrow",


### PR DESCRIPTION
gm

adding new pyth protocols:

MachFi:
Pyth is the primary oracle for MachFi (on top of API3), as noted in the audit results https://machfi.gitbook.io/machfi-documentation/contracts/audit

Neptune:
Pyth is the primary oracle for Neptune https://docs.hydrogenlabs.xyz/neptune-protocol/protocol-design/security

WaveX:
Pyth is used with Chainlink as the main oracles for the perp protocol https://wavex.fi/

Beraborrow:
Pyth is the main oracle for Beraborrow, as noted in the audit results https://beraborrow.gitbook.io/docs/audits/audits

Quill Finance:
Pyth is used with Chainlink as the main oracles for the stablecoin protocol https://docs.quill.finance/faq/liquidations-oracle-and-redemptions