### PR TITLE
Add option to limit protocol response size

### DIFF
--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -244,6 +244,7 @@ async function getProtocolishData(req: HyperExpress.Request, res: HyperExpress.R
     useNewChainNames,
     useHourlyData,
     skipAggregatedTvl,
+    restrictResponseSize: true,
   });
   return res.json(responseData);
 }

--- a/defi/src/api2/utils/craftParentProtocolV2.ts
+++ b/defi/src/api2/utils/craftParentProtocolV2.ts
@@ -26,7 +26,7 @@ export async function craftParentProtocolV2({
     });
   }
 
-  const getProtocolData = (protocolData: any) => cachedCraftProtocolV2({ protocolData, useNewChainNames: true, useHourlyData, skipAggregatedTvl: false, })
+  const getProtocolData = (protocolData: any) => cachedCraftProtocolV2({ protocolData, useNewChainNames: true, useHourlyData, skipAggregatedTvl: false, restrictResponseSize: false })
 
   const childProtocolsTvls: Array<IProtocolResponse> = await Promise.all(childProtocols.map(getProtocolData));
 
@@ -34,7 +34,7 @@ export async function craftParentProtocolV2({
   const isHourlyTvl = (tvl: Array<{ date: number }>) =>
     tvl.length < 2 || tvl[1].date - tvl[0].date < 86400 ? true : false;
 
-  const res = await craftParentProtocolInternal({ parentProtocol, childProtocolsTvls, skipAggregatedTvl, isHourlyTvl, fetchMcap: getCachedMCap, parentRaises:[] })
+  const res = await craftParentProtocolInternal({ parentProtocol, childProtocolsTvls, skipAggregatedTvl, isHourlyTvl, fetchMcap: getCachedMCap, parentRaises: [] })
   const childNames = cache.otherProtocolsMap[parentProtocol.id] ?? []
 
   res.otherProtocols = [parentProtocol.name, ...childNames]

--- a/defi/src/api2/utils/index.ts
+++ b/defi/src/api2/utils/index.ts
@@ -62,3 +62,14 @@ export function roundVaules(obj: any) {
   }
   return obj
 }
+
+export function getObjectKeyCount(obj: any) {
+  if (!obj || typeof obj !== 'object') {
+    return 1
+  }
+  let count = 1
+  for (const key in obj) {
+    count += getObjectKeyCount(obj[key])
+  }
+  return count
+}

--- a/defi/src/utils/craftParentProtocol.ts
+++ b/defi/src/utils/craftParentProtocol.ts
@@ -7,7 +7,7 @@ import fetch from "node-fetch";
 import { getAvailableMetricsById } from "../adaptors/data/configs";
 import treasuries from "../protocols/treasury";
 import { protocolMcap, getRaises } from "./craftProtocol";
-import { getClosestDayStartTimestamp } from "./date";
+import { getObjectKeyCount } from "../api2/utils";
 
 export interface ICombinedTvls {
   chainTvls: {
@@ -169,21 +169,7 @@ export async function craftParentProtocolInternal({
   };
 
   // Filter overall tokens, tokens in usd by date if data is more than 6MB
-  // const jsonData = JSON.stringify(response); // this is too expensive, replacing it with counting keys and if it over 500k
-  // const dataLength = jsonData.length;
-
-  // if (dataLength >= 5.8e6) {
-  //   for (const chain in response.chainTvls) {
-  //     response.chainTvls[chain].tokens = null;
-  //     response.chainTvls[chain].tokensInUsd = null;
-  //   }
-  // }
-  let keyCount = 0;
-  for (const chain in response.chainTvls) {
-    (response.chainTvls[chain]?.tokens || []).forEach(({ tokens }: any) => {
-      keyCount += Object.keys(tokens).length;
-    });
-  }
+  let keyCount = getObjectKeyCount(response);
   if (keyCount >= 1.5e5) { // there are more than 150k keys
     for (const chain in response.chainTvls) {
       response.chainTvls[chain].tokens = null;


### PR DESCRIPTION
Introduce a feature to restrict the size of protocol responses by counting the number of keys in the response object. If the key count exceeds a specified threshold, certain data fields will be nullified to reduce the response size.