### PR TITLE
Add supported chains to DIA oracles

### DIFF
--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -412,6 +412,23 @@ const chainsByOracle: Record<string, Array<string>> = {
     "Vara",
     "Velas",
     "Wanchain",
+    "Bevm"
+    "Bob"
+    "CrossFi"
+    "EDU Chain"
+    "Goat"
+    "Hydration"
+    "Kadena"
+    "Linea"
+    "Lukso"
+    "Plume Mainnet"
+    "Sonic"
+    "Stacks"
+    "Superseed"
+    "Lukso"
+    "Swellchain"
+    "Unichain"
+    "XRPL"
   ],
   "Witnet": [
     "Arbitrum",


### PR DESCRIPTION
Hello DeFi Llama team,

Please see the requested changes to add the supported chains live on DIA oracles to our DeFiLlama.

Thank you,
Josh
