### PR TITLE
Update Oracles for Takara.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5399,18 +5399,23 @@ const data4: Protocol[] = [
     chains: ["Sei"],
     oraclesBreakdown: [
       {
-        name: "Api3",
+        name: "RedStone",
         type: "Primary",
         proof: [
           "https://takara.gitbook.io/takara-lend/protocol-information/security#takara-security-measures",
-          "https://app.takaralend.com/market/WSEI",
-          "https://app.takaralend.com/market/spSEI",
-          "https://app.takaralend.com/market/iSEI",
+          "https://app.takaralend.com/market/enzoBTC",
           "https://app.takaralend.com/market/uBTC",
+          "https://app.takaralend.com/market/USD%E2%82%AE0",
           "https://app.takaralend.com/market/MBTC",
-          "https://app.takaralend.com/market/SBTC",
+          "https://app.takaralend.com/market/USDC",
         ],
       },
+          {
+        name: "Api3",
+        type: "Fallback",
+        proof: [https://app.takaralend.com/
+          ,
+        ],
       {
         name: "Pyth",
         type: "Fallback",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Takara Lend on Sei. After issues with previous provider Takara switched to RedStone on all major markets (and will continue to switch on other feeds).

Oracle Provider(s): RedStone

Implementation Details: Takara switched to RedStone push feeds as the primary solution for major assets: EnzoBTC (30,2m), UBTC (28,1m), USDT (23,3m), USDC (5,7m) which represent ~87,3m/150m ~58,2% of their tvl

Documentation/Proof:
 "https://app.takaralend.com/market/enzoBTC",
          "https://app.takaralend.com/market/uBTC",
          "https://app.takaralend.com/market/USD%E2%82%AE0",
          "https://app.takaralend.com/market/MBTC",
          "https://app.takaralend.com/market/USDC",