### PR TITLE
Update oracle for Avalon Finance.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -40667,9 +40667,10 @@ const data3: Protocol[] = [
     chains: ["Merlin", "Ethereum", "Bitlayer", "Binance", "Arbitrum", "CORE", "Scroll"],
     oraclesByChain: {
       ethereum: ["Chainlink"], //https://docs.avalonfinance.xyz/avalon-products/cedefi-cdp-usda/risk-management
-      sonic: ["Chainlink"], //https://docs.avalonfinance.xyz/avalon-products/cedefi-cdp-usda/risk-management
+      sonic: ["RedStone"], //https://docs.avalonfinance.xyz/avalon-products/defi-lending/oracles
       mantle: ["Chainlink"], //https://docs.avalonfinance.xyz/avalon-products/cedefi-cdp-usda/risk-management
-      binance:["Chainlink"], //https://docs.avalonfinance.xyz/avalon-products/cedefi-cdp-usda/risk-management
+      binance:["RedStone"], //https://docs.avalonfinance.xyz/avalon-products/defi-lending/oracles
+      taiko:["RedStone"], //https://docs.avalonfinance.xyz/avalon-products/defi-lending/oracles
     }, //https://github.com/avalonfinancexyz/ORACLE https://github.com/DefiLlama/defillama-server/pull/7838 removed apro on apro team request
     forkedFrom: ["AAVE V3"],
     module: "avalon-finance/index.js",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Avalon on BSC, Sonic, Taiko.

Oracle Provider(s): RedStone

Implementation Details: Avalon Finance (defi lending) switched to RedStone btc price feeds for main pools on BSC, Sonic, Taiko.

Documentation/Proof:
https://docs.avalonfinance.xyz/avalon-products/defi-lending/oracles