### PR TITLE
Update GoGoPool listing to include rebrand

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -10749,13 +10749,13 @@ const data3_1: Protocol[] = [
   },
   {
     id: "3179",
-    name: "GoGoPool",
+    name: "Hypha",
     address: "avax:0x69260B9483F9871ca57f81A90D91E2F96c2Cd11d",
     symbol: "GGP",
-    assetToken: "ggAVAX",
+    assetToken: "stAVAX",
     url: "https://www.gogopool.com",
     description:
-      "GoGoPool is the first permissionless staking protocol built for Avalanche Subnets and node operators to launch  for cheaper and faster using the GGP token. Currently, we cater to node operators and liquid stakers.",
+      "Hypha is the first permissionless staking protocol built for Avalanche Subnets and node operators to launch  for cheaper and faster using the GGP token. Currently, we cater to node operators and liquid stakers.",
     chain: "Avalanche",
     logo: `${baseIconsUrl}/gogopool.png`,
     audits: "2",
@@ -10766,8 +10766,8 @@ const data3_1: Protocol[] = [
     chains: ["Avalanche"],
     forkedFrom: [],
     module: "gogopool/index.js",
-    twitter: "GoGoPool_",
-    audit_links: ["https://docs.gogopool.com/audits"],
+    twitter: "hypha_sh",
+    audit_links: ["https://docs.hypha.sh/protocol/security/audits"],
     listedAt: 1688122598,
   },
   {


### PR DESCRIPTION
Hi, GoGoPool is in the process of being rebranded to Hypha ([proof](https://x.com/hypha_sh/status/1924503084157268462)). 

The addresses of tokens are staying the same, but we are updating token name of our LST (ggAVAX -> stAVAX) and some other things. 

Also, I couldn't find a way to submit a new project logo. Can you please let me know how I can do that? 