### PR TITLE
Update smilee-finance metadata

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -37818,29 +37818,21 @@ const data3: Protocol[] = [
     address: null,
     symbol: "-",
     url: "https://smilee.finance/",
-    description: `On-chain derivatives for volatility trading. Creators of Impermanent Gain—the first DeFi native convex payoff`,
-    chain: "Arbitrum",
+    description: `Start Generating Awesome Yield with the LST that plays Proof of Liquidity for you, only on Berachain.`,
+    chain: "Berachain",
     logo: `${baseIconsUrl}/smilee-finance.jpg`,
     audits: "2",
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Options",
-    chains: ["Arbitrum"],
-    oracles: ["Chainlink"], // https://docs.smilee.finance/protocol-design/oracles-and-risks
-    oraclesBreakdown: [
-      {
-        name: "Chainlink",
-        type: "Primary",
-        proof: ["https://docs.smilee.finance/protocol-design/oracles-and-risks"]
-
-      }
-    ],
+    category: "Liquid Staking",
+    chains: ["Berachain"],
+    oracles: [],
     forkedFrom: [],
     module: "smilee-finance/index.js",
     twitter: "SmileeFinance",
     audit_links: ["https://docs.smilee.finance/resources/audits"],
-    github: ["dverso"],
+    github: ["smilee-finance"],
     listedAt: 1711149739,
   },
   {


### PR DESCRIPTION
This pull request includes updates to the protocol data for `smilee-finance` in the `defi/src/protocols/data3.ts` file. The changes reflect a shift in the protocol's focus and associated details.

### Updates to protocol data:

* Updated the `description` to reflect the new focus on generating yield with LST on Berachain.
* Changed the `chain` from Arbitrum to Berachain.
* Revised the `category` from "Options" to "Liquid Staking".
* Updated the `chains` list to include only Berachain.
* Removed `oracles` and `oraclesBreakdown` details, indicating no current oracle usage.
* Updated the `github` username from "dverso" to "smilee-finance".