### PR TITLE
add eOracle to Silo Avalanche & Arb

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -1192,14 +1192,32 @@ const data4: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Lending",
-    chains: ["Arbitrum", "Sonic"],
+    chains: ["Arbitrum", "Sonic", "Avalanche"],
     oraclesBreakdown: [
       {
         name: "RedStone",
         type: "Primary",
         proof: ["https://app.silo.finance", "https://github.com/DefiLlama/defillama-server/pull/9560"],
+        chains: [
+          {
+            chain: "Sonic",
+          },
+        ],      
       },
       {
+        name: "eOracle",
+        type: "Primary",
+        proof: ["https://app.silo.finance/markets/avalanche/xbtc-btcb-130?action=deposit&token=0", "https://app.silo.finance/markets/avalanche/xusd-usdc-129?action=deposit&token=0", "https://app.silo.finance/markets/arbitrum/xusd-usdc-146?action=deposit", "https://app.silo.finance/markets/arbitrum/xusd-usdc-146?action=deposit"],
+        chains: [
+          {
+            chain: "Avalanche",
+          },
+          {
+            chain: "Arbitrum",
+          },
+        ],
+      },
+       {
         name: "Chainlink",
         type: "Secondary",
         proof: ["https://github.com/DefiLlama/defillama-server/pull/9388", "https://silopedia.silo.finance/oracles"],


### PR DESCRIPTION
gm! adding eOracle to Silo Avalance & Arbitrum

**Avalanche**  - Silo finance Avalanche market's majority TVL is deposited in the xBTC/BTC & xUSD/USDC markets, both of which are secured by eOracle. UI links - https://app.silo.finance/markets/avalanche/xbtc-btcb-130?action=deposit, https://app.silo.finance/markets/avalanche/xusd-usdc-129?action=deposit

**Arbitrum** - Silo finance Arbitrum market's majority TVL is deposited in xUSD/USDC market, with a combined TVL of 20M (xUSD & USDC collateral value). No other external oracle secures higher value of collateral on Silo Arbitrum. UI link - https://app.silo.finance/markets/arbitrum/xusd-usdc-146?action=deposit

