### PR TITLE
add eOracle to Sturdy

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -33050,6 +33050,7 @@ const data3: Protocol[] = [
     chains: ["Ethereum"],
     oraclesByChain: {
       mode: ["Api3", "RedStone"], //https://docs.sturdy.finance/overview/security-and-audits
+      ethereum: ["eoracle"],
     },
     forkedFrom: ["AAVE V2"],
     module: "sturdy-v2/index.js",


### PR DESCRIPTION
Sturdy finance uses eOracle in the eBTC/tBTC silo on Ethereum. 

https://v2.sturdy.finance/silos/ethereum/0xf94B349d52c542aBd8Fb612c2854974e1D72223B