### PR TITLE
Name change on canary protocol metadata

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5987,7 +5987,7 @@ const data4: Protocol[] = [
   },
   {
     id: "5828",
-    name: "Canary Protocol",
+    name: "Canary Protocol Legacy",
     address: null,
     symbol: "-",
     url: "https://www.canaryprotocol.com/",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5987,7 +5987,7 @@ const data4: Protocol[] = [
   },
   {
     id: "5828",
-    name: "Canary Protocol Legacy",
+    name: "Legacy Canary Protocol",
     address: null,
     symbol: "-",
     url: "https://www.canaryprotocol.com/",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5988,6 +5988,7 @@ const data4: Protocol[] = [
   {
     id: "5828",
     name: "Legacy Canary Protocol",
+    deprecated: true,
     address: null,
     symbol: "-",
     url: "https://www.canaryprotocol.com/",


### PR DESCRIPTION
We're requesting a name changing as the protocol is legacy at this point.

thank you for your time!