### PR TITLE
Berachain token mappings update

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -61,6 +61,11 @@
     }
   },
   "berachain": {
+    "0x118D2cEeE9785eaf70C15Cd74CD84c9f8c3EeC9a": {
+      "decimals": "18",
+      "symbol": "sWBERA",
+      "to": "coingecko#pol-staked-wbera"
+    },
     "0x5bad2b7a0a2eee88a4ef05d5470cdedb0ff948ea": {
       "decimals": "18",
       "symbol": "hOHM",

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -66,10 +66,25 @@
       "symbol": "hOHM",
       "to": "coingecko#origami-hohm"
     },
+    "0x225B86198ba36321a8A840291416aEd62494043f": {
+      "decimals": "18",
+      "symbol": "SOL",
+      "to": "coingecko#wrapped-sol-2"
+    },
+    "0x7e768f47dfDD5DAe874Aac233f1Bc5817137E453": {
+      "decimals": "18",
+      "symbol": "yBGT",
+      "to": "coingecko#ybgt"
+    },
     "0xD2C41BF4033A83C0FC3A7F58a392Bf37d6dCDb58": {
       "decimals": "18",
       "symbol": "osBGT",
-      "to": "coingecko#infrafred-bgt"
+      "to": "coingecko#infrared-bgt"
+    },
+    "0x1b25ca174c158440621ff96e4b1262cb5cc8942f": {
+      "decimals": "18",
+      "symbol": "SolvBTC.BNB",
+      "to": "coingecko#solv-protocol-solvbtc-bnb"
     },
     "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba": {
       "decimals": "18",

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -68,13 +68,18 @@
     },
     "0x9b6761bf2397bb5a6624a856cc84a3a14dcd3fe5": {
       "decimals": "18",
-      "symbol": "sWBERA",
+      "symbol": "iBERA",
       "to": "coingecko#infrared-bera"
     },
     "0xd77552d3849ab4d8c3b189a9582d0ba4c1f4f912": {
       "decimals": "18",
       "symbol": "wgBERA",
       "to": "coingecko#wrapped-gbera"
+    },
+    "0x0f81001ef0a83ecce5ccebf63eb302c70a39a654": {
+      "decimals": "18",
+      "symbol": "DOLO",
+      "to": "coingecko#dolomite"
     },
     "0x5bad2b7a0a2eee88a4ef05d5470cdedb0ff948ea": {
       "decimals": "18",

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -66,6 +66,16 @@
       "symbol": "sWBERA",
       "to": "coingecko#pol-staked-wbera"
     },
+    "0x9b6761bf2397bb5a6624a856cc84a3a14dcd3fe5": {
+      "decimals": "18",
+      "symbol": "sWBERA",
+      "to": "coingecko#infrared-bera"
+    },
+    "0xd77552d3849ab4d8c3b189a9582d0ba4c1f4f912": {
+      "decimals": "18",
+      "symbol": "wgBERA",
+      "to": "coingecko#wrapped-gbera"
+    },
     "0x5bad2b7a0a2eee88a4ef05d5470cdedb0ff948ea": {
       "decimals": "18",
       "symbol": "hOHM",

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -67,7 +67,7 @@
       "to": "coingecko#origami-hohm"
     },
     "0x225B86198ba36321a8A840291416aEd62494043f": {
-      "decimals": "18",
+      "decimals": "9",
       "symbol": "SOL",
       "to": "coingecko#wrapped-sol-2"
     },


### PR DESCRIPTION
fix osBGT mapping typo
Add mappings for missing API price tokens:
- add wrapped SOL (wormhole bridged)
- add yBGT (official coingecko listing, wasn't recognizing a price)
- add solvBTC.BNB (official coingecko listing, wasn't recognizing a price)