### PR TITLE
Update Takara Lend primary oracle

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5389,11 +5389,16 @@ const data4: Protocol[] = [
     chains: ["Sei"],
     oraclesBreakdown: [
       {
-        name: "RedStone",
+        name: "Api3",
         type: "Primary",
         proof: [
           "https://takara.gitbook.io/takara-lend/protocol-information/security#takara-security-measures",
           "https://app.takaralend.com/market/WSEI",
+          "https://app.takaralend.com/market/spSEI",
+          "https://app.takaralend.com/market/iSEI",
+          "https://app.takaralend.com/market/uBTC",
+          "https://app.takaralend.com/market/MBTC",
+          "https://app.takaralend.com/market/SBTC",
         ],
       },
       {
@@ -5405,7 +5410,7 @@ const data4: Protocol[] = [
         ],
       },
       {
-        name: "Api3",
+        name: "RedStone",
         type: "Fallback",
         proof: [
           "https://takara.gitbook.io/takara-lend/protocol-information/security#takara-security-measures",


### PR DESCRIPTION
Update the primary oracle for Takara Lend.  Team has switch a majority of the primary oracles to Api3
Proof in markets          
          https://app.takaralend.com/market/WSEI
          https://app.takaralend.com/market/spSEI
          https://app.takaralend.com/market/iSEI
          https://app.takaralend.com/market/uBTC
          https://app.takaralend.com/market/MBTC
          https://app.takaralend.com/market/SBTC
          
<img width="551" height="456" alt="image" src="https://github.com/user-attachments/assets/b91771a7-a9b1-439a-b953-83619b9b81f5" />
