### PR TITLE
Update Oracles for Hyperlend.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -8593,7 +8593,7 @@ const data4: Protocol[] = [
       },
       {
         name: "RedStone",
-        type: "Fallback",
+        type: "Primary",
         proof: ["https://github.com/DefiLlama/DefiLlama-Adapters/pull/13990"]
       }
     ],


### PR DESCRIPTION
Hey Llamas,

Kindly asking to add RedStone as the second primary oracle for HyperLend on Hyperliquid. RedStone is integrated on kHYPE (25%), UBTC (6,7%), UETH (3,6%), sUSDe (0.1%), USR markets which account for ~35,4% of HyperLend's TVL. 

Since those markets are in Core (pooled) pools (aave fork) and we secure significant % of tvl in case of manipulation on those markets whole Hyperlend TVL would be at risk.

Documenation/Proof:

Oracle used can be checked in the "Oracle provider" section in the market details -> https://app.hyperlend.finance/markets/0xfD739d4e423301CE9385c1fb8850539D657C296D