### PR TITLE
Update EulerDAO description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14240,15 +14240,21 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Risk Curators",
-    chains: ["Base", "Ethereum", "Unichain"],
+    chains: ["Base", "Ethereum", "Unichain", "Berachain"],
     forkedFrom: [],
     module: "euler-dao/index.js",
     twitter: "eulerfinance",
     oraclesBreakdown: [
       {
-        name: "Chainlink",
+        name: "Chainlink", 
         type: "Primary",
         proof: ["https://forum.euler.finance/t/eip-18-move-all-asset-price-oracles-to-chainlink-where-available-ahead-of-the-merge/349"]
+      },
+         {
+        name:  "Chronicle",
+        type: "Primary",
+        proof: [""],
+        chains: [{ chain: "Base" },{ chain: "Ethereum"}, { chain: "Berachain"}],
       },
     ],
     listedAt: 1747734034


### PR DESCRIPTION
hi, Llamas. Updating the EulerDAO description as the TVS for Euler has been recently moved from Euler to the curator. 

Chronicle is powering Euler on Ethereum, Base and Berachain. Please find below the whitelisted addresses:

Ethereum
- [0x420a9855fA5FE985b9A6458780214a2700e0D9c6](https://etherscan.io/search?f=0&q=0x420a9855fA5FE985b9A6458780214a2700e0D9c6) - SKY/USD
- [0x9Ee335e15692317A4fAdb221feA0AFfe48953130](https://etherscan.io/address/0x9Ee335e15692317A4fAdb221feA0AFfe48953130) - WSTETH/USD
- [0x956C9b887cB8779140EED942fa91f51B13Bd1b86](https://etherscan.io/address/0x956C9b887cB8779140EED942fa91f51B13Bd1b86#code) - ETH/USD
- [0xDC8af46aDF7143e58047beECA27210D6dc760721](https://etherscan.io/address/0xDC8af46aDF7143e58047beECA27210D6dc760721#code) - CBBTC/USDC
- [0x5c5B67D71559744d5d1DbB2c9C282761919A25Cf](https://etherscan.io/address/0x5c5B67D71559744d5d1DbB2c9C282761919A25Cf#code) - MKR/USD
- [0x5a47412c769A6a57bA757253fB199eDC3cCFCDe6](https://etherscan.io/address/0x5a47412c769A6a57bA757253fB199eDC3cCFCDe6#code) - SUSD/USD
- [0x6245cd4E6fef97ccc0508242135fdF2577006cfc](https://etherscan.io/address/0x6245cd4E6fef97ccc0508242135fdF2577006cfc#code) - USDS/USD

Base
- [0xa73E4A743135c16A36CfC746699d7F53bb00aA7a](https://basescan.org/address/0xa73E4A743135c16A36CfC746699d7F53bb00aA7a#code) - USDC/USD
- [0x6f3621dF5c5e33e6F1e82Fc11999777E08A1a2A7](https://basescan.org/address/0x6f3621dF5c5e33e6F1e82Fc11999777E08A1a2A7#code) - CBBTC/USDC
- [0xe7bc2e0dBb7E1B4E4A4cf50651A8c1412b397B9e](https://basescan.org/address/0xe7bc2e0dBb7E1B4E4A4cf50651A8c1412b397B9e#code) - WSTETH/USD
- [0x59FbC622F1130a5A939b883f5708613d91b2870f](https://basescan.org/address/0x59FbC622F1130a5A939b883f5708613d91b2870f#code) - CBETH/USD
- [0x03eCA93727e268FcA65baea35912014B6F446142](https://basescan.org/address/0x03eCA93727e268FcA65baea35912014B6F446142#code) - ETH/USD

Berachain
- [0xe8a784f4BdCd4707BAF4068e72887888Ad58c033](https://berascan.com/address/0xe8a784f4BdCd4707BAF4068e72887888Ad58c033#code) - SRUSD/USD
 - [0x617889fED99d725831305d13b86Ecc110D772822](https://berascan.com/address/0x617889fED99d725831305d13b86Ecc110D772822#code) - RUSD/USD

