### PR TITLE
Update cygnus oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -56359,7 +56359,7 @@ const data3: Protocol[] = [
     oraclesBreakdown: [
       {
         name: "Restone",
-        type: "Primary",
+        type: "Secondary",
         proof: ["https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work"]
       }
     ],


### PR DESCRIPTION
Hello

redoing the PR as i was not able to reply to the other one, also changed the PR

As per docs: 
https://wiki.cygnus.finance/whitepaper/cygnus-network/how-does-cygnus-work

> RedStone feeds are used as a cross-check for calculating user deposits value while minting cg-assets (cgUSD, clETH, Cygnus-stBTC…)

Looking at their current TVL of almost $800M
- $398M is on clBTC
- $268M is on cgETH

both of this assets are not supported by Redstone
so i changed the Type from "Primary" to "Secondary" because they secures less than 50% of TVL 