### PR TITLE
Add PumpSpace and AquaBank metadata entries (Avalanche)

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -32563,7 +32563,7 @@ const data4: Protocol[] = [
     audit_note: null,
     gecko_id: "",
     cmcId: "",
-    category: "Dexes",
+    category: "Yield",
     chains: ["Avalanche"],
     module: "aquaspace/index.js",
     twitter: "Aquabank2025",


### PR DESCRIPTION
This PR adds official metadata entries for two Avalanche-based protocols: PumpSpace and AquaBank.

Added new metadata entries (id: 6909 for PumpSpace, id: 6910 for AquaBank) in data2.ts.
Included full audit references, icons, and verified URLs.