### PR TITLE
feat: add AntFun protocol listing

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -3558,5 +3558,30 @@ const data5: Protocol[] = [
     audit_links: [],
     listedAt: 1764008747,
   },
+  {
+    id: "7044",
+    name: "AntFun",
+    address: null,
+    symbol: "-",
+    url: "https://ant.fun",
+    description:
+      "Ant.fun is a mobile-first decentralized trading app offering real-time on-chain swap analysis and cross-chain execution across major networks. It intelligently surfaces trending tokens and high-signal opportunities, helping users choose better targets and improve their trading profitability.",
+    chain: "Solana",
+    logo: `${baseIconsUrl}/antfun.jpg`,
+    audits: "0",
+    audit_note: null,
+    gecko_id: null,
+    cmcId: null,
+    category: "Trading App",
+    chains: ["Solana"],
+    module: "dummy.js",
+    twitter: "ant_fun_trade",
+    forkedFromIds: [],
+    audit_links: [],
+    dimensions: {
+      fees: "antfun"
+    },
+    listedAt: 1764064269,
+  },
 ];
 export default data5;


### PR DESCRIPTION
## Summary
Add protocol listing for AntFun (ant.fun) trading app.

## Details
- **Protocol Name**: AntFun
- **Website**: https://ant.fun
- **Twitter**: @ant_fun_trade
- **Category**: Trading App
- **Chain**: Solana
- **Logo**: https://ant.fun/logo-512.png
- **Description**: Ant.fun is a mobile-first decentralized trading app offering real-time on-chain swap analysis and cross-chain execution across major networks.

## Related PRs
- Fees adapter: https://github.com/DefiLlama/dimension-adapters/pull/4734

## Dimensions
- Fees: antfun (adapter already submitted in dimension-adapters repo)

**Please enable "Allow edits by maintainers" for this PR.**