### PR TITLE
feat: revert ylds to usd-coin while troubleshooting

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -11917,7 +11917,7 @@
       "symbol": "ueur.trading"
     },
     "uylds.fcc": {
-      "to": "coingecko#ylds",
+      "to": "coingecko#usd-coin",
       "decimals": 6,
       "symbol": "uylds.fcc"
     },


### PR DESCRIPTION
Setting the coingecko ID for YLDS (seen here listed on coingecko: https://www.coingecko.com/en/coins/ylds) resulted in losing the YLDS in the Provenance TVL. This PR reverts it just to map back to USDC since YLDS is also a stablecoin. Would request some assistance in figuring out why `coingeck#ylds` results in a non-response, though. It should return a value.