### PR TITLE
Update Oracle for BitFi BTC.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -50820,7 +50820,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Anchor BTC",
     chains: ["AILayer"],
-    oracles: [],
+    oracles: ["RedStone"], //https://bitfi-2.gitbook.io/bitfi/developer/epoch-and-ratio/underlying-asset-price-variation, https://bitfi-2.gitbook.io/bitfi/developer/using-contract/unstake-bfbtc, https://bitfi-2.gitbook.io/bitfi/developer/using-contract/bfbtc-price-oracle
     forkedFrom: [],
     module: "bitfi/index.js",
     twitter: "Bitfi_Org",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for BitFi (on all chains)

Oracle Provider(s): RedStone

Implementation Details: BitFi is using RedStone to calulate value of assets during minting and redemption process of bfBTC. Wrong price provided by RedStone can lead to excess mint/ redemption of bfBTC and exploit of value within the protocol.

Documentation/Proof:
https://bitfi-2.gitbook.io/bitfi/developer/epoch-and-ratio/underlying-asset-price-variation

https://bitfi-2.gitbook.io/bitfi/developer/using-contract/unstake-bfbtc