### PR TITLE
Add IMF to DIA Oracles

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -48994,6 +48994,13 @@ const data3_2: Protocol[] = [
     twitter: "intlmemefund",
     github: ["International-Meme-Fund"],
     listedAt: 1721214362,
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028"]
+      }
+    ],
   },
   {
     id: "4894",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add International Meme Fund to DIA Oracles TVS.

Oracles: DIA

Implementation Details: IMF is using DIA to support price feeds for their underlying assets for borrowing from the USDS market (MOG, PEPE, JOE) - and additional assets as requested (SPX & IMF).

Documentation: DIA request on forum (https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028), & partnership details (https://www.diadata.org/blog/post/dia-oracles-imf-lending-defi/)

Failure Scenario: The collateralization ratio is used for determining the borrowed asset, if the underlying assets (MOG, PEPE, JOE) are incorrectly priced, it can result in the incorrect amount of USDS minted and therefore a potential loss of funds.

Thank you,
Josh