### PR TITLE
Set Edge as primary oracle for Adrena Protocol 

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61169,7 +61169,7 @@ const data3_2: Protocol[] = [
     module: "adrena/index.js",
     twitter: "AdrenaProtocol",
     forkedFrom: [],
-    oracles: ["Edge", "Pyth"], // https://docs.adrena.xyz/technical-documentation/oracles-and-price-feeds
+    oracles: ["Edge"],
     oraclesBreakdown: [
       {
         name: "Edge",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -61169,7 +61169,19 @@ const data3_2: Protocol[] = [
     module: "adrena/index.js",
     twitter: "AdrenaProtocol",
     forkedFrom: [],
-    oracles: ["Pyth"], // https://docs.adrena.xyz/technical-documentation/oracles-and-price-feeds
+    oracles: ["Edge", "Pyth"], // https://docs.adrena.xyz/technical-documentation/oracles-and-price-feeds
+    oraclesBreakdown: [
+      {
+        name: "Edge",
+        type: "Primary",
+        proof: ["https://x.com/AdrenaProtocol/status/1925828470573076631"],
+      },
+      {
+        name: "Pyth",
+        type: "Fallback",
+        proof: ["https://docs.adrena.xyz/technical-documentation/oracles-and-price-feeds"],
+      },
+    ],
     audit_links: ["https://docs.adrena.xyz/technical-documentation/audits"],
     github: ["AdrenaFoundation"],
     listedAt: 1731508730


### PR DESCRIPTION
Set Edge Oracle as primary on Adrena Protocol on Solana, adjusted Pyth to fallback oracle. 

Reference: https://x.com/AdrenaProtocol/status/1925828470573076631