### PR TITLE
update the orcale of Eigenpie from chainlink to RedStone

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31691,7 +31691,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Ethereum"],
-    oracles: ["RedStone"],
+    oracles: ["RedStone"], // https://github.com/DefiLlama/defillama-server/pull/9841
     forkedFrom: [],
     module: "eigenpie/index.js",
     twitter: "Eigenpiexyz_io",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -31691,7 +31691,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Ethereum"],
-    oracles: ["Chainlink"],
+    oracles: ["RedStone"],
     forkedFrom: [],
     module: "eigenpie/index.js",
     twitter: "Eigenpiexyz_io",


### PR DESCRIPTION
Hello, 
requesting to add RedStone as an oracle provider for Eigenpie. Their feeds are used both for yield calculation and for calculating the amount of receipt tokens when depositing into the vault.  RedStone could expose deposit vaults to significant risks through inaccurate valuations and yield calculations, potentially leading to losses, a drain of the vault or inefficient capital allocation.

Materials: https://docs.eigenpiexyz.io/native-restaking#redstone-oracles


