### PR TITLE
add Plume Mainnet to Dinari deployment

### DIFF
--- a/coins/src/adapters/rwa/dinari.ts
+++ b/coins/src/adapters/rwa/dinari.ts
@@ -34,6 +34,12 @@ const config: any = {
     quoteToken: "0x98C6616F1CC0D3E938A16200830DD55663dd7DD3",
     usdplus: "0x98C6616F1CC0D3E938A16200830DD55663dd7DD3",
   },
+  plume_mainnet: {
+    factory: "0x7a861Ae8C708DC6171006C57c9163BD2BB57a8Aa",
+    processor: "0x68Dd74e23461d99b7312Bfb5baddfd3Fa28404c7",
+    quoteToken: "0x1fA3671dF7300DF728858B88c7216708f22dA3Fb",
+    usdplus: "0x1fA3671dF7300DF728858B88c7216708f22dA3Fb",
+  }
 };
 
 async function getTokenPrices(chain: string, timestamp: number, writes: Write[] = []): Promise<Write[]> {

--- a/defi/src/utils/symbols/symbols.json
+++ b/defi/src/utils/symbols/symbols.json
@@ -4351,6 +4351,7 @@
   "dinari-pld": "PLD.D",
   "dinari-pypl-dshares": "PYPL.D",
   "dinari-spy-dshares": "SPY.D",
+  "dinari-srln-dshares": "SRLN.D",
   "dinari-tsla-dshares": "TSLA.D",
   "dinari-usfr-dshares": "USFR.D",
   "dinartether": "DINT",


### PR DESCRIPTION
This also adds support for SRLN.D, which will go into Plume's flagship staking protocol Nest on mainnet launch.