### PR TITLE
Update Morpho description

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30315,7 +30315,7 @@ const data3: Protocol[] = [
     category: "Lending",
     chains: ["Ethereum"],
     oraclesByChain: {
-      base: ["Chainlink"], // Chainlink is the oracle for Base - https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc
+      base: ["Chainlink", "Chronicle"], // Chainlink is the oracle for Base - https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc
     },
     forkedFrom: [],
     module: "morpho-blue/index.js",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30315,7 +30315,7 @@ const data3: Protocol[] = [
     category: "Lending",
     chains: ["Ethereum"],
     oraclesByChain: {
-      base: ["Chainlink", "Chronicle"], // Chainlink is the oracle for Base - https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc
+      base: ["Chainlink", "Chronicle"], // https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc, https://github.com/DefiLlama/defillama-server/pull/9498/files
     },
     forkedFrom: [],
     module: "morpho-blue/index.js",


### PR DESCRIPTION
Chronicle powers several Morpho vaults on Base listed below. Below you will find the adapters used to read from Chronicle oracles along with the corresponding oracle. We use Chainlink Morpho adapters since they are compatible.

- [0x06aE266A252E2ee96A4c05cFDa8163ED94379a5a](https://basescan.org/address/0x06aE266A252E2ee96A4c05cFDa8163ED94379a5a#code) - wstETH/USD
- [0x308b4C07e4FD4677F8d710660027d6D03845Cb83](https://basescan.org/address/0x308b4C07e4FD4677F8d710660027d6D03845Cb83#code) - cbETH/USD
- [0x4Eb7916682F59E25F824d8CE2a8F2318319296F6](https://basescan.org/address/0x4Eb7916682F59E25F824d8CE2a8F2318319296F6#code) - ETH/USD
- [0x6999f231968b8ea5288633388dab00db80299d7e](https://basescan.org/address/0x6999f231968b8ea5288633388dab00db80299d7e) - cbBTC/USD
- [0x7Bd7990A47b0DDF52d6eE2B89603a228910C2836](https://basescan.org/address/0x7Bd7990A47b0DDF52d6eE2B89603a228910C2836) - wstETH/USD
