### PR TITLE
change icon url

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -11944,7 +11944,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     description:
       "The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.",
     chain: "Fantom",
-    logo: `${baseIconsUrl}/beets-sml.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
     audits: "3",
     audit_note: null,
     gecko_id: null,

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -11944,7 +11944,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     description:
       "The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.",
     chain: "Fantom",
-    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.png`,
     audits: "3",
     audit_note: null,
     gecko_id: null,

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -32680,7 +32680,7 @@ const data3: Protocol[] = [
     url: "https://beets.fi",
     description: "Liquid staked tokens on Fantom ($sFTMx) and Sonic ($stS)",
     chain: "Fantom",
-    logo: `${baseIconsUrl}/beets-sml.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
     audits: "2",
     audit_note: null,
     gecko_id: null,

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -32680,7 +32680,7 @@ const data3: Protocol[] = [
     url: "https://beets.fi",
     description: "Liquid staked tokens on Fantom ($sFTMx) and Sonic ($stS)",
     chain: "Fantom",
-    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.png`,
     audits: "2",
     audit_note: null,
     gecko_id: null,

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2357,7 +2357,7 @@ const data4: Protocol[] = [
     description:
       "The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.",
     chain: "Sonic",
-    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.png`,
     audits: "0",
     audit_note: null,
     gecko_id: null,

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2357,7 +2357,7 @@ const data4: Protocol[] = [
     description:
       "The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.",
     chain: "Sonic",
-    logo: `${baseIconsUrl}/beets-sml.jpg`,
+    logo: `${baseIconsUrl}/beets-sml-new.jpg`,
     audits: "0",
     audit_note: null,
     gecko_id: null,


### PR DESCRIPTION
Few people still see the old logo. Hoping a new name for the logo fixes caches.

Corresponding icon PR: https://github.com/DefiLlama/icons/pull/2170