### PR TITLE
add eoracle to Yieldfi oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -671,6 +671,12 @@ const data4: Protocol[] = [
         type: "Primary",
         proof: ["https://github.com/DefiLlama/defillama-server/pull/9183"],
         chains: [{chain: "arbitrum"}]
+      },
+      {
+        name: "eOracle",
+        type: "Primary",
+        proof: ["https://docs.yield.fi/resources/oracles"],
+        chains: [{chain: "Ethereum"}]
       }
     ],
     forkedFrom: [],

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -676,7 +676,7 @@ const data4: Protocol[] = [
         name: "eOracle",
         type: "Primary",
         proof: ["https://docs.yield.fi/resources/oracles"],
-        chains: [{chain: "Ethereum"}]
+        chains: [{chain: "ethereum"}]
       }
     ],
     forkedFrom: [],


### PR DESCRIPTION
YieldFi uses eOracle as the primary oracle on Ethereum mainnet https://docs.yield.fi/resources/oracles,

Added oracle breakdown, please help add this, and let us know if you have any questions. 

 






