### PR TITLE
Update oracles for Morpho on Unichain & Hyperliquid L1.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -29718,6 +29718,19 @@ const data3_1: Protocol[] = [
         proof: ["https://github.com/DefiLlama/defillama-server/pull/9498/files"],
         chains: [{chain: "base"}]
       },
+         {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://app.morpho.org/unichain/earn"],
+        chains: [{chain: "Unichain"}]
+      },
+         {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://x.com/MorphoLabs/status/1915405407251812787"],
+        chains: [{chain: "Hyperliquid L1"}]
+      },
+      
     ],
     forkedFrom: [],
     module: "morpho-blue/index.js",


### PR DESCRIPTION
Hey Llamas,

Kindly asking to add RedStone as the main oracle for Morpho Blue on Unichain and Hyperliquid. The PR with proofs for Hyperliquid was already shared [here](https://github.com/DefiLlama/defillama-server/pull/9834) but I adjusted it to new oracle-breakdown format for your convenience.

Documenation/Proof:

Morpho Blue Unichain -> all markets on Unichain rely on our price feeds, this can be verified by going to "advanced" -> oracle section in each market.
https://app.morpho.org/unichain/market/0xdacbdd711936b4f4bd789f0f7111e36e925d730ebd41178e36e705efd78a4aa1/weeth-weth
https://app.morpho.org/unichain/market/0x665c97ec413f4371e1c30c71153757e9b9144dfbe4284a3e910f85dedba6527d/wsteth-weth
https://app.morpho.org/unichain/market/0xb98720c2275d134e04e37c94e2f82d0078b6b44f7d588cd2554353f45684c3ba/ezeth-weth
https://app.morpho.org/unichain/market/0xae4c2c8f12e170497b7282c0c257636546c7dadb56122d18cfae50defb2d6777/wsteth-usdt0


Morpho Blue Hyperliquid L1 -> proofs shared already in PR here: https://github.com/DefiLlama/defillama-server/pull/9834

(Morpho instance on Hyperliquid has currently $227m TVL biggest chunk of it comes from Felix Vanilla markets (https://usefelix.xyz/vanilla-borrow) which are entirely and exclusively secured by our oracles. (Morpho doesn't have it's front end on hyperliquid as it acts as a back end for Felix) Another big part of this TVL comes from HyperBeat which is also reliant on our oracles.)