### PR TITLE
nibiru: add MIM (magic-internet-money) to tokenMapping.json

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -373,6 +373,11 @@
       "symbol": "USDC",
       "to": "coingecko#usd-coin"
     },
+    "0xfCfc58685101e2914cBCf7551B432500db84eAa8": {
+      "decimals": "18",
+      "symbol": "MIM",
+      "to": "coingecko#magic-internet-money"
+    },
     "0x08EBA8ff53c6ee5d37A90eD4b5239f2F85e7B291": {
       "decimals": "18",
       "symbol": "USDC.arb",


### PR DESCRIPTION
## Purpose 

MIMswap was added as a TVL adapter successfully on Nibiru. 

Currently, it shows roughly half of the pool's TVL, likely because it includes the USDC TVL and not the MIM TVL. This change should fix that. 

## MIM on Block Explorer

https://nibiscan.io/token/0xfCfc58685101e2914cBCf7551B432500db84eAa8/contract/code?type=erc20

## TVL Discrepancy 

On Mimswap

![image](https://github.com/user-attachments/assets/1554e3d1-a3e7-4422-889f-0a80ce8ff979)

On DeFiLlama

![image](https://github.com/user-attachments/assets/04e62564-09b8-46d4-b6de-229d27c7f18e)