### PR TITLE
Update Rho Protocol

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15229,7 +15229,7 @@ const data4: Protocol[] = [
     description: `Rho Protocol is a cryptonative interest rates market. The platform uniquely offers trading of staking, lending, and perpetual future funding rates all in one venue, as well as allowing users to passively earn yield by depositing into Rho's vaults`,
     chain: "Arbitrum",
     logo: `${baseIconsUrl}/rho-protocol.jpg`,
-    audits: "0",
+    audits: "1",
     audit_note: null,
     gecko_id: null,
     cmcId: null,
@@ -15262,7 +15262,6 @@ const data4: Protocol[] = [
     forkedFrom: [],
     module: "rho-vaults/index.js",
     twitter: "Rho_xyz",
-    audit_links: ["https://audits.oxor.io/reports/-NsF0vIwYyzQJhrgL2nf"],
     parentProtocol: "parent#rho",
     listedAt: 1747966849
   },


### PR DESCRIPTION
Audits aren't displaying at https://defillama.com/protocol/rho-protocol

Also, I have a few questions

1. On the [parent page](https://defillama.com/protocol/rho), the TVL from Vaults is shown. Is it possible to display the sum of protocol + vaults? If not, it would be better to show Protocol data (our main product).
2. 
<img width="876" alt="image" src="https://github.com/user-attachments/assets/7d3be21d-a903-4aaf-8ce2-9a702573adbb" />
Protocol counts in USDT0 but Vault in USDT. It refers at same coin (tether) but looks strange at parent page
3. For any page, is TVL the only main metric? Is it possible to use another metric?
4. Is it possible to load historical data? Currently, data is only available from 22 May 2025. Ideally, we’d like to have it from 29 May 2024.


Thanks, 
Valentin