### PR TITLE
Fix typo

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -46109,7 +46109,7 @@ const data3_2: Protocol[] = [
     cmcId: null,
     category: "CDP",
     chains: ["Ethereum"],
-    oracles: ["Chroncile"], // https://x.com/jigsawdefi/status/1915455029190025438, https://github.com/DefiLlama/defillama-server/pull/9737
+    oracles: ["Chronicle"], // https://x.com/jigsawdefi/status/1915455029190025438, https://github.com/DefiLlama/defillama-server/pull/9737
     forkedFrom: [],
     module: "jigsaw/index.js",
     twitter: "jigsawdefi",


### PR DESCRIPTION
Hello, Llamas. Fixing a small typo, "Chronicle" instead of "Chroncile". This typo was creating a new oracle that does not exist.