### PR TITLE
Update oracles for Euler on Unichain & Swellchain.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -52585,6 +52585,20 @@ const data3_2: Protocol[] = [
     cmcId: null,
     category: "Lending",
     chains: ["Ethereum"],
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://oracles.euler.finance/146/"],
+        chains: [{chain: "Unichain"}]
+      },
+           {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://oracles.euler.finance/1923/"],
+        chains: [{chain: "Swellchain"}]
+      },
+    ],
      // euler does not set any oracles, they are set by the risk curators
     forkedFrom: [],
     module: "euler-v2/index.js",


### PR DESCRIPTION
Hey Llamas,

Kindly asking to add RedStone as the primary oracle for Euler on Unichain & Swellchain. RedStone is the only integrated and used oracle by Euler on those chains.

Documenation/Proof:

Unichain -> https://oracles.euler.finance/130/

Swellchain -> https://oracles.euler.finance/1923/