### PR TITLE
Update MEV Capital description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15809,6 +15809,15 @@ const data4: Protocol[] = [
         ],
         chains: [{ chain: "Unichain" }],
       },
+         {
+        name: "Chronicle",
+        type: "Primary",
+        proof: [
+          "https://arbiscan.io/address/0x69a351bf446b5997642477bcb95979a89ac78c17#code",
+          "https://arbiscan.io/address/0x8db25afe02c20783c7d4b52c738f8a560d53cdf9#code"
+        ],
+        chains: [{ chain: "Arbitrum" }],
+      },
       {
         name: "eOracle",
         type: "Primary",


### PR DESCRIPTION
Hello, Llamas. Opening a PR to add Chronicle as oracle for MEV Capital on Arbitrum.

These markets are using the MorphoChainlinkOracleV2 wrapper. The oracle under the hood can be found by looking in the _Read contract_ section at _Base_Feed_1_ (eg: for the https://arbiscan.io/address/0x8db25afe02c20783c7d4b52c738f8a560d53cdf9#code we see that the corresponding oracle is
[Chronicle_SUSDAI_USD_1](https://arbiscan.io/address/0x5e55bDDa344D077975BfC7ddDeC89d88DA733E9a#code)