### PR TITLE
emissions allow breakdown even if last 30d no emissions

### DIFF
--- a/defi/src/storeEmissionsUtils.ts
+++ b/defi/src/storeEmissionsUtils.ts
@@ -237,7 +237,7 @@ export async function processSingleProtocol(
     emissionsAverage1y,
   };
 
-  if (sum([breakdown.emission24h, breakdown.emission7d, breakdown.emission30d]) > 0) emissionsBrakedown[sluggifiedId] = breakdown;
+  //if (sum([breakdown.emission24h, breakdown.emission7d, breakdown.emission30d]) > 0) emissionsBrakedown[sluggifiedId] = breakdown;
 
   await storeR2JSONString(`emissions/${sluggifiedId}`, JSON.stringify({ ...data, unlockUsdChart }));
 


### PR DESCRIPTION
to fix edge cases like pcs 