### PR TITLE
Edge -> Chaos Rebrand

### DIFF
--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -520,6 +520,23 @@ const chainsByOracle: Record<string, Array<string>> = {
   ],
   "Quex": [
     "Arbitrum",
+  ],
+  "Chaos": [
+    "Arbitrum",
+    "Solana",
+    "Avalanche",
+    "Ethereum",
+    "Corn",
+    "Ink",
+    "Scroll",
+    "Botanix",
+    "BSC",
+    "Optimism",
+    "Linea",
+    "Base",
+    "Polygon",
+    "OP Mainnet",
+    "Gnosis"
   ]
 };
 

--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -8275,7 +8275,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     twitter: "BenqiFinance",
     audit_links: ["https://docs.benqi.fi/risks#audits"],
     oraclesBreakdown: [
-      { name: "Edge", type: "Primary", proof: ["https://docs.benqi.fi/resources/contracts/price-feeds"] },
+      { name: "Chaos", type: "Primary", proof: ["https://docs.benqi.fi/resources/contracts/price-feeds"] },
       { name: "Chainlink", type: "Fallback", proof: ["https://docs.benqi.fi/resources/contracts/price-feeds"] }
     ],
     forkedFromIds: ["114"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -15728,7 +15728,7 @@ const data3_1: Protocol[] = [
     twitter: "GMX_IO",
     forkedFrom: [],
     // https://x.com/GMX_IO/status/1866794916392874021 https://gov.gmx.io/t/implementation-of-chaos-labs-risk-oracles/3861
-    oracles: ["Chainlink","Edge"],
+    oracles: ["Chainlink","Chaos"],
     oraclesBreakdown: [
       {
         name: "Chainlink",
@@ -15736,7 +15736,7 @@ const data3_1: Protocol[] = [
         proof: ["https://docs.gmx.io/docs/intro"]
       },
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://x.com/GMX_IO/status/1866794916392874021", "https://gov.gmx.io/t/implementation-of-chaos-labs-risk-oracles/3861"]
       }
@@ -32451,10 +32451,10 @@ const data3_1: Protocol[] = [
     category: "Derivatives",
     chains: ["Solana"],
     // https://support.jup.ag/hc/en-us/articles/19355326396700-Jupiter-Perpetuals-price-oracles
-    oracles: ["Edge"],
+    oracles: ["Chaos"],
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://support.jup.ag/hc/en-us/articles/19355326396700-Jupiter-Perpetuals-price-oracles"]
       },
@@ -62593,7 +62593,7 @@ const data3_2: Protocol[] = [
     forkedFrom: [],
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://x.com/AdrenaProtocol/status/1925828470573076631"],
         startDate: "2025-05-23"

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15973,7 +15973,7 @@ const data4: Protocol[] = [
         chains: [{ chain: "Base" }],
       },
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: [
           "https://cornscan.io/address/0xFe423163bfEe287a132E656D5EC4a363B8A2B4f3/contract/21000000/readContract#F1",
@@ -19896,7 +19896,7 @@ const data4: Protocol[] = [
     listedAt: 1751313277,
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations","https://github.com/DefiLlama/defillama-server/pull/10407"],
       },
@@ -19924,7 +19924,7 @@ const data4: Protocol[] = [
     listedAt: 1751313285,
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://etherfi.gitbook.io/etherfi/contracts-and-integrations/integrations","https://github.com/DefiLlama/defillama-server/pull/10407"],
       },
@@ -23881,7 +23881,7 @@ const data4: Protocol[] = [
     },
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://arbiscan.io/address/0x7b09d87945102d25069c173ee45db397c6e055b3#readContract#F4","https://github.com/DefiLlama/defillama-server/pull/10782"],
       },
@@ -31714,7 +31714,7 @@ const data4: Protocol[] = [
     twitter: "tydrohq",
     oraclesBreakdown: [
       {
-        name: "Edge",
+        name: "Chaos",
         type: "Primary",
         proof: ["https://docs.tydro.com/primitives/oracle"],
       },


### PR DESCRIPTION
**Oracle Provider(s):** Edge Oracle -> now Chaos Oracle

**Implementation Details:** n/a

**Documentation/Proof:** 
- see redirect: edgebychaos.com -> https://oracles.chaoslabs.xyz/home
- also see recent announcement: https://x.com/chaos_labs/status/1978788189100761092