### PR TITLE
Add Stork as oracle for EVAA

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34387,7 +34387,19 @@ const data3: Protocol[] = [
     module: "evaa/index.js",
     twitter: "evaaprotocol",
     forkedFrom: [],
-    oracles: ["RedStone"], //https://evaa.gitbook.io/intro/details-of-protocol/risks/protocol-risks#oracle-risk
+    oracles: ["Stork", "Redstone"],
+    oraclesBreakdown: [
+      {
+      name: "Stork",
+      type: "Primary",
+      proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
+      }
+      {
+      name: "Redstone",
+      type: "Secondary",
+      proof: ["https://evaa.gitbook.io/intro/details-of-protocol/risks/protocol-risks#oracle-risk"],
+      }
+    ],
     audit_links: ["https://certificate.quantstamp.com/full/evaa/df7aa699-793b-49f7-b348-1f78e9ca9870/index.html"],
     github: ["evaafi"],
     listedAt: 1709220208,

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34387,15 +34387,20 @@ const data3: Protocol[] = [
     module: "evaa/index.js",
     twitter: "evaaprotocol",
     forkedFrom: [],
-    oracles: ["Stork", "Redstone"],
+    oracles: ["Stork", "Redstone", "Pyth"],
     oraclesBreakdown: [
       {
       name: "Stork",
       type: "Aggregator",
       proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
-      }
+      },
       {
       name: "Redstone",
+      type: "Aggregator",
+      proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
+      },
+            {
+      name: "Pyth",
       type: "Aggregator",
       proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
       }

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34391,13 +34391,13 @@ const data3: Protocol[] = [
     oraclesBreakdown: [
       {
       name: "Stork",
-      type: "Primary",
+      type: "Aggregator",
       proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
       }
       {
       name: "Redstone",
-      type: "Secondary",
-      proof: ["https://evaa.gitbook.io/intro/details-of-protocol/risks/protocol-risks#oracle-risk"],
+      type: "Aggregator",
+      proof: ["https://evaa.gitbook.io/intro/details-of-protocol/organization-of-work-with-price-oracles"],
       }
     ],
     audit_links: ["https://certificate.quantstamp.com/full/evaa/df7aa699-793b-49f7-b348-1f78e9ca9870/index.html"],


### PR DESCRIPTION
Hey! Another request for you to add Stork as an oracle. It was tough to tell primary from secondary, but because Stork supports the highest number of feeds, we decided we'd submit it as primary.

Thanks!