### PR TITLE
Update data3.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31469,7 +31469,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Ethereum"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink","RedStone"],
     forkedFrom: [],
     module: "eigenpie/index.js",
     twitter: "Eigenpiexyz_io",


### PR DESCRIPTION
Hello, 
requesting to add RedStone as an oracle provider for EigenPie. RedStone secures our staking-oriented product, and helps us calculate yield of supported strategies. Incorrect oracle data from RedStone could expose strategies to significant risks through inaccurate valuations and yield calculations, potentially leading to losses, a drain of the vault or inefficient capital allocation. Since RedStone provides critical data for yield calculations, its reliability directly impacts the EigenPie’s system stability.