### PR TITLE
add eOracle to Telos Consilium on Plasma

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -29568,7 +29568,7 @@ const data4: Protocol[] = [
       {
         name: "eOracle",
         type: "Primary",
-        proof: [],
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/10766],
         chains: [{ chain: "Plasma" }],
       },
     ],


### PR DESCRIPTION
Telos Consilium's xUSD market on Euler plasma is secured by eOracle. 

Majority of Telos Consilium's Plasma chain TVL is in this market https://app.euler.finance/?governor=telosc&network=plasma

To check for the Oracle used by the xUSD market, 

1/Visit the Oracle Router for this market here (found on the bottom of the page)[Plasmascan](https://plasmascan.to/address/0xB9c2Cc549bD00FC2e733EC1dA47b0A088D4163B6)
2/Call getConfiguredOracle with params base - 0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C(underlying xUSD address) & quote as 0x0000000000000000000000000000000000000348
3/ above call returns the ChainlinkInfrequentOracle adapter address [Plasmascan](https://plasmascan.to/address/0x399B7dfb817D0f1c61BdfEA2de6C23cdFB946389)
4/ Call feed() on this contract which returns https://plasmascan.to/address/0x51d947B18f546696c31d9a1c81B55d84e6d8e959/contract/9745/code which is a feed maintained by eOracle. 

You can find eOracle feed addresses on Plasma here https://docs.eo.app/docs/eprice/feeds-addresses/price-feed-addresses/plasma. 

