### PR TITLE
Update suilend oracle

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -35642,15 +35642,10 @@ const data3_2: Protocol[] = [
     chains: ["Sui"],
     module: "suilend/index.js",
     twitter: "suilendprotocol",
-    oracles: ["Pyth", "Switchboard"],
+    oracles: ["Pyth"],
     oraclesBreakdown: [
       {
         name: "Pyth",
-        type: "Primary",
-        proof: ["https://docs.suilend.fi/security/risks"]
-      },
-      {
-        name: "Switchboard",
         type: "Primary",
         proof: ["https://docs.suilend.fi/security/risks"]
       }


### PR DESCRIPTION
Hi

Updated Suilend oracle based on actual Oracle used
here is a table where i summarized the curred TVL and oracle for each markets

<img width="1046" height="742" alt="image" src="https://github.com/user-attachments/assets/b3cd4f5b-246c-4fec-a88a-a78b2d7a163f" />

Oracle used can be seen by selecting a market, clicking "more parameters" and under Objects - oracle, you will see the feed responsible which is from Pyth

<img width="921" height="415" alt="image" src="https://github.com/user-attachments/assets/daebf119-7335-4b23-aa68-8e4d6de862cf" />
