### PR TITLE
Added oracles to Tearex protocol

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -8298,6 +8298,7 @@ const data4: Protocol[] = [
     cmcId: null,
     category: "Derivatives",
     chains: ["Sei"],
+    oraclesBreakdown: [{ name: "Chainlink", type: "Primary", proof: ["https://docs.trex.trade/more-about-the-jungle/jungle-scouts-oracles#our-jungle-scouts-oracle-sources"] }],
     forkedFrom: [],
     module: "tearex/index.js",
     audit_links: ["ttps://github.com/TeahouseFinance/Tea-REX/blob/master/audit.pdf"],


### PR DESCRIPTION
Hi @realdealshaman! Chainlink is now the Primary Oracle provider of Tea-REX, securing over 50% of the value!!!
You can find more here: https://docs.trex.trade/more-about-the-jungle/jungle-scouts-oracles#our-jungle-scouts-oracle-sources
