### PR TITLE
update Bit Reserve category to CDP

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -44089,7 +44089,7 @@ const data3: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Liquid Staking",
+    category: "CDP",
     chains: ["CORE"],
     oracles: [],
     forkedFrom: [],


### PR DESCRIPTION
update bit reserve category from Liquid Staking to CDP 

Users deposit liquid staking tokens (LSTs) into the protocol to mint RS tokens, representing collateralized debt positions (CDP). These RS tokens are non-liquid staking positions , allowing holders to earn continuous yield from underlying deposited assets