### PR TITLE
Update Beraborrow description

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -4564,16 +4564,26 @@ const data4: Protocol[] = [
     oraclesBreakdown: [
       {
         name: "RedStone",
-        type: "Secondary",
+        type: "Primary",
         proof: [
           "https://app.redstone.finance/app/feeds/?page=1&sortBy=popularity&sortDesc=false&perPage=32&networks=80094",
           "https://berascan.com//address/0x83c6f7F61A55Fc7A1337AbD45733AD9c1c68076D",
         ],
+        endDate: "2025-12-04"
       },
       {
         name: "Chronicle",
         type: "Primary",
         proof: ["https://beraborrow.gitbook.io/docs/pricing-assets#single-sided-assets"],
+        startDate: "2025-12-04"
+      },
+      {
+        name: "RedStone",
+        type: "Secondary",
+        proof: [
+          "https://app.redstone.finance/app/feeds/?page=1&sortBy=popularity&sortDesc=false&perPage=32&networks=80094",
+          "https://berascan.com//address/0x83c6f7F61A55Fc7A1337AbD45733AD9c1c68076D",
+        ],
       },
     ],
     forkedFrom: [],


### PR DESCRIPTION
Currently the TVL of Beraborrow comes primarily from the [uniBTC vault](https://app.beraborrow.com/managed-vault/deposit/uniBTC) - 40.54M out of total of total [42.2M](https://defillama.com/protocol/beraborrow) in total. The uniBTC vault is secured by Chronicle, as mentioned in the [docs](https://beraborrow.gitbook.io/docs/pricing-assets#single-sided-assets).