### PR TITLE
fix - Timeout Handler Not Awaiting Async Cleanup 

### DIFF
--- a/defi/src/storeTvlTask.ts
+++ b/defi/src/storeTvlTask.ts
@@ -263,7 +263,7 @@ process.on('uncaughtException', (err) => {
 
 setTimeout(async () => {
   console.log('Timeout! Shutting down...');
-  preExit()
+  await preExit()
   process.exit(1);
 }, 1000 * 60 * 45); // 45 minutes
 


### PR DESCRIPTION
`preExit()` is NOT awaited before `process.exit(1)`. 

This means when the 45-minute timeout fires, the process exits immediately without waiting for:
- SDK cache to be saved to R2 storage
- Any in-flight database writes to complete

This can cause data loss - cached adapter responses and computation results are lost, forcing re-computation on next run.