### PR TITLE
Update Oracles for Morpho on Hyperliquid L1.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30527,6 +30527,8 @@ const data3: Protocol[] = [
     chains: ["Ethereum"],
     oraclesByChain: {
       base: ["Chainlink", "Chronicle"], // https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc, https://github.com/DefiLlama/defillama-server/pull/9498/files
+      Hyperliquid L1: ["RedStone"], // https://app.morpho.org/base/market/0x8793cf302b8ffd655ab97bd1c695dbd967807e8367a65cb2f4edaf1380ba1bda/weth-usdc, https://github.com/DefiLlama/defillama-server/pull/9498/files
+      
     },
     forkedFrom: [],
     module: "morpho-blue/index.js",


### PR DESCRIPTION
Hey Llamas,

Kindly asking to add RedStone as the main oracle for Morpho Blue on Hyperliquid. Morpho is currently operating with front end by Felix protocol & HyperBeat both of which rely exclusively on RedStone price feeds.



Documenation/Proof:
https://x.com/MorphoLabs/status/1915405407251812787

<img width="576" alt="Zrzut ekranu 2025-05-14 o 13 25 54" src="https://github.com/user-attachments/assets/4636a358-40e6-4052-b88a-da9719c926f7" />

