### PR TITLE
fix usdt0 audits

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -7367,7 +7367,7 @@ const data4: Protocol[] = [
       "USDT0 is a one stop solution for Tether’s Interoperability and Expansion.",
     chain: "Ethereum",
     logo: `${baseIconsUrl}/usdt0.jpg`,
-    audits: "0",
+    audits: "3",
     audit_note: null,
     gecko_id: null,
     cmcId: null,


### PR DESCRIPTION
Changed `audits` from 0 to 3 for USDT0. The `audit_links` already contains links to those audits.