### PR TITLE
Changed PBG category

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -20446,7 +20446,7 @@ const data4: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Reserve Currency",
+    category: "Onchain Capital Allocator",
     chains: ["Cardano"],
     forkedFromIds: [],
     module: "PBG/index.js",


### PR DESCRIPTION
Changed PBG category from Reserve Currency to Onchain Capital Allocator

Reason: although the project's native token is a Reserve Currency, "Onchain Capital Allocator" better describes the actual underlying smart contract. Most competing projects on other chains also seem to categorize themselves as "Onchain Capital Allocator".