### PR TITLE
Update Hyperithm description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -15696,6 +15696,16 @@ const data4: Protocol[] = [
     forkedFrom: [],
     module: "hyperithm/index.js",
     twitter: "hyperithm",
+      oraclesBreakdown: [
+      {
+        name: "Chronicle",
+        type: "Primary",
+        proof: [
+          "https://arbiscan.io/address/0x52dea1e79273887ad0bdf3faf3904351ae9460e0#readContract",
+        ],
+        chains: [{ chain: "Arbitrum" }],
+      },
+    ],
     listedAt: 1747734486,
     dimensions: {
       fees: "hyperithm"


### PR DESCRIPTION
Hello, Llamas. Opening a PR to add Chronicle as oracle for Hyperithm on Arbitrum.

These markets are using the MorphoChainlinkOracleV2 wrapper. The oracle under the hood can be found by looking in the Read contract section at Base_Feed_1 (eg: for the https://arbiscan.io/address/0x52dea1e79273887ad0bdf3faf3904351ae9460e0#readContract we see that the corresponding oracle is
[Chronicle_WSRUSD_USD_1](https://arbiscan.io/address/0x5e1a2a77D4df85d3C0907715ED616e0B04eE51Dd)