### PR TITLE
Updated oracles for Flexperps

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -6358,14 +6358,9 @@ const data4: Protocol[] = [
     chains: ["Base"],
     oraclesBreakdown: [
       {
-        name: "Pyth",
-        type: "Aggregator",
-        proof: ["https://docs.flex.trade/#product-features"]
-      },
-      {
         name: "Chainlink",
-        type: "Aggregator",
-        proof: ["https://docs.flex.trade/#product-features"]
+        type: "Primary",
+        proof: ["https://docs.flex.trade/oracles"]
       }
     ],
     forkedFromIds: ["2296"],


### PR DESCRIPTION
Hi Llamas! Flexperps has set Chainlink as its primary oracle, so I made some updates in this commit. You can find more info here: https://docs.flex.trade/oracles