### PR TITLE
Updated Echelon oracles

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -37706,8 +37706,17 @@ const data3_2: Protocol[] = [
     chains: ["Aptos", "Movement"],
     oraclesBreakdown: [
       {
-        name: "Pyth",
+        name: "Chainlink",
         type: "Primary",
+        proof: ["https://docs.echelon.market/echelon/core/oracles"],
+          chains: [
+          {chain: "Aptos"},
+          {chain: "Move"},
+        ]
+      },
+      {
+        name: "Pyth",
+        type: "Secondary",
         proof: ["https://app.echelon.market/markets?network=aptos_mainnet", "https://app.echelon.market/markets?network=movement_mainnet", "https://docs.echelon.market/echelon-v1/risks#oracle-risk"],
         chains: [
           {chain: "Aptos"},

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -37708,7 +37708,7 @@ const data3_2: Protocol[] = [
       {
         name: "Chainlink",
         type: "Primary",
-        proof: ["https://docs.echelon.market/echelon/core/oracles"],
+        proof: ["https://docs.echelon.market/echelon/core/oracles","https://github.com/DefiLlama/defillama-server/pull/10509"],
           chains: [
           {chain: "Aptos"},
         ]
@@ -37716,7 +37716,11 @@ const data3_2: Protocol[] = [
 	  {
         name: "Pyth",
         type: "Primary",
-        proof: ["https://app.echelon.market/markets?network=aptos_mainnet", "https://app.echelon.market/markets?network=movement_mainnet", "https://docs.echelon.market/echelon-v1/risks#oracle-risk"],
+        proof: [
+			"https://app.echelon.market/markets?network=aptos_mainnet", 
+			"https://app.echelon.market/markets?network=movement_mainnet", 
+			"https://docs.echelon.market/echelon-v1/risks#oracle-risk"
+		],
         chains: [
           {chain: "Move"},
         ]
@@ -37724,7 +37728,12 @@ const data3_2: Protocol[] = [
       {
         name: "Pyth",
         type: "Secondary",
-        proof: ["https://app.echelon.market/markets?network=aptos_mainnet", "https://app.echelon.market/markets?network=movement_mainnet", "https://docs.echelon.market/echelon-v1/risks#oracle-risk"],
+        proof: [
+			"https://app.echelon.market/markets?network=aptos_mainnet", 
+			"https://app.echelon.market/markets?network=movement_mainnet", 
+			"https://docs.echelon.market/echelon-v1/risks#oracle-risk",
+			"https://github.com/DefiLlama/defillama-server/pull/10509"
+		],
         chains: [
           {chain: "Aptos"},
         ]

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -37711,6 +37711,13 @@ const data3_2: Protocol[] = [
         proof: ["https://docs.echelon.market/echelon/core/oracles"],
           chains: [
           {chain: "Aptos"},
+        ]
+      },
+	  {
+        name: "Pyth",
+        type: "Primary",
+        proof: ["https://app.echelon.market/markets?network=aptos_mainnet", "https://app.echelon.market/markets?network=movement_mainnet", "https://docs.echelon.market/echelon-v1/risks#oracle-risk"],
+        chains: [
           {chain: "Move"},
         ]
       },
@@ -37720,7 +37727,6 @@ const data3_2: Protocol[] = [
         proof: ["https://app.echelon.market/markets?network=aptos_mainnet", "https://app.echelon.market/markets?network=movement_mainnet", "https://docs.echelon.market/echelon-v1/risks#oracle-risk"],
         chains: [
           {chain: "Aptos"},
-          {chain: "Move"},
         ]
       },
       {


### PR DESCRIPTION
Hi DefiLlama team! Echelon is now being secured by Chainlink oracles! You can find the official announcement [here](https://x.com/EchelonMarket/status/1960734061938532857) and the proof [here](https://docs.echelon.market/echelon/core/oracles). 