### PR TITLE
add eOracle for Layerbank on hemi

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12618,7 +12618,7 @@ const data3: Protocol[] = [
       mode: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles
       bsquared: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9219
       bob: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9219
-      hemi: ["eOracle"],
+      hemi: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9533
     },
     listedAt: 1689773129,
     audit_links: [

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12618,6 +12618,7 @@ const data3: Protocol[] = [
       mode: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles
       bsquared: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9219
       bob: ["eOracle"], // https://github.com/DefiLlama/defillama-server/pull/9219
+      hemi: ["eOracle"],
     },
     listedAt: 1689773129,
     audit_links: [


### PR DESCRIPTION
Layerbank uses eOracle to secure their markets on Hemi chain, 

Layerbank's github has all the contract addresses listed https://github.com/layerbank/contracts

Their `PriceCalculator` contract with address [0x9c5973Fbbe1C5C4E75f435f47a046663Cc613B6c](https://explorer.hemi.xyz/address/0x9c5973Fbbe1C5C4E75f435f47a046663Cc613B6c) is used to set the price feed for each support collateral asset. 

Following transactions were used to set the feeds for various assets 

- [brBTC](https://explorer.hemi.xyz/address/0x93919784C523f39CACaa98Ee0a9d96c3F32b593e)
- [enzoBTC](https://explorer.hemi.xyz/tx/0x846e64f92f9166819f2f9972383a602f907269feb4ed6f2e8f7d9c12b40e3cfa)
- [iBTC](https://explorer.hemi.xyz/tx/0xdc639d32941054ae3cef85e6afc77b841d0f2d71443fa57a8a9dbf77b81b7f05)
- [vUSD](https://explorer.hemi.xyz/tx/0x6287b4207eb12dc01fff008f5ab542b80c51044879619a50122d1101ffd628c2)
- [rsETH](https://explorer.hemi.xyz/tx/0xc0a36da26018c9a3f353580ce8f0f09361281d81b00a5999159e772c8e471d40)
- [uBTC](https://explorer.hemi.xyz/tx/0xba84281751d68020171a954d09b668814b6528ca822c37985b00421282d4f949)
- [tBTC](https://explorer.hemi.xyz/tx/0x105704284ff3586208945534274ba8d7f725499ff2a961ed83beef266ab8d860)
- [stBTC](https://explorer.hemi.xyz/tx/0x75aec33c095dd2a1d01e9c9efb21bc6d1fdacaec18c8cc386d44cefac26315fc)
- [pumpBTC](https://explorer.hemi.xyz/tx/0x89f47e313b638b6a974992bd94ce4134b709c62b7e9a10cfe01b53a558d0bf2a)
- [oBTC](https://explorer.hemi.xyz/tx/0x9f12acf22a093b0e101e23512ace4a9b22c61cf70bfcae3dacec06f31695b519)
- [mBTC](https://explorer.hemi.xyz/tx/0x038b93bb542fb8548e35231d6b0ddbaaf64cbab132350e592d1be94390cb69af)

As this is a Compound V2 fork, a misreport on any of these price feeds could lead to a loss of TVL to the protocol. 
