### PR TITLE
feat: support Noble Dollar

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -6160,6 +6160,11 @@
       "to": "coingecko#ondo-us-dollar-yield",
       "decimals": 18,
       "symbol": "ausdy"
+    },
+    "uusdn": {
+      "to": "coingecko#m-2",
+      "decimals": 6,
+      "symbol": "uusdn"
     }
   },
   "neox": {


### PR DESCRIPTION
This PR adds support for the Noble Dollar (USDN). As the collateral of the token is solely M by M^0, we choose to use their Coingecko ID until we're directly supported there. This will be paired with an adapter PR to update the TVL computation of the Noble blockchain.