### PR TITLE
Update Oracles for Hyperlend.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -8602,8 +8602,8 @@ const data4: Protocol[] = [
       },
       {
         name: "RedStone",
-        type: "Fallback",
-        proof: ["https://github.com/DefiLlama/DefiLlama-Adapters/pull/13990"]
+        type: "Primary",
+        proof: https://app.hyperlend.finance/markets/0xfD739d4e423301CE9385c1fb8850539D657C296D
       }
     ],
     twitter: "hyperlendx",


### PR DESCRIPTION
Hey Llamas,

Through this [commit](https://github.com/DefiLlama/defillama-server/commit/cf69df063cb46ef1b8ec0bc2f67194a289c57082) RedStone got delisted as an Oracle for HyperLend while % of Hyperlend TVL it secures has actually grown.

While submitting previous [PR](https://github.com/DefiLlama/defillama-server/pull/10312) we were securing ~35,4% of HyperLend TVL. Right now the numbers look as follows: 

RedStone is integrated as a primary oracle on kHYPE (31.6%), UBTC (6.3%), UETH (6%), sUSDe (0.08%), USR markets which account for ~**44% of HyperLend's TVL that is secured by RedStone feeds**. While those markets are in Core (pooled) pools (aave fork) and we secure significant % of tvl in case of manipulation on those markets whole Hyperlend TVL would be at risk.


Documenation/Proof:

Oracle used can be checked in the UI "Oracle provider" section in the market details -> https://app.hyperlend.finance/markets/0xfD739d4e423301CE9385c1fb8850539D657C296D