### PR TITLE
Update DIA Oracles as Primary on Zest

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -40706,7 +40706,7 @@ const data3_2: Protocol[] = [
       },
       {
         name: "DIA",
-        type: "Secondary",
+        type: "Primary",
         proof: ["https://explorer.hiro.so/txid/SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.alex-oracle-v1-1?chain=mainnet","https://github.com/DefiLlama/defillama-server/pull/10672"]
       },
     ],


### PR DESCRIPTION
Hello,

Wanting to update DIA oracles as a Primary oracle provider for Zest from secondary - as we are securing the protocol and can result in a loss of funds. DIA secures the feeds for all tokens (minus STX) which is >50% of the overall market TVL.

ref: https://github.com/DefiLlama/defillama-server/pull/10672

Thank you!