### PR TITLE
Perf - prevent memory leak in withTimeout utility

### DIFF
--- a/defi/src/utils/shared/withTimeout.ts
+++ b/defi/src/utils/shared/withTimeout.ts
@@ -1,9 +1,13 @@
 export const withTimeout = (millis: number, promise: any, id: string = "") => {
-  const timeout = new Promise((resolve, reject) =>
-    setTimeout(() => {
+  let timeoutId: NodeJS.Timeout;
+  
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
       reject(`${id} timed out after ${millis / 1000} s.`);
-      resolve;
-    }, millis)
-  );
-  return Promise.race([promise, timeout]);
+    }, millis);
+  });
+  
+  return Promise.race([promise, timeout]).finally(() => {
+    clearTimeout(timeoutId);
+  });
 };


### PR DESCRIPTION

The `withTimeout` function creates a timeout promise that rejects after a delay, but the `resolve` callback is placed on a separate line without being called. This means the timeout is never cleared even when the main promise completes first,  this can cause memory leaks and zombie timers.

Fix :
- Store setTimeout ID and clear it when promise race completes
- Use .finally() to ensure cleanup in all cases
- Remove unused resolve reference