### PR TITLE
add eOracle to layerbank morph

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -12450,7 +12450,11 @@ const data3_1: Protocol[] = [
           {
             chain: "Hemi",
             startDate: "2025-03-25"
-          }
+          },
+		  {
+            chain: "Morph",
+            startDate: "2025-07-04"
+          },	
         ]
       }
     ],


### PR DESCRIPTION
Layerbank uses eOracle data feed to secure their markets on Morph. 
Steps to verify - 
* Layerbank Github Repo with all their deployment addresses - https://github.com/layerbank-foundation/v2-contracts
* On the Morph mainnet section, find Price calculator address - https://explorer.morphl2.io/address/0xebBeA62F9e4D97D42f4784d8E04b054dae553B40
For each setTokenFeed transaction, you can find the token and price feed address - 

<img width="1130" height="435" alt="Screenshot 2025-09-12 at 5 13 27 PM" src="https://github.com/user-attachments/assets/4beb4793-eccd-4397-868c-50f54bb2643a" />


<img width="1082" height="285" alt="Screenshot 2025-09-12 at 5 13 09 PM" src="https://github.com/user-attachments/assets/4a68ad34-1216-4040-a256-f1369e2e587f" />


You can find all eOracle price feed addresses here https://docs.eo.app/docs/eprice/feeds-addresses/price-feed-addresses/morph