### PR TITLE
Update Oracles for Cap.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -22652,7 +22652,6 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Lending", 
-    chains: ["Ethereum"],
     module: "cap-money/index.js",
     twitter: "capmoney_",
     audit_links: ["https://github.com/cap-labs-dev/cap-audits"],


### PR DESCRIPTION
Hey Lamas,

Kindly asking you to update Oracles for Cap with chains line removed as requested.

Oracle Provider(s): RedStone.

Implementation details: Cap is using RedStone the primary Oracle for all feeds.

Documenation/Proof: https://docs.cap.app/concepts/oracles
