### PR TITLE
add: redstone oracle

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -12649,7 +12649,6 @@ const data4: Protocol[] = [
   {
     id: "6107",
     name: "Hyperbeat",
-    oracles : ["RedStone"],
     address: null,
     symbol: "-",
     url: "https://hyperbeat.org/",
@@ -12667,6 +12666,13 @@ const data4: Protocol[] = [
     module: "hyperbeat/index.js",
     twitter: "0xhyperbeat",
     audit_links: [],
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/9931"],
+      },
+    ],
     listedAt: 1745849227,
   },
   {

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -12649,6 +12649,7 @@ const data4: Protocol[] = [
   {
     id: "6107",
     name: "Hyperbeat",
+    oracles : ["RedStone"],
     address: null,
     symbol: "-",
     url: "https://hyperbeat.org/",


### PR DESCRIPTION
Hello DefiLlama Team! 
Requesting to add RedStone as an oracle provider for HyperBeat. HyperBeat uses RedStone Oracles as a security check before accepting deposits into Hyperliquid vaults to ensure proper receipt tokens for all assets (i.e. hbHYPE, hypeETH, hypeBTC) allocation calculations. This additional validation layer ensures that deposit vaults are safe, compliant with risk parameters, and operating under accurate market conditions.

Incorrect oracle data from RedStone could expose deposit vaults to significant risks through inaccurate valuations and yield calculations, potentially leading to losses, a drain of the vault or inefficient capital allocation. Since RedStone provides critical data for vault calculations its reliability directly impacts the vault system's stability.