### PR TITLE
Add Stork as oracle for RE7 on Plume

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14469,8 +14469,16 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Risk Curators",
-    chains: ["Ethereum", "Base", "Sonic", "Berachain", "Binance"],
+    chains: ["Ethereum", "Base", "Sonic", "Berachain", "Binance", "Plume"],
     forkedFrom: [],
+    oraclesBreakdown: [
+      {
+        name: "Stork",
+        type: "Primary",
+        proof: ["https://lite.morpho.org/plume/earn", "https://explorer.plume.org/address/0xcEedB1173F4D3db19288b4913335CB2d44BEb175?tab=internal_txns", "https://explorer.plume.org/address/0x7824e4B3E21678f143Ce22308ADfd48d1D3160FB?tab=internal_txns", "https://explorer.plume.org/address/0xDF16567dA7d2F5Fec172DDFe42036976C6e7D95F?tab=internal_txns"],
+        chains: [{ chain: "Plume"}]
+      },
+    ],
     module: "re7/index.js",
     twitter: "Re7Labs",
     listedAt: 1747735814


### PR DESCRIPTION
Hey @realdealshaman ! Bit of a more complicated one here. 63.6% of TVL secured by Stork Contracts through the StorkChainlinkAdapter for nBASIS, nALPHA, and nCREDIT on RE7's Vault on Plume. 

<img width="1239" height="199" alt="Screenshot 2025-07-22 at 2 16 40 PM" src="https://github.com/user-attachments/assets/64d22024-b63b-4ec8-b318-f22768026d1c" />
<img width="1226" height="195" alt="Screenshot 2025-07-22 at 2 16 10 PM" src="https://github.com/user-attachments/assets/fbdd3c5c-fb3c-4ee8-beac-d4cc68b2fd0d" />
<img width="1222" height="209" alt="Screenshot 2025-07-22 at 2 16 04 PM" src="https://github.com/user-attachments/assets/ef65e53a-4860-48ee-9ed8-f43f0828bf26" />
