### PR TITLE
Oracles: Add Fragmetric to Switchboard supported protocols

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -19884,7 +19884,7 @@ const data3: Protocol[] = [
   },
   {
     id: "3564",
-    name: "Arena SocialFi", 
+    name: "Arena SocialFi",
     previousNames: ["Stars Arena", /*"The Arena"*/],
     address: null,
     symbol: "-",
@@ -59597,7 +59597,7 @@ const data3: Protocol[] = [
     cmcId: null,
     category: "Liquid Restaking",
     chains: ["Solana"],
-    oracles: [],
+    oracles: ["Switchboard"],
     oraclesBreakdown: [
       {
         name: "Switchboard",


### PR DESCRIPTION
## Add Fragmetric to Switchboard Supported Protocols

Fragmetric is a Solana based restaking app that allows multicollateral deposits and withdraws for different types of lsts to their vaults.

These vaults use Switchboard to price these deposited tokens which controls how much fragSOL (or frag<BASE> for non-LST vaults) will get distributed to a user representing their % ownership of the vaults funds

In this way, Switchboard secures fragmetric TVL