### PR TITLE
update Oracle for Layerbank on Manta

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12702,7 +12702,7 @@ const data3: Protocol[] = [
     forkedFromIds: ["114"],
     oraclesByChain: {
       zklink: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles
-      manta: ["RedStone"], // https://pacific-explorer.manta.network/address/0xF2C1E27A4Bf0D81Bb4A6E6e3E5DCD1DC6ED3A7fA?tab=read_contract#7dc0d1d0
+      manta: ["eOracle"], // https://pacific-explorer.manta.network/address/0xF2C1E27A4Bf0D81Bb4A6E6e3E5DCD1DC6ED3A7fA?tab=read_contract#7dc0d1d0
       scroll: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles
       linea: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles
       mode: ["eOracle"], // https://docs.layerbank.finance/protocol/lending/oracles


### PR DESCRIPTION
Layerbank now uses eOracle price feeds for its Manta Deployment (https://app.layerbank.finance/bank?chain=manta-pacific&network=manta-pacific). 

Layerbanks PriceCalculator contract on Manta - https://pacific-explorer.manta.network/address/0x38f4384B457F81A4895c93a7503c255eFd0746d2

The feed settings was executed in May, linking some of the above txs below - 

ETH - https://pacific-explorer.manta.network/tx/0x95677374bb7e0ca0f141e0cca3de5129aecf54e72ab3e6b83e805181fbaaf417

USDC - https://pacific-explorer.manta.network/tx/0xf0a37ecf829f771d27f8eab5f7e33b60dcb1f425531dc4c2e7b1e04f6231de1d

STONE - https://pacific-explorer.manta.network/tx/0xdccd1da9c19cfe24b656cb171de0cfc251b141d334c9960fdebd7fbf546679f9

wstETH - https://pacific-explorer.manta.network/tx/0xf8563861b5552d693fbc6f76ee80048e515dea50822b77f75da832b9283b0450

MANTA - https://pacific-explorer.manta.network/tx/0xf1e1c50acbbb83d80a42d686013681b7580435ca2032bc60e9f4a51dacf975aa

As these markets have majority of Layerbank's TVL on Manta, a misreport in any of these can cause a loss of TVL.

 

