### PR TITLE
Add Stork as oracle for Helix

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -54695,12 +54695,12 @@ const data3: Protocol[] = [
     module: "injective-orderbook/index.js",
     twitter: "HelixApp_",
     forkedFrom: [],
-    oracles: ["Stork","Pyth"],
+    oracles: ["Pyth"],
     oraclesBreakdown: [
       {
         name: "Stork",
-        type: "Primary",
-        proof: ["https://docs.helixapp.com/trading/perpetuals"]
+        type: "Secondary",
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/9709"]
       },
       {
         name: "Pyth",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -54695,23 +54695,18 @@ const data3: Protocol[] = [
     module: "injective-orderbook/index.js",
     twitter: "HelixApp_",
     forkedFrom: [],
-    oracles: ["Band"], // band oracle was confirmed by helix team
+    oracles: ["Stork","Pyth"],
     oraclesBreakdown: [
       {
-        name: "Band",
+        name: "Stork",
         type: "Primary",
-        proof: ["https://api.injective.exchange/#injectiveoraclerpc-oraclelist"]
+        proof: ["https://docs.helixapp.com/trading/perpetuals"]
       },
       {
         name: "Pyth",
         type: "Secondary",
-        proof: ["https://api.injective.exchange/#injectiveoraclerpc-oraclelist"]
+        proof: ["https://docs.helixapp.com/trading/perpetuals"]
       },
-      {
-        name: "Stork",
-        type: "Fallback",
-        proof: ["https://helixapp.zendesk.com/hc/en-us/articles/8790962218383-Which-oracle-provider-does-Helix-use"]
-      }
     ],
     parentProtocol: "parent#helix",
     listedAt: 1724923885

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -54704,7 +54704,7 @@ const data3: Protocol[] = [
       },
       {
         name: "Pyth",
-        type: "Secondary",
+        type: "Primary",
         proof: ["https://docs.helixapp.com/trading/perpetuals"]
       },
     ],


### PR DESCRIPTION
Hi again,

Submitting a PR for Stork as the primary oracle for Helix. Looks like for mark prices it's split between Stork and Pyth, but for unique use-cases and index perpetuals, Helix uses solely Stork.

Thanks!