### PR TITLE
fix: change WBTC decimal on soneium chain(18 to 8)

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -9589,7 +9589,7 @@
     },
     "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c": {
       "to": "coingecko#wrapped-bitcoin",
-      "decimals": 18,
+      "decimals": 8,
       "symbol": "WBTC"
     },
     "0x3b0dc2dac9498a024003609031d973b1171de09e": {


### PR DESCRIPTION
https://soneium.blockscout.com/token/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c

<img width="677" height="435" alt="image" src="https://github.com/user-attachments/assets/5a494d6f-2899-43fb-8ff2-212bc8f255d7" />

fix: correct WBTC decimal from 18 to 8
