### PR TITLE
Add previousNames mapping for Save (formerly Solend) for search discoverability

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -8056,6 +8056,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     id: "458",
     // previous Solend
     name: "Save",
+    previousNames: ["Solend"],
     address: "solana:SAVEaeeqeXNKYb4Lyx28DkUms5gyZ76vGa6fCfdzWfK",
     symbol: "SAVE",
     url: "https://www.save.finance/",


### PR DESCRIPTION
- Added `previousNames: ["Solend"]` to the Save protocol (id: "458") in `defillama-server/defi/src/protocols/data1.ts.`

- Ensures searches for “solend” resolve to the current protocol “Save” via the API cache and search index.
