### PR TITLE
Added Koala Governance Token

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -9259,6 +9259,12 @@
       "to": "coingecko#wrapped-bitcoin",
       "decimals": 8,
       "symbol": "WBTC"
+    },
+    "0x2689fAabe22Ec4516d716Da5B5f81e7e3aE379c3": {
+      "name": "Koala Governance Token",
+      "decimals": "18",
+      "symbol": "koala",
+      "to": "coingecko#koala-governance-token"
     }
   },
   "rbn": {


### PR DESCRIPTION
Koala-KOALA – Koala Governance Token on Unit0 blockchain.
Proof of reserves / token explorer: https://explorer.unit0.dev/token/0x2689fAabe22Ec4516d716Da5B5f81e7e3aE379c3