### PR TITLE
Add Snake Finance to DIA Oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -4573,6 +4573,12 @@ const data4: Protocol[] = [
     module: "snake/index.js",
     twitter: "SnakeOnSonic",
     listedAt: 1738964053,
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://x.com/SnakeOnSonic/status/194843031691111238"]
+      }
   },
   {
     id: "5761",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Snake Finance to DIA Oracles TVS.

Oracles: DIA

Implementation Details: DIA is providing the $SNAKE price feed required for their forest (farm), capturing $903k of their $1.44M TVL (~63%)

Documentation: https://x.com/SnakeOnSonic/status/1948430316911112384

Failure Scenario: The price of $SNAKE determines the $GSNAKE rewards. If $SNAKE price is maliciously changed, it can result in high emissions of $GSNAKE.

Thank you,
Josh