### PR TITLE
Add "oraclesBreakdown" section to Blend protocol

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -12595,6 +12595,16 @@ const data4: Protocol[] = [
       "https://github.com/blend-capital/blend-contracts-v2/tree/main/audits",
     ],
     listedAt: 1746030822,
+    oraclesBreakdown: [
+      {
+        name: "Reflector",
+        type: "Primary",
+        proof: [
+          "https://docs.blend.capital/pool-creators/selecting-an-oracle#well-known-oracles",
+          "https://github.com/blend-capital/oracle-aggregator#supported-oracles"
+        ]
+      }
+    ]
   },
   {
     id: "6123",


### PR DESCRIPTION
### Oracle Provider
**Reflector** (https://reflector.network/)

### Implementation Details
Reflector is the default oracle provider for all Blend pools since the inception. Currently, the only compatible option for Blend oracle aggregator.

### Documentation/Proof
- https://docs.blend.capital/pool-creators/selecting-an-oracle#well-known-oracles
- https://github.com/blend-capital/oracle-aggregator#supported-oracles

 