### PR TITLE
Update FOOM.Cash category

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -374,7 +374,7 @@ const data5: Protocol[] = [
     audit_note: null,
     gecko_id: null,
     cmcId: null,
-    category: "Luck Games",
+    category: "Privacy",
     chains: ["Ethereum", "Base"],
     forkedFrom: [],
     module: "foom-cash/index.js",


### PR DESCRIPTION
Update FOOM.Cash category to _Privacy_; the protocol needs to be classified under _Privacy_ instead of _Luck Games_, since its primary focus is on privacy features. Because only one category can be selected on DefiLlama, _Privacy_ is the more accurate choice. As a zero-knowledge product, FOOM.Cash is fundamentally privacy-first.