### PR TITLE
Update oracles for Silo on Sonic.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -1212,16 +1212,16 @@ const data4: Protocol[] = [
     category: "Lending",
     chains: ["Arbitrum","Sonic"],
     oraclesByChain: {
-      sonic: ["Chainlink"], // https://silopedia.silo.finance/oracles
+      sonic: ["RedStone"], // https://app.silo.finance/
     },
     oraclesBreakdown: [
       {
-        name: "Chainlink",
+        name: "RedStone",
         type: "Primary",
         proof: ["https://silopedia.silo.finance/oracles"]
       },
       {
-        name: "RedStone",
+        name: "Chainlink",
         type: "Secondary",
         proof: ["https://github.com/DefiLlama/defillama-server/pull/9388"]
       }


### PR DESCRIPTION
Hey Llamas,

Kindly asking to update oracles for Silo on Sonic.

Oracle Provider(s): RedStone

Implementation Details: Sonic is using RedStone on isolated pools:

S - stS, $261m secured
wstkscUSD - USDC, $18.5m secured
SolvBTC.BBN - SolvBTC, $10m secured
PT-stS - S, $10m secured
PT-aUSDC - scUSD, $9m secured
S - scUSD, $5.5m secured
PTwstkscETH - ETH, $4m secured
PTwstkscUSD - USDC, $2.5m secured
wstkscETH - ETH, $1.5m secured

That sums up to $322m secured across pools by RedStone feeds which is ~60% of Silo's Sonic TVL. 

Just as a comparsion on pools where Chainlink is securing any of the included assets it adds up to $176.5m ~33%.

Data can be checked in their app here: https://app.silo.finance/