### PR TITLE
Add eOracle for Zerolend on Hemi

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12440,6 +12440,7 @@ const data3: Protocol[] = [
       era: ["Pyth"], //https://docs.zerolend.xyz/security/oracles#using-pyth-oracles
       zircuit: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
       xlayer: ["Api3"], // https://docs.zerolend.xyz/security/oracles#oracles-operated-by-api3
+      hemi: ["eOracle"]
     },
     forkedFrom: ["AAVE V3"],
     audit_links: ["https://github.com/zerolend/audits/blob/main/mundus/zerolend_report_depcheck_final.pdf"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12440,7 +12440,7 @@ const data3: Protocol[] = [
       era: ["Pyth"], //https://docs.zerolend.xyz/security/oracles#using-pyth-oracles
       zircuit: ["RedStone"], //https://docs.zerolend.xyz/security/oracles#using-redstone-oracles:~:text=zerolend/pyth%2Doracles-,Using%20Redstone%20Oracles,-RedStone%20is%20a
       xlayer: ["Api3"], // https://docs.zerolend.xyz/security/oracles#oracles-operated-by-api3
-      hemi: ["eOracle"]
+      hemi: ["eOracle"],
     },
     forkedFrom: ["AAVE V3"],
     audit_links: ["https://github.com/zerolend/audits/blob/main/mundus/zerolend_report_depcheck_final.pdf"],


### PR DESCRIPTION
Zerolend uses eOracle price feeds for all their asset markets on the Hemi market.
Zerolend is an Aave V3 fork, with all assets supported on the primary market can be found here https://app.zerolend.xyz/market/?marketName=proto_hemi_v3
Any misreport on any of feeds can cause loss of TVL.
You can find eOracle price feeds here https://docs.eo.app/docs/eprice/feed-addresses/hemi

**Verification:**

Zerolend lists their Hemi AaveOracle contract address to be https://berascan.com/address/0xA249579e05fC7E66B1dbC939AB9A81C1acB1933b, which can be found on the docs here https://docs.zerolend.xyz/security/deployed-addresses. 
This contract isn't verified on the Hemi block explorer  but has the standard AaveOracle interface. The price feed used for any asset can be queried using the following cast call, with Asset address to be the underlying asset address on Hemi chain.
`cast call 0x817A4FEd0A801C060c8627756b2f21077e80AA26 "getSourceOfAsset(address)(address)" 0xAssetAddress  -r https://rpc.hemi.network/rpc`
Some results obtained by making the same cast call for HemiBTC, WETH, or rsETH tokens


```
(base) Sid@eoracle % cast call 0x817A4FEd0A801C060c8627756b2f21077e80AA26 "getSourceOfAsset(address)(address)" 0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28 -r https://rpc.hemi.network/rpc

0x8bC0c2FFfB7dD10D0D99D77C6244a243a19c96Fa

(base) Sid@eoracle % cast call 0x817A4FEd0A801C060c8627756b2f21077e80AA26 "getSourceOfAsset(address)(address)" 0x4200000000000000000000000000000000000006 -r https://rpc.hemi.network/rpc

0xB2304167972E7aa838899f749E518F2069e78caC

(base) Sid@eoracle % cast call 0x817A4FEd0A801C060c8627756b2f21077e80AA26 "getSourceOfAsset(address)(address)" 0xc3eACf0612346366Db554C991D7858716db09f58 -r https://rpc.hemi.network/rpc

0xe3d3e1B1578321d6A333582AaD8205817eAE3c6F
```