### PR TITLE
feat: add Bedrock uniBTC to TAC

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -11155,6 +11155,11 @@
       "decimals": "18",
       "symbol": "wstUSR",
       "to": "coingecko#resolv-wstusr"
+    },
+    "0x236f8c0a61dA474dB21B693fB2ea7AAB0c803894": {
+      "to": "coingecko#universal-btc",
+      "decimals": 8,
+      "symbol": "uniBTC"
     }
   },
   "initia": {


### PR DESCRIPTION
Hi team, submitting PR to map uniBTC on TAC to the existing CoinGecko ID `universal-btc` as is the case for what has been done with the same uniBTC on other chains.

That's because:

```
Balance table for [tac] Unrecognized tokens
┌─────────┬──────────┬──────────┬─────────┬──────────────────────────────────────────────────┬──────────┐
│ (index) │ name     │ symbol   │ balance │ label                                            │ decimals │
├─────────┼──────────┼──────────┼─────────┼──────────────────────────────────────────────────┼──────────┤
│ 0       │ 'uniBTC' │ 'uniBTC' │ '320'   │ 'tac:0xf9775085d726e782e83585033b58606f7731ab18' │ '8'      │
└─────────┴──────────┴──────────┴─────────┴──────────────────────────────────────────────────┴──────────┘
```