### PR TITLE
Added RedStone Oracle for Hyperpie

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -9039,6 +9039,12 @@ const data4: Protocol[] = [
         proof: ["https://docs.hyperpiexyz.io/tech-stack-and-media-kit/oracle/pyth"],
         startDate: "2025-05-19"
       },
+      {
+        name: "RedStone",
+        type: "Secondary",
+        proof: ["https://docs.hyperpiexyz.io/tech-stack-and-media-kit/oracle/redstone"],
+        startDate: "2025-06-05"
+      },
     ],
     twitter: "Hyperpiexyz_io",
     audit_links: [


### PR DESCRIPTION
Hyperpie has collaborated with the RedStone team to integrate a decentralized price oracle for the mHYPE token. The oracle feed is now live and actively serving on-chain price data, enhancing transparency and reliability for the Hyperpie ecosystem. The deployed contract address is 0xa42a6568f1df29ef95DDDF440c41e48D4cfB310E, and further technical documentation and implementation details can be found in the [Hyperpie documentation](https://docs.hyperpiexyz.io/tech-stack-and-media-kit/oracle/redstone). This integration ensures accurate and timely pricing for mHYPE, supporting more robust DeFi operations across platforms leveraging Hyperpie.

https://app.redstone.finance/app/feeds/?page=1&sortBy=popularity&sortDesc=false&perPage=32&search=mhype