### PR TITLE
Update save oracles

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -7703,7 +7703,10 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     twitter: "save_finance",
     parentProtocol: "parent#save-protocol",
     audit_links: ["https://github.com/solendprotocol/solana-program-library/tree/master/token-lending/audit"],
-    oracles: ["Pyth", "Switchboard"], // https://github.com/DefiLlama/defillama-server/pull/5174
+    oraclesBreakdown: [
+      { name: "Pyth", type: "Primary", proof: ["https://docs.save.finance/protocol/oracles"] },
+      { name: "Switchboard", type: "Fallback", proof: ["https://docs.save.finance/protocol/oracles"] }
+    ],
   },
   {
     id: "459",


### PR DESCRIPTION
Updated Save oracles based on docs.
as mentioned, Switchboard is backup oracle.

also, upon inspection, Switchboard is only used on SOL, USDT and ETH
<img width="1120" height="1134" alt="image" src="https://github.com/user-attachments/assets/d87feda1-d652-44dd-aa88-4bae27b06f61" />

most markets shows Swictchboard oralce as nu1111
<img width="873" height="370" alt="image" src="https://github.com/user-attachments/assets/efe8f894-e559-47f0-a44d-105bf7a7de75" />
