### PR TITLE
Add Edge Oracle to EtherFi Cash 

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -19869,6 +19869,13 @@ const data4: Protocol[] = [
       Scroll: ["LIQUIDETH", "LIQUIDUSD", "LIQUIDBTC", "EBTC"],
     },
     listedAt: 1751313277,
+    oraclesBreakdown: [
+      {
+        name: "Edge",
+        type: "Primary",
+        proof: ["https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations"],
+      },
+    ],
   },
   {
     id: "6373",
@@ -19890,6 +19897,13 @@ const data4: Protocol[] = [
     forkedFrom: [],
     parentProtocol: "parent#etherfi-cash",
     listedAt: 1751313285,
+    oraclesBreakdown: [
+      {
+        name: "Edge",
+        type: "Primary",
+        proof: ["https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations"],
+      },
+    ],
   },
   {
     id: "6374",


### PR DESCRIPTION
**Oracle Provider(s):** Edge

**Implementation Details:** Used as the price oracle for EtherFi Cash on Scroll

**Documentation/Proof:** https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations

See the following (accidently closed) PR for relevant details & recent comments: https://github.com/DefiLlama/defillama-server/pull/10407#issuecomment-3191697908