### PR TITLE
Update Oracles for Cygnus restake.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34532,7 +34532,7 @@ const data3: Protocol[] = [
     category: "RWA",
     chains: ["Base"],
     module: "cygnus-finance/index.js",
-    twitter: "",
+    twitter: "CygnusFi",
     forkedFrom: [],
     oraclesByChain: {
       base: ["Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/8247
@@ -56071,7 +56071,7 @@ const data3: Protocol[] = [
     category: "Liquid Staking",
     chains: ["TON"],
     module: "cygnus-fi-ton/index.js",
-    twitter: "",
+    twitter: "CygnusFi",
     forkedFrom: [],
     oracles: [],
     audit_links: [],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34532,7 +34532,7 @@ const data3: Protocol[] = [
     category: "RWA",
     chains: ["Base"],
     module: "cygnus-finance/index.js",
-    twitter: "CygnusFi",
+    twitter: "",
     forkedFrom: [],
     oraclesByChain: {
       base: ["Chainlink"], // https://github.com/DefiLlama/defillama-server/pull/8247
@@ -56071,7 +56071,7 @@ const data3: Protocol[] = [
     category: "Liquid Staking",
     chains: ["TON"],
     module: "cygnus-fi-ton/index.js",
-    twitter: "CygnusFi",
+    twitter: "",
     forkedFrom: [],
     oracles: [],
     audit_links: [],
@@ -56233,6 +56233,13 @@ const data3: Protocol[] = [
     twitter: "CygnusFi",
     forkedFrom: [],
     oracles: ["RedStone"], //https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work
+    oraclesBreakdown: [
+      {
+        name: "Restone",
+        type: "Primary",
+        proof: ["https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work"]
+      }
+    ],
     parentProtocol: "parent#cygnus-finance",
     listedAt: 1726581992
   },

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -56232,7 +56232,7 @@ const data3: Protocol[] = [
     module: "cygnus-fi-restake/index.js",
     twitter: "CygnusFi",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["RedStone"], //https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work
     parentProtocol: "parent#cygnus-finance",
     listedAt: 1726581992
   },


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Cygnus Restake

Oracle Provider(s): RedStone

Implementation Details: Cygnus Restake is using RedStone as the primary oracle for asset pricing. RedStone feeds are used as a cross-check for calculating user deposits value while minting cg-assets (cgUSD, clETH, Cygnus-stBTC…)

Wrong price provided by RedStone can lead to excess mint/ redemption of Cygnus assets and exploit of value within the protocol.

Documentation/Proof:
https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work