### PR TITLE
Update of Orderly Perps Oracle

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -20644,7 +20644,7 @@ const data2: Protocol[] = [
     module: "orderly-network/index.js",
     twitter: "OrderlyNetwork",
     forkedFrom: [],
-    oracles: [],
+    oracles: ["Pyth"], // https://orderly.network/docs/changelog/evm#february-25th%2C-2025-major-update (Upgraded to Pyth Lazer for price feeds)
     audit_links: ["https://github.com/OrderlyNetwork/Audits"],
     parentProtocol: "parent#orderly-network",
     listedAt: 1668086145,


### PR DESCRIPTION
Hi Llamas!

Orderly recently upgraded and uses Pyth Lazer for their Perps

https://orderly.network/docs/changelog/evm#february-25th%2C-2025-major-update