### PR TITLE
add eOracle to Edge Capital TAC

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -23625,7 +23625,7 @@ const data4: Protocol[] = [
       {
         name: "eOracle",
         type: "Primary",
-        proof: [],
+        proof: ["https://github.com/DefiLlama/defillama-server/pull/10777"],
         chains: [{ chain: "TAC" }],
       },
       ],


### PR DESCRIPTION
Edge Capital's Euler cluster on TAC is secured by eOracle. https://app.euler.finance/?governor=edge-capital&network=tac

eOracle secures the LBTC, cbBTC & wstETH markets of the Cluster, which combined have majority of the TVL of this cluster, no other oracle secures a higher value on this vault. 

The oracle being used on these markets can be seen on the Euler UI. 


