### PR TITLE
Update Oracles for Venus Core Pool.ts

### DIFF
--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2317,7 +2317,7 @@ const data: Protocol[] = [
     audit_links: ["https://www.certik.org/projects/swipe"],
     forkedFrom: ["Compound V2"],
     oraclesByChain: {
-      bsc: ["Chainlink"], // https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
+      bsc: ["RedStone", "Chainlink"], // https://docs-v4.venus.io/risk/resilient-price-oracle#bnb-chain https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
       //   op_bnb: ["Binance Oracle"]
       unichain: ["RedStone"] //https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool
     },

--- a/defi/src/protocols/data.ts
+++ b/defi/src/protocols/data.ts
@@ -2317,7 +2317,7 @@ const data: Protocol[] = [
     audit_links: ["https://www.certik.org/projects/swipe"],
     forkedFrom: ["Compound V2"],
     oraclesByChain: {
-      bsc: ["RedStone", "Chainlink"], // https://docs-v4.venus.io/risk/resilient-price-oracle#bnb-chain https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
+      bsc: ["RedStone"], // https://docs-v4.venus.io/risk/resilient-price-oracle#bnb-chain https://docs-v4.venus.io/risk/resilient-price-oracle Venus team confirmed:  Our Core Pool Resilient Oracle system uses Chainlink as principal source and 4 additional Oracles. The main one is Chainlink but, we also use Pyth, RedStone, Binance Oracle and TWAP
       //   op_bnb: ["Binance Oracle"]
       unichain: ["RedStone"] //https://docs-v4.venus.io/risk/resilient-price-oracle#unichain-mainnet:~:text=%2D-,Unichain%20Mainnet,-Pool
     },


### PR DESCRIPTION
Hello Llamas,

We request to add RedStone as the main oracle for Venus on the BNB Chain. RedStone is currently the main Oracle for the two largest markets in Venus Core pool: BTC (~$846m) and BNB (~$652m) which adds up to ~$1.5b secured out of $2.5b. (60% of the TVL)

Documenation/Proof: https://docs-v4.venus.io/risk/resilient-price-oracle#bnb-chain