### PR TITLE
Update Oracles for Felix.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -10623,7 +10623,7 @@ const data4: Protocol[] = [
     module: "felix/index.js",
     twitter: "felixprotocol",
     forkedFrom: ["Liquity V2"],
-    oracles: [],
+    oracles: ["RedStone"], //https://usefelix.gitbook.io/felix-docs/advanced/risk-management#redstone-oracles
     audit_links: ["https://usefelix.gitbook.io/felix-docs/advanced/smart-contract-audits#felix-audits"],
     listedAt: 1744135586
   },


### PR DESCRIPTION
Hey Lamas, 

Kindly asking you to update Oracles for Felix on Hyperliquid. 

Oracle Provider(s): RedStone. 

Implementation details. Felix is using RedStone as the primary Oracle on all main pools. 

Documenation/Proof: https://usefelix.gitbook.io/felix-docs/advanced/risk-management#redstone-oracles