### PR TITLE
CVEX Rebranding

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -1136,10 +1136,10 @@ const data4: Protocol[] = [
   },
   {
     id: "5610",
-    name: "Crypto Valley Exchange",
+    name: "Jetstream",
     address: null,
     symbol: "-",
-    url: "https://cvex.xyz/",
+    url: "https://jetstream.trade/",
     description:
       "Decentralized derivatives clearing protocol. Enabling traders to reduce margin and unlock capital by providing exchanges with a robust clearing mechanism. First Exchange offers Crypto Derivatives with full portfolio risk. Ready to unleash and empower crypto derivatives by unlocking collateral.",
     chain: "Arbitrum",
@@ -1153,7 +1153,7 @@ const data4: Protocol[] = [
     oraclesBreakdown: [ { name: "Internal", type: "Primary", proof: ["https://github.com/DefiLlama/DefiLlama-Adapters/pull/13046"] } ],
     forkedFrom: [],
     module: "cvex/index.js",
-    twitter: "cvex_xyz",
+    twitter: "Jetstreamtrade",
     listedAt: 1736469235
   },
   {


### PR DESCRIPTION
Hey @realdealshaman we have rebranded CVEX to Jetstream, you can check cvex.xyz is now redirecting to jetstream.trade.
Now we would appreciate if we can change the branding on defillama as well. Please see all changes required in the PR, new logo is attached below.
![image](https://github.com/user-attachments/assets/e6e5ee90-30af-4564-a09e-0f7b7ec3f0e9)
Thank You!
