### PR TITLE
update ease url

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -18306,7 +18306,7 @@ const data2: Protocol[] = [
     name: "Ease.org",
     address: "0xEa5eDef1287AfDF9Eb8A46f9773AbFc10820c61c",
     symbol: "EASE",
-    url: "https://ease.org",
+    url: "https://easedefi.org",
     description:
       "Ease is a decentralized coverage protocol that enables users to protect their DeFi tokens without a premium while earning compounding yield.",
     chain: "Ethereum",


### PR DESCRIPTION
The domain change was [announced](https://x.com/EaseDeFi/status/1953924381123789186) on their [Twitter](https://x.com/EaseDeFi).