### PR TITLE
add eOracle to ouroboros capital oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14574,6 +14574,16 @@ const data4: Protocol[] = [
     forkedFrom: [],
     module: "ouroboros/index.js",
     twitter: "OuroborosCap8",
+    oraclesBreakdown: [
+      {
+        name: "eOracle",
+        type: "Primary",
+        proof: [
+          "https://app.morpho.org/ethereum/vault/0x2F21c6499fa53a680120e654a27640Fc8Aa40BeD/openeden-usdc-vault",
+        ],
+        chains: [{chain: "Ethereum"}]
+      },
+    ],
     listedAt: 1747735650
   },
   {

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -14580,6 +14580,7 @@ const data4: Protocol[] = [
         type: "Primary",
         proof: [
           "https://app.morpho.org/ethereum/vault/0x2F21c6499fa53a680120e654a27640Fc8Aa40BeD/openeden-usdc-vault",
+          "https://github.com/DefiLlama/defillama-server/pull/10516/files"
         ],
         chains: [{chain: "Ethereum"}]
       },


### PR DESCRIPTION
gm!

Ouroboros Capital (Risk Curator) managed a vault on Morpho Eth mainnet, which is their entire reported TVL (https://app.morpho.org/ethereum/vault/0x2F21c6499fa53a680120e654a27640Fc8Aa40BeD/openeden-usdc-vault). 

The vault allocates 98%+ capital to the PT-cUSDO-20NOV2025 / USDC market. (https://app.morpho.org/ethereum/market/0x8a71a66ac828c2b6d4f8accce5859aba0822b502f3833bec4aff09479affffdb/pt-cusdo-20nov2025-usdc), which is secured by eOracle data feed. 

Verification - 

- Go to advanced tab within the market page, go to the morpho oracle address on the bottom of the page - https://etherscan.io/address/0x0dF910a47452B995F545D66eb135f38D0FbB142E#readContract
- call BASE_FEED_1 on the morpho oracle, it returns - https://etherscan.io/address/0xCE84fD399620B7D20e18AB6009Fc8A0cdaad880f#code, which is deployed and maintained by eOracle. 
- You can find all eOracle pendle feeds here https://docs.eo.app/docs/eprice/feeds-addresses/pt-feeds-addresses/pendle/ethereum

As majority of this curators vault TVL on ethereum is secured by eOracle, a misreport by the oracle can lead to loss of funds.  
