### PR TITLE
Update Oracles for Cap.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -22654,7 +22654,6 @@ const data4: Protocol[] = [
         name: "RedStone",
         type: "Primary",
         proof: ["https://docs.cap.app/concepts/oracles"],
-        chains: ["Ethereum"]
       }
     ],
     github: ["cap-labs-dev"],


### PR DESCRIPTION
Hey Lamas,

Kindly asking you to update Oracles for Cap

Oracle Provider(s): RedStone.

Implementation details: Cap is using RedStone the primary Oracle for data on Ethereum.

Documenation/Proof: https://docs.cap.app/concepts/oracles
