### PR TITLE
fix: Correctly sum oracle TVS across multiple chains

### DIFF
--- a/defi/src/getOracles.ts
+++ b/defi/src/getOracles.ts
@@ -93,7 +93,7 @@ function sum(
   if (!oracleProtocols[oracle]) {
     oracleProtocols[oracle] = {};
   }
-  oracleProtocols[oracle][protocol.name] = totalTvl;
+  oracleProtocols[oracle][protocol.name] = (oracleProtocols[oracle][protocol.name] ?? 0) + totalTvl;
 }
 
 function isActive(timestamp: number, startDateStr?: string, endDateStr?: string): 'active' | 'inactive' | 'not-started' {


### PR DESCRIPTION
Currently, when calculating the TVS for an oracle, if a single protocol uses that oracle on multiple chains, the TVS from each chain overwrites the previous one instead of being added together.