### PR TITLE
Add IMFv2 to DIA Oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -18744,6 +18744,13 @@ const data4: Protocol[] = [
     forkedFrom: [],
     twitter: "intlmemefund",
     parentProtocol: "parent#international-meme-fund",
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028"]
+      }
+    ],
   },
   {
     id: "6406",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -18748,7 +18748,7 @@ const data4: Protocol[] = [
       {
         name: "DIA",
         type: "Primary",
-        proof: ["https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028"]
+        proof: ["https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028", "https://github.com/DefiLlama/defillama-server/pull/10130"]
       }
     ],
   },


### PR DESCRIPTION
Copy from previous post (https://github.com/DefiLlama/defillama-server/pull/10115)

Hello DefiLlama team,

Requesting to add International Meme Fund to DIA Oracles TVS.

Oracles: DIA

Implementation Details: IMF is using DIA to support price feeds for their underlying assets for borrowing from the USDS market (MOG, PEPE, JOE) - and additional assets as requested (SPX & IMF).

Documentation: DIA request on forum (https://forum.diadata.org/t/cdr-094-international-meme-fund-token-price-feed/1028), & partnership details (https://www.diadata.org/blog/post/dia-oracles-imf-lending-defi/)

Failure Scenario: The collateralization ratio is used for determining the borrowed asset, if the underlying assets (MOG, PEPE, JOE) are incorrectly priced, it can result in the incorrect amount of USDS minted and therefore a potential loss of funds.

Thank you,
Josh

@realdealshaman Reference new info on IMF v2: IMFv2 uses the IMF-USDS, MOG, and PEPE price feeds. the V1 (depreciated has no current active price feeds supported by DIA), so the requested update is associated with V2 (see https://docs.imf.bz/docs/contracts.html). Thanks!