### PR TITLE
Add DIA Oracles to Peapods Finance

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30423,6 +30423,7 @@ const data3_1: Protocol[] = [
     twitter: "PeapodsFinance",
     audit_links: ["https://sourcehat.com/audits/PeapodsFinance/"],
     listedAt: 1706184132,
+    oracles : ["DIA"],
   },
   {
     id: "4064",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -30423,7 +30423,13 @@ const data3_1: Protocol[] = [
     twitter: "PeapodsFinance",
     audit_links: ["https://sourcehat.com/audits/PeapodsFinance/"],
     listedAt: 1706184132,
-    oracles : ["DIA"],
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/9974"]
+      }
+    ],
   },
   {
     id: "4064",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Peapods Finance to DIA Oracles TVS.

Oracles: DIA
Implementation Details: Enabling external lending and borrowing protocol integrations for the Peapods Finance native PEAS token (on all markets). Includes additional price feeds for SERV, NPC, XMW.
Documentation: Peapods request on forum (https://forum.diadata.org/t/cdr-091-peapods-finance-asset-price/1011/5), partnership details (https://www.diadata.org/blog/post/partnership-with-peapods-finance/)
Failure Scenario: Stale price data can lead to vaults being liquidated (as these are leveraged, more susceptible to price variation), which can result in the TVL of each vault being under risk.