### PR TITLE
add eOracle for Sumer.money on berachain

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -25453,13 +25453,14 @@ const data3: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Lending",
-    chains: ["Meter"],
+    chains: ["Meter","Berachain"],
     oraclesByChain: {
       zklink: ["RedStone"], //https://docs.sumer.money/developers/price-feeds/redstone-price-feeds-on-zklink-nova
       meter: ["Pyth"], //https://docs.sumer.money/developers/price-feeds/pyth-price-feeds-on-meter
       ethereum: ["Chainlink"],
       arbitrum: ["Chainlink"], // https://docs.sumer.money/developers/price-feeds/chainlink-price-feeds-on-arbitrum
       base: ["Chainlink"], // https://docs.sumer.money/developers/price-feeds/chainlink-price-feeds-on-base
+      berachain: ["eOracle"],
     },
     forkedFrom: ["Compound V2"],
     module: "sumer/index.js",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -25460,7 +25460,7 @@ const data3: Protocol[] = [
       ethereum: ["Chainlink"],
       arbitrum: ["Chainlink"], // https://docs.sumer.money/developers/price-feeds/chainlink-price-feeds-on-arbitrum
       base: ["Chainlink"], // https://docs.sumer.money/developers/price-feeds/chainlink-price-feeds-on-base
-      berachain: ["eOracle"],
+      berachain: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9319
     },
     forkedFrom: ["Compound V2"],
     module: "sumer/index.js",


### PR DESCRIPTION
Sumer.money use eOracle for their NECT, HONEY and BERA markets on Berachain (https://app.sumer.money/?chain=80094).

Their comptroller address 0xc7fFEAa5949d50A408bD92DdB0D1EAcef3F8a3Bc

Their Pricefeed contract for NECT address https://berascan.com/address/0xc7ffeaa5949d50a408bd92ddb0d1eacef3f8a3bc#code

A cast call on the NECT price feed contract resturns the eOracle NECT price feed address 

`cast call 0xc7fFEAa5949d50A408bD92DdB0D1EAcef3F8a3Bc "chainlinkFeeds(address)" 0x1ce0a25d13ce4d52071ae7e02cf1f6606f4c79d3 --rpc-url https://rpc.berachain.com
`
You can fund eOracle berachain feeds here https://docs.eoracle.io/docs/eoracle-price-feeds/feed-addresses/berachain

Sumer money is a Compound V2 fork so misreporting on any of these oracle feeds can cause loss of all the TVL. 
