### PR TITLE
Add Hydration Lending to DIA Oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15793,7 +15793,7 @@ const data4: Protocol[] = [
       {
         name: "DIA",
         type: "Primary",
-        proof: ["https://hydration.subsquare.io/treasury/proposals/23"]
+        proof: ["https://hydration.subsquare.io/treasury/proposals/23","https://github.com/DefiLlama/defillama-server/pull/10142"]
       }
     ],
   },

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15789,6 +15789,13 @@ const data4: Protocol[] = [
     module: "hydration-lending/index.js",
     twitter: "hydration_net",
     listedAt: 1749084847,
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://hydration.subsquare.io/treasury/proposals/23"]
+      }
+    ],
   },
   {
     id: "6272",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Hydration Lending to DIA Oracles TVS.

Oracles: DIA

Implementation Details: DIA will deploy, monitor, and maintain 10 market-based price oracles for HydraDX’s on-chain money market. The assets which will be initially supported are: WBTC, WETH, DOT, VDOT, and additional assets will be added upon request to support new markets.

Documentation: Approval of governance proposal on the Hydration DAO forum (https://hydration.subsquare.io/treasury/proposals/23)

Failure Scenario: Underlying asset prices will determine the borrow ratio, if the price of the underlying assets are not correctly determined then can result in overborrowing, therefore allowing undercollateralization and liquidations to occur.

Thank you,
Josh