### PR TITLE
Update Oracle for BitFi.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -4647,7 +4647,7 @@ const data4: Protocol[] = [
     cmcId: null,
     category: "Basis Trading",
     chains: ["Binance"],
-    oracles: [],
+    oracles: ["RedStone"],//https://bitfi-2.gitbook.io/bitfi/developer/epoch-and-ratio/underlying-asset-price-variation, https://bitfi-2.gitbook.io/bitfi/developer/using-contract/unstake-bfbtc, https://bitfi-2.gitbook.io/bitfi/developer/using-contract/bfbtc-price-oracle
     forkedFrom: [],
     module: "bitfi-cedefi/index.js",
     twitter: "Bitfi_Org", 


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for BitFi (on all chains)

Oracle Provider(s): RedStone

Implementation Details: BitFi is using RedStone to calulate value of assets during minting and redemption process of bfBTC. Wrong price provided by RedStone can lead to excess mint/ redemption of bfBTC and exploit of value within the protocol.

Documentation/Proof:
https://bitfi-2.gitbook.io/bitfi/developer/epoch-and-ratio/underlying-asset-price-variation

https://bitfi-2.gitbook.io/bitfi/developer/using-contract/unstake-bfbtc