### PR TITLE
Update Steakhouse description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14480,6 +14480,13 @@ const data4: Protocol[] = [
     category: "Risk Curators",
     chains: ["Ethereum", "Base"],
     forkedFrom: [],
+    oraclesBreakdown: [
+      {
+        name: "Chronicle",
+        type: "Primary",
+        proof: [""]
+      },
+    ],
     module: "steakhouse/index.js",
     twitter: "SteakhouseFi",
     listedAt: 1747736199

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14485,7 +14485,7 @@ const data4: Protocol[] = [
         name: "Chronicle",
         type: "Primary",
         proof: ["https://github.com/DefiLlama/defillama-server/pull/10124"],
-      
+        chains: [{ chain: "Base" },{ chain: "Unichain"}],
       },
     ],
     module: "steakhouse/index.js",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14478,13 +14478,14 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Risk Curators",
-    chains: ["Ethereum", "Base"],
+    chains: ["Ethereum", "Base", "Unichain"],
     forkedFrom: [],
     oraclesBreakdown: [
       {
         name: "Chronicle",
         type: "Primary",
-        proof: [""]
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/10124"],
+      
       },
     ],
     module: "steakhouse/index.js",


### PR DESCRIPTION
Hi, Llamas. I was told in a ticket that the TVS for Morpho has been moved with the curator and to open a PR here.

Chronicle powers several Morpho vaults on Base and Unichain listed below. Below you will find the adapters used to read from Chronicle oracles along with the corresponding oracle. We use Chainlink Morpho adapters since they are compatible.

 BASE:
    [0x06aE266A252E2ee96A4c05cFDa8163ED94379a5a](https://basescan.org/address/0x06aE266A252E2ee96A4c05cFDa8163ED94379a5a#code) - wstETH/USD
    [0x308b4C07e4FD4677F8d710660027d6D03845Cb83](https://basescan.org/address/0x308b4C07e4FD4677F8d710660027d6D03845Cb83#code) - cbETH/USD
    [0x4Eb7916682F59E25F824d8CE2a8F2318319296F6](https://basescan.org/address/0x4Eb7916682F59E25F824d8CE2a8F2318319296F6#code) - ETH/USD
    [0x6999f231968b8ea5288633388dab00db80299d7e](https://basescan.org/address/0x6999f231968b8ea5288633388dab00db80299d7e) - cbBTC/USD
    [0x7Bd7990A47b0DDF52d6eE2B89603a228910C2836](https://basescan.org/address/0x7Bd7990A47b0DDF52d6eE2B89603a228910C2836) - wstETH/USD
    
 UNICHAIN:
    [0x7f94B1aE11593cF704a5dab9Dd05f068662a0e34](https://uniscan.xyz/address/0x7f94B1aE11593cF704a5dab9Dd05f068662a0e34#code) - RSETH/ETH
    [0xcD65e1B0bF2A6363Be667D9dDbb346E0886bbF4E](https://uniscan.xyz/address/0xcD65e1B0bF2A6363Be667D9dDbb346E0886bbF4E#code) - EZETH/ETH
    [0xcD65e1B0bF2A6363Be667D9dDbb346E0886bbF4E](https://uniscan.xyz/address/0xcD65e1B0bF2A6363Be667D9dDbb346E0886bbF4E#code) - WSTETH/ETH#fundamental 
    [0x7f94B1aE11593cF704a5dab9Dd05f068662a0e34](https://uniscan.xyz/address/0x7f94B1aE11593cF704a5dab9Dd05f068662a0e34#code) - WSTETH/ETH#fundamental 
    