### PR TITLE
fix: berapaw wrong category

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -11265,7 +11265,7 @@ const data4: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Yield Aggregator",
+    category: "Liquid Staking",
     chains: ["Berachain"],
     forkedFrom: [],
     oracles: [],


### PR DESCRIPTION
category was assigned wrong on initial merge.
we is liquid staking, no yield aggregator