### PR TITLE
Feat: Add Kadena as deadChain

### DIFF
--- a/defi/src/storeTvlInterval/getAndStoreTvl.ts
+++ b/defi/src/storeTvlInterval/getAndStoreTvl.ts
@@ -177,7 +177,7 @@ type StoreTvlOptions = {
   isRunFromUITool?: boolean
 }
 
-export const deadChains = new Set(['heco', 'astrzk', 'real', 'milkomeda', 'milkomeda_a1', 'eos_evm', 'eon', 'plume', 'bitrock', 'rpg'])
+export const deadChains = new Set(['heco', 'astrzk', 'real', 'milkomeda', 'milkomeda_a1', 'eos_evm', 'eon', 'plume', 'bitrock', 'rpg', 'kadena'])
 
 export type storeTvl2Options = StoreTvlOptions & {
   unixTimestamp: number,


### PR DESCRIPTION
> Kadena has recently halted operations on their chain; there haven’t been any new blocks produced for a few days now