### PR TITLE
Update cygnus oraclesByChain

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -56350,14 +56350,10 @@ const data3: Protocol[] = [
     module: "cygnus-fi-restake/index.js",
     twitter: "CygnusFi",
     forkedFrom: [],
-    oracles: ["RedStone"], //https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work
-    oraclesBreakdown: [
-      {
-        name: "Restone",
-        type: "Primary",
-        proof: ["https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work"]
-      }
-    ],
+    oraclesByChain: {
+      ton: ["RedStone"], // https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle
+      bsquared: ["RedStone"], // https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle
+    },
     parentProtocol: "parent#cygnus-finance",
     listedAt: 1726581992
   },


### PR DESCRIPTION
Hi

Saw from the proof on why RS was used as Primary Oracle that

> RedStone feeds are used as a cross-check for calculating user deposits value while minting cg-assets (cgUSD, clETH, Cygnus-stBTC…)

Link:
https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work

An entry from the also says this

> On TON and BSquared Cygnus Finance has integrated [RedStone](https://redstone.finance/) Price Feeds in order to ensure the stability of cgUSD's peg to the US Dollar.

Link:
https://wiki.cygnus.finance/whitepaper/cygnus-omnichain-liquidity-validation-system-lvs/cygnus-lvs-integration/cgusd-v1/token-and-contract/cgusd/on-chain-price-oracle

So i made a PR to change to `oraclesByChain` instead of `oracles` and `oraclesBreakdown`, since RS does not secure the pull TVL of Cygnus