### PR TITLE
Update BerraBorrow description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -3792,6 +3792,12 @@ const data4: Protocol[] = [
     oracles: [],
     oraclesBreakdown: [
       {
+        name: "Chronicle",
+        type: "Primary",
+        proof: ["https://chroniclelabs.org/dashboard/oracles"], 
+
+      },
+      {
         name: "Restone",
         type: "Primary",
         proof: ["https://app.redstone.finance/app/feeds/?page=1&sortBy=popularity&sortDesc=false&perPage=32&networks=80094", "https://berascan.com//address/0x83c6f7F61A55Fc7A1337AbD45733AD9c1c68076D"]


### PR DESCRIPTION
Adding Chronicle as primary oracle for BeraBorrow
Feeds and links:
- NECT/HONEY[0x66eDB52dA8deF8d1A93808a369a3F9A67e064965](https://berascan.com/address/0x66eDB52dA8deF8d1A93808a369a3F9A67e064965)
- HONEY/USD[0x15FD574Fa0410E9D5ffC961e23030B6Ca5Ff7CBf](https://berascan.com/address/0x15FD574Fa0410E9D5ffC961e23030B6Ca5Ff7CBf#code)
- pumpBTC/USD[0xA1b630Ac027cEe384b1ADBF432c71BFad2b15274](https://berascan.com/address/0xA1b630Ac027cEe384b1ADBF432c71BFad2b15274#code)
