### PR TITLE
Update Oracle for Silo V2 on Sonic.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -763,7 +763,7 @@ const data4: Protocol[] = [
     category: "Lending",
     chains: ["Arbitrum","Sonic"],
     oraclesByChain: {
-      sonic: ["Chainlink"], // https://silopedia.silo.finance/oracles
+      sonic: ["Chainlink", "RedStone"], // https://silopedia.silo.finance/oracles
     },
     forkedFrom: [],
     module: "silo-v2/index.js",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Silo on Sonic.

Oracle Provider(s): RedStone

Implementation Details: Sonic is using RedStone on it's biggest S/stS market, and a few other markets. (Can be checked [here](https://v2.silo.finance/).

<img width="1415" alt="Zrzut ekranu 2025-02-28 o 18 33 36" src="https://github.com/user-attachments/assets/42137a9f-fa09-4ca1-a072-ebcc60fa8e09" />


Overall RedStone feeds are securing ~$178m across markets which is around 46,5% of Silo sonic TVL. Since the impact of the hack would be significant here, kindly asking to add RedStone to Silo reflected oracle setup.