### PR TITLE
add eOracle as primary for Re7 on TAC

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14590,7 +14590,7 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Risk Curators",
-    chains: ["Ethereum", "Base", "Sonic", "Berachain", "Binance", "Plume Mainnet"],
+    chains: ["Ethereum", "Base", "Sonic", "Berachain", "Binance", "Plume Mainnet", "TAC"],
     forkedFrom: [],
     oraclesBreakdown: [
       {
@@ -14612,6 +14612,14 @@ const data4: Protocol[] = [
           "https://app.morpho.org/unichain/vault/0x6af5E46456A8ac80BB53a02799965DEF99c26e52/re7-weth", 
           "https://app.morpho.org/unichain/vault/0x2c0F7e917257926BA6233B20DE19d7fe3210858C/re7-usdt0",
           "https://oracles.euler.finance/130/"
+        ],
+        chains: [{chain: "Unichain"}]
+      },
+      {
+        name: "eOracle",
+        type: "Primary",
+        proof: [
+          "https://app.euler.finance/?governor=re7-labs&network=tac"
         ],
         chains: [{chain: "Unichain"}]
       },

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14619,9 +14619,10 @@ const data4: Protocol[] = [
         name: "eOracle",
         type: "Primary",
         proof: [
-          "https://app.euler.finance/?governor=re7-labs&network=tac"
+          "https://app.euler.finance/?governor=re7-labs&network=tac",
+          "https://github.com/DefiLlama/defillama-server/pull/10515"
         ],
-        chains: [{chain: "Unichain"}]
+        chains: [{chain: "TAC"}]
       },
     ],
     module: "re7/index.js",


### PR DESCRIPTION
Re7 Labs Cluster's cbBTC market (TAC)(https://app.euler.finance/vault/0x2eF66758705426e7BF598669AEf23eE9b9CC3088?network=tac) is secured by eOracle. 
Steps to verify - 
1/ visit the oracle router here https://explorer.tac.build/address/0x51e0CAcc951ed4402366572eaCd120C8B28853d4?tab=read_write_contract
2/ call getConfiguredOracle with base as cbBTC (0x7048c9e4aBD0cf0219E95a17A8C6908dfC4f0Ee4) and quote as USD(0x0000000000000000000000000000000000000348), it returns the Euler Chainlinkadapter here https://explorer.tac.build/address/0x5777baB47b2705C8576aBc4995589157E59384a1?tab=contract
3/ call feed() on the adapter, it returns https://explorer.tac.build/address/0xaE5Dc951d55535679252Cff49E89Af8cEcbf5E1f which is deployed and maintained by eOracle. 

You can find eOracle TAC feeds here https://docs.eo.app/docs/eprice/feeds-addresses/price-feed-addresses/tac-mainnet. 

As Re7s majority TVL on TAC chain is on cbBTC Euler market, a misreport to this price feed could affect capital managed within the curator's vault. 




