### PR TITLE
feat: map SolvBTC.BERA to SolvBTC

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -205,6 +205,11 @@
       "decimals": "8",
       "symbol": "WFBTC",
       "to": "coingecko#ignition-fbtc"
+    },
+    "0x0F6f337B09cb5131cF0ce9df3Beb295b8e728F3B": {
+      "decimals": "18",
+      "symbol": "SolvBTC.BERA",
+      "to": "coingecko#solv-btc"
     }
   },
   "alephium": {


### PR DESCRIPTION
Hi DefiLlama team, as per https://docs.solv.finance/key-products/solv-vaults-lsts/minting-and-redemption, SolvBTC.BERA on Berachain should be pegged to SolvBTC's pricing instead.