### PR TITLE
Add Parallel Protocol V3 to DIA Oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -22997,6 +22997,12 @@ const data4: Protocol[] = [
     audit_links: ["https://docs.parallel.best/resources/security-audits"],
     parentProtocol: "parent#parallel-protocol",
     listedAt: 1753821437,
+    oraclesBreakdown: [
+      {
+        name: "DIA",
+        type: "Primary",
+        proof: ["https://gov.parallel.best/t/pgp-34-l-launch-parallel-stablecoins-price-feeds-using-dia/488"]
+      }
   },
   {
     id: "6501",


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Parallel Protocol to DIA Oracles TVS.

Oracles: DIA

Implementation Details: DIA is supporting Parallel Protocol markets for all their price feeds on all chains.

Documentation: https://gov.parallel.best/t/pgp-34-l-launch-parallel-stablecoins-price-feeds-using-dia/488 & https://docs.parallel.best/developers-hub/parallel-v3/onchain-tools/oracles#dia

Thank you,
Josh