### PR TITLE
Update Oracles for Enzyme Finance.ts

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2589,7 +2589,7 @@ const data: Protocol[] = [
     module: "enzyme/index.js",
     twitter: "enzymefinance",
     audit_links: ["https://audit.enzyme.finance/"],
-    oracles: ["Chainlink"],
+    oracles: ["Chainlink" "RedStone"] //https://docs.enzyme.finance/general-info/risks-and-nuances#oracle-risk,
     governanceID: ["snapshot:enzymefinance.eth"],
     github: ["enzymefinance"],
   },


### PR DESCRIPTION
Hey Lamas, 

Kindly asking you to update Oracles for Enzyme Finance on Ethereum Mainnet. 

Oracle Provider(s): RedStone. 

Implementation details: Enzyme is using RedStone as one of the primary Oracle on all main pools. 

Documenation/Proof: https://docs.enzyme.finance/general-info/risks-and-nuances#oracle-risk