### PR TITLE
Update Maker RWA description

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -22095,7 +22095,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "RWA",
     chains: ["Ethereum"],
-    oracles: [],
+    oracles: ["Chronicle"],
     forkedFrom: [],
     module: "maker-rwa/index.js",
     twitter: "MakerDAO",


### PR DESCRIPTION
Chronicle is the sole oracle powering Maker. Currently though, only the MakerDAO portion is credited. Opening this PR to add the Maker RWA part as well. 