### PR TITLE
Update oracles for Takara.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5417,6 +5417,17 @@ const data4: Protocol[] = [
     category: "Lending",
     chains: ["Sei"],
     oraclesBreakdown: [
+       {
+        name: "RedStone",
+        type: "Primary",
+        proof: [
+         "https://app.takaralend.com/market/enzoBTC",
+"https://app.takaralend.com/market/uBTC",
+"https://app.takaralend.com/market/USD%E2%82%AE0",
+"https://app.takaralend.com/market/MBTC",
+"https://app.takaralend.com/market/USDC",
+        ],
+         startDate: "2025-11-12",
       {
         name: "Api3",
         type: "Primary",
@@ -5429,6 +5440,7 @@ const data4: Protocol[] = [
           "https://app.takaralend.com/market/MBTC",
           "https://app.takaralend.com/market/SBTC",
         ],
+         endDate: "2025-11-12",
       },
       {
         name: "Pyth",


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Takara Lend on Sei. After issues with previous provider Takara switched to RedStone on all major markets (and will continue to switch on other feeds).

Oracle Provider(s): RedStone

Implementation Details: Takara switched to RedStone push feeds as the primary solution for major assets: EnzoBTC (28,3m), M-BTC (17,6m), USDT (8,7m), USDC (2,4m) which represent ~57m/81,9m ~70% of their tvl

Documentation/Proof:
"https://app.takaralend.com/market/enzoBTC",
"https://app.takaralend.com/market/uBTC",
"https://app.takaralend.com/market/USD%E2%82%AE0",
"https://app.takaralend.com/market/MBTC",
"https://app.takaralend.com/market/USDC",