### PR TITLE
Update Oracles for beraborrow.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -3789,7 +3789,7 @@ const data4: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Berachain"],
-    oracles: [],
+    oracles: ["RedStone"], //https://beraborrow.gitbook.io/docs/borrowing/understanding-collateral/eth-and-btc-based-derivatives
     oraclesBreakdown: [
       {
         name: "Restone",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Beraborrow on Berachain.

Oracle Provider(s): RedStone

Implementation Details: Beraborrow is using RedStone as the primary oracle on all main pools. (i.e. pumpBTC and SolvBTC)

Documentation/Proof:
https://beraborrow.gitbook.io/docs/borrowing/understanding-collateral/eth-and-btc-based-derivatives