### PR TITLE
Add Blend Finance to DIA Oracles

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -50591,6 +50591,12 @@ const data3_2: Protocol[] = [
     twitter: "Protocol_Blend",
     github: ["Blend-Blend"],
     listedAt: 1722858892,
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://x.com/DIAdata_org/status/1963603033688011073"]
+      }
   },
   {
     id: "4943",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Blend Finance to DIA Oracles TVS.

Oracles: DIA

Implementation Details: DIA is supporting the Blend Finance markets for all their price feeds on EDU Chain.

Documentation: https://x.com/DIAdata_org/status/1963603033688011073 (repost & comment)

Failure Scenario: Underlying asset prices will determine the borrow ratio, if the price of the underlying assets are not correctly determined then can result in overborrowing, therefore allowing undercollateralization and liquidations to occur.

Thank you,
Josh