### PR TITLE
Add Edge Oracle to EtherFi Cash

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -18234,6 +18234,13 @@ const data4: Protocol[] = [
     forkedFrom: [],
     parentProtocol: "parent#etherfi-cash",
     listedAt: 1751313285,
+    oraclesBreakdown: [
+      {
+        name: "Edge",
+        type: "Primary",
+        proof: ["https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations"]
+      }
+    ]
   },
   {
     id: "6374",


### PR DESCRIPTION
Oracle Provider(s): Edge

Implementation Details: Used as the price oracle for EtherFi Cash on Scroll

Documentation/Proof: https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations
