### PR TITLE
Update Oracles for JonesDAO.ts

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -1280,7 +1280,7 @@ const data2: Protocol[] = [
     cmcId: "17743",
     category: "Yield Aggregator",
     chains: ["Arbitrum"],
-    oracles: [],
+    oracles: ["RedStone"], //https://docs.jonesdao.io/jones-dao/other/security#oracles
     forkedFrom: [],
     module: "jones-dao/index.js",
     twitter: "DAOJonesOptions",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for JonesDAO

Oracle Provider(s): RedStone

Implementation Details: JonesDAO is using RedStone as the primary oracle on main pools.

Documentation/Proof:
https://docs.jonesdao.io/jones-dao/other/security#oracles