### PR TITLE
add eOracle re7 plasma

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15873,8 +15873,9 @@ const data4: Protocol[] = [
         proof: [
           "https://app.euler.finance/?governor=re7-labs&network=tac",
           "https://github.com/DefiLlama/defillama-server/pull/10515",
+          "https://github.com/DefiLlama/defillama-server/pull/10780" // plasma chain
         ],
-        chains: [{ chain: "TAC" }],
+        chains: [{ chain: "TAC" },{chain: "Plasma"}],
       },
       {
         name: "Chainlink",
@@ -15884,12 +15885,6 @@ const data4: Protocol[] = [
           "https://app.morpho.org/base/earn",
         ],
         chains: [{ chain: "Polygon" }, { chain: "Base" }],
-      },
-      {
-        name: "eOracle",
-        type: "Primary",
-        proof: [],
-        chains: [{ chain: "Plasma" }],
       },
     ],
     module: "re7/index.js",


### PR DESCRIPTION
eOracle secures Re7s plasma vault https://app.euler.finance/vault/0x8AdB906421f65C27155f44f1829Ca1E5B024c3F6?network=plasma

eOracle provides the feed for the collateral asset ie xUSD for this vault, 

This can be verified by - 
1/visit the oracle router here https://plasmascan.to/address/0x6e59D9BA9357ee336E7177472f9a9Fdd3952B899
2/the above returns the ChainlinkinfrequentOracle adapter https://plasmascan.to/address/0x399B7dfb817D0f1c61BdfEA2de6C23cdFB946389
3/ call feed() and it ruturns https://plasmascan.to/address/0x51d947B18f546696c31d9a1c81B55d84e6d8e959
which is the xUSD/USD feed maintained by eOracle. 


You can find eOracle plasma feeds here https://docs.eo.app/docs/eprice/feeds-addresses/price-feed-addresses/plasma


