### PR TITLE
bugfix: update the eclipse symbol

### DIFF
--- a/coins/src/adapters/yield/sandglass/index.ts
+++ b/coins/src/adapters/yield/sandglass/index.ts
@@ -135,7 +135,7 @@ const marketInfos: MarketInfo[] = [
   {
     address: "DAsYPZgVAgFikzHU2R55RGPtmjJ4ia5zLSzCAyXHzznE",
     mintAddress: "A8uPGauLyDTw9dMjBpb9Vrgq7frbWX46XqX71paW4pri",
-    symbol: "CRT",
+    symbol: "tETH",
     unit: "ETH",
     decimals: 9,
     oracleDecimals: 0,


### PR DESCRIPTION
Sorry, but I updated the symbol for `tETH` mint in eclipse. 😊