### PR TITLE
Add otherProtocolsMap to cache and refactor child protocol name retrieval

### DIFF
--- a/defi/src/api2/utils/craftParentProtocolV2.ts
+++ b/defi/src/api2/utils/craftParentProtocolV2.ts
@@ -35,12 +35,9 @@ export async function craftParentProtocolV2({
     tvl.length < 2 || tvl[1].date - tvl[0].date < 86400 ? true : false;
 
   const res = await craftParentProtocolInternal({ parentProtocol, childProtocolsTvls, skipAggregatedTvl, isHourlyTvl, fetchMcap: getCachedMCap, parentRaises:[] })
+  const childNames = cache.otherProtocolsMap[parentProtocol.id] ?? []
 
-  res.otherProtocols = [parentProtocol.name, ...childProtocolsTvls.sort((a: any, b: any) => {
-    if (a.deprecated && !b.deprecated) return 1
-    if (!a.deprecated && b.deprecated) return -1
-    return b.tvl - a.tvl
-  }).map((p: any) => p.name)]
+  res.otherProtocols = [parentProtocol.name, ...childNames]
 
   const debug_totalTime = performance.now() - debug_t0
   const debug_dbTime = debug_t1 - debug_t0

--- a/defi/src/api2/utils/craftProtocolV2.ts
+++ b/defi/src/api2/utils/craftProtocolV2.ts
@@ -166,11 +166,7 @@ export async function craftProtocolV2({
 
   if (parentProtocolId) {
     parentName = cache.metadata.parentProtocols.find((p) => p.id === parentProtocolId)?.name ?? null;
-    childProtocolsNames = cache.metadata.protocols.filter((p) => p.parentProtocol === parentProtocolId).sort((a, b) => {
-      if (a.deprecated && !b.deprecated) return 1
-      if (!a.deprecated && b.deprecated) return -1
-      return (cache.tvlProtocol[b.id]?.tvl ?? 0) - (cache.tvlProtocol[a.id]?.tvl ?? 0)
-    }).map((p) => p.name);
+    childProtocolsNames = cache.otherProtocolsMap[parentProtocolId] ?? []
   }
 
   if (childProtocolsNames.length > 0 && parentName) {

--- a/defi/src/getYieldsConfig.ts
+++ b/defi/src/getYieldsConfig.ts
@@ -26,6 +26,4 @@ const handler = async (
     return cache20MinResponse(getYieldsConfig());
 };
 
-handler({} as any).then(console.log)
-
 export default wrap(handler);


### PR DESCRIPTION
Introduce `otherProtocolsMap` to the cache for improved organization of child protocol names. Refactor the retrieval of child protocol names to utilize this new mapping.