### PR TITLE
Remove surf-liquid listing

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -29335,28 +29335,6 @@ const data4: Protocol[] = [
     }
   },
   {
-    id: "6765",
-    name: "Surf Liquid",
-    address: null,
-    symbol: "-",
-    url: "https://surfliquid.com/",
-    description:
-      "SurfLiquid is an AI-powered DeFi platform designed to automate and optimise yield generation across the most profitable opportunities in decentralised finance.",
-    chain: "Base",
-    logo: `${baseIconsUrl}/surf-liquid.jpg`,
-    audits: "0",
-    audit_note: null,
-    gecko_id: null,
-    cmcId: null,
-    category: "Yield",
-    chains: ["Base"],
-    forkedFromIds: [],
-    module: "surf-liquid/index.js",
-    twitter: "Surf_Liquid",
-    audit_links: [],
-    listedAt: 1758736221
-  },
-  {
     id: "6766",
     name: "set.wtf",
     address: null,


### PR DESCRIPTION
This PR removes the surf-liquid protocol listing from DefiLlama as requested for delisting.
## Remove surf-liquid adapter

This PR removes the surf-liquid adapter as requested by the DefiLlama team for delisting.

### Protocol Information (being removed):
- **Name**: Surf liquid
- **Website**: https://surfliquid.com
- **Chain**: Base
- **Category**: Liquid Staking
- **Current TVL**: $20.06k
- **Treasury Address**: 0x663585f2464b673efbe6f46af2c0e2514a6f199a
- **Description**: Liquid staking protocol on Base chain
- **Oracle Provider**: Chainlink
- **Implementation**: Vault-based liquid staking protocol integrated into Base ecosystem

### Changes:
- Deleted `projects/surf-liquid/index.js` adapter

### Reason:
Delisting request from DefiLlama team.