### PR TITLE
Fix: Restore price data for nDEPS token (#9832)

### DIFF
--- a/coins/src/adapters/other/manualInput.ts
+++ b/coins/src/adapters/other/manualInput.ts
@@ -165,6 +165,12 @@ const contracts: { [chain: string]: TokenInfo[] } = {
       decimals: 18,
       redirect: "coingecko#gho",
     },
+    {
+      symbol: "nDEPS",
+      address: "0xc71104001a3ccda1bef1177d765831bd1bfe8ee6",
+      decimals: 18,
+      redirect: "coingecko#native-decentralized-euro-protocol-share",
+    },
   ],
 };
 


### PR DESCRIPTION
Problem
The DeFi Llama price API endpoint was returning empty results for the nDEPS token (Native Decentralized Euro Protocol Share):

Token address: 0xc71104001a3ccda1bef1177d765831bd1bfe8ee6 (Ethereum)
API response: {"coins":{}}
This was causing incorrect TVL calculations for the dEURO protocol

Solution
Added nDEPS to the manualInput adapter with a redirect to its CoinGecko listing. This allows the price API to fetch current price data from CoinGecko.
Changes

File: coins/src/adapters/other/manualInput.ts
Change: Added nDEPS token entry to the ethereum array with:

Symbol: nDEPS
Address: 0xc71104001a3ccda1bef1177d765831bd1bfe8ee6
Decimals: 18
Redirect: coingecko#native-decentralized-euro-protocol-share



Verification

- Token exists and is active on [CoinGecko](https://www.coingecko.com/en/coins/native-decentralized-euro-protocol-share)
- Contract verified on [Etherscan](https://etherscan.io/token/0xc71104001a3ccda1bef1177d765831bd1bfe8ee6)
- Token has 18 decimals (standard ERC-20)
- Follows the same pattern used for other tokens in the file (GHO, eETH, etc.)
- TypeScript compilation shows no syntax errors in the modified file

Note
The established pattern used successfully for 20+ other tokens in the same adapter file, making it a low-risk configuration change.
Impact
This fix will restore price data for the nDEPS token and resolve the TVL calculation issues for the dEURO protocol adapter.
Fixes #9832