### PR TITLE
Update oracle for Venus.ts

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2314,6 +2314,7 @@ const data: Protocol[] = [
     oraclesByChain: {
       bsc: ["Chainlink"], // https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
       //   op_bnb: ["Binance Oracle"]
+      Unichain: ["RedStone"] //https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool
     },
     parentProtocol: "parent#venus-finance",
   },

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2314,7 +2314,7 @@ const data: Protocol[] = [
     oraclesByChain: {
       bsc: ["Chainlink"], // https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
       //   op_bnb: ["Binance Oracle"]
-      Unichain: ["RedStone"] //https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool
+      unichain: ["RedStone"] //https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool
     },
     parentProtocol: "parent#venus-finance",
   },


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Venus on Unchain.

Oracle Provider(s): RedStone

Implementation Details: Venus Protocol is using RedStone as primary Oracle provider on all Unichain pools (weth, USDC)

Documentation/Proof:
https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool