### PR TITLE
Oracles: Add Echelon to Switchboard supported protocols

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -38320,19 +38320,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Aptos"],
-    oracles: ["Pyth"],
-    oraclesBreakdown: [
-      {
-        name: "Pyth",
-        type: "Primary",
-        proof: ["https://app.echelon.market/markets?network=aptos_mainnet","https://docs.echelon.market/echelon-v1/risks#oracle-risk"]
-      },
-      {
-        name: "Switchboard",
-        type: "Secondary",
-        proof: ["https://app.echelon.market/markets?network=aptos_mainnet"],
-      },
-    ],
+    oracles: ["Pyth", "Switchboard"], // https://docs.echelon.market/echelon-v1/risks#oracle-risk
     forkedFrom: [],
     module: "echelon/index.js",
     twitter: "EchelonMarket",


### PR DESCRIPTION
## Add Echelon to Switchboard Supported Protocols

Echelon ensures price feed security by checking for derivation between Switchboard and Pyth prices for multisource security. 

Echelon documentation on the multisource pricing tactics can be found in their documentation below.

https://docs.echelon.market/echelon/core/oracles

Requirements:

To be listed as a supported oracle protcol on defillama one of the two requirements below must be met:
- If a single oracle can be hacked to drain TVL
- If the protocol uses and aggregator to make sure all prices agree. If that aggregate were to drain 50% or more TVL it will count

We have received confirmation from @0xwml who is a project core contributor that Switchboard is properly meeting the second category