### PR TITLE
Update Re7 description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15869,6 +15869,19 @@ const data4: Protocol[] = [
     chains: ["Ethereum", "Base", "Sonic", "Berachain", "Binance", "Plume Mainnet", "TAC", "Plasma"],
     forkedFrom: [],
     oraclesBreakdown: [
+         {
+        name: "Chronicle",
+        type: "Primary",
+        proof: [
+          "https://berascan.com/address/0x83348bef4994abfc11af0790ca83fa5f582b77ae",
+          "https://berascan.com/address/0x4d210d0d7cb11eae6f3b970cfa68594a71564310",
+          "https://berascan.com/address/0x7614a738accc2ed7234638250e769f72bcbc3880",
+          "https://berascan.com/address/0x9fbecbf8cb18170ae52cd5bbde09fe918d1dbbf9",
+          "https://berascan.com/address/0xe3822ff32fdb60a263df046f5bee6c3cb51e3e1b",
+          "https://berascan.com/address/0x6d34d7b10ddfc1875da4455ce58f90ca97b4e669"
+        ],
+        chains: [{ chain: "Berachain" }],
+      },
       {
         name: "Stork",
         type: "Primary",


### PR DESCRIPTION
Hello, Llamas. Opening a PR to add Chronicle as oracle for Re7 on Berachain.

These markets are using the MorphoChainlinkOracleV2 wrapper. The oracle under the hood can be found by looking in the **Read contract** section at **Base_Feed_1** (eg: for the https://berascan.com/address/0x83348bef4994abfc11af0790ca83fa5f582b77ae we see that the corresponding oracle is [
Chronicle_WGBERA_USD_1 ](https://berascan.com/address/0x34F13852066A5F9D386db0899E814E1EA9B282f9)