### PR TITLE
Delist Jumper-exchange Fees adapter

### DIFF
--- a/defi/src/adaptors/data/fees/config.ts
+++ b/defi/src/adaptors/data/fees/config.ts
@@ -2085,7 +2085,8 @@ export default {
         id: "5715"
     },
     "jumper-exchange": {
-        id: "3524"
+        id: "3524",
+         enabled: false
     },
     "ocelex": {
         parentId: "Ocelex",


### PR DESCRIPTION
As jumper charges 0 fees and all the fee goes to bridges, so no point in showing double fees