### PR TITLE
Update Oracles for Lodestar.ts

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -22306,7 +22306,7 @@ const data2: Protocol[] = [
     module: "lodestar/index.js",
     twitter: "LodestarFinance",
     forkedFrom: ["Compound V2"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink", "RedStone"], //https://docs.jonesdao.io/jones-dao/other/security#oracles
     listedAt: 1670424005,
     parentProtocol: "parent#lodestar-finance",
   },


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Lodestar

Oracle Provider(s): RedStone

Implementation Details: Lodestar is using RedStone as the primary oracle on all main pools.

Documentation/Proof:
https://docs.jonesdao.io/jones-dao/other/security#oracles