### PR TITLE
feat: add denario silver and gold

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -473,6 +473,16 @@
       "decimals": "18",
       "symbol": "BEPRO",
       "to": "coingecko#bepro-network"
+    },
+    "0x5d4e735784293a0a8d37761ad93c13a0dd35c7e7": {
+      "decimals": "8",
+      "symbol": "DSC",
+      "to": "asset#ethereum:0x5d4e735784293a0a8d37761ad93c13a0dd35c7e7"
+    },
+    "0xf7e2d612f1a0ce09ce9fc6fc0b59c7fd5b75042f": {
+      "decimals": "8",
+      "symbol": "DGC",
+      "to": "asset#ethereum:0xf7e2d612f1a0ce09ce9fc6fc0b59c7fd5b75042f"
     }
   },
   "evmos": {


### PR DESCRIPTION
hey team,

- adding denario silver and gold coins on polygon
- 100% metal backed and regulated in switzerland
- more info https://denario.swiss

thanks for support!