### PR TITLE
fix: update Lumi Finance category from Algo-Stables to Gaming

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -27896,7 +27896,7 @@ const data3_1: Protocol[] = [
     audit_note: null,
     gecko_id: "lumi-finance",
     cmcId: "30333",
-    category: "Algo-Stables",
+    category: "Gaming",
     forkedFrom: [],
     chains: ["Arbitrum"],
     module: "lumi-finance/index.js",


### PR DESCRIPTION
Fixes #16134

## Changes
- Updated Lumi Finance category from "Algo-Stables" to "Gaming"

## Reasoning
Lumi Finance is described as "a crucial component of the Lumiterra game flywheel" and should be categorized as a Gaming protocol rather than an algorithmic stablecoin protocol.

## Testing
- Verified only the category field was changed in data3.ts
- No other files or lines were modified