### PR TITLE
Update Oracles for Neverland.ts

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -2772,9 +2772,9 @@ const data5: Protocol[] = [
     audit_links: ["https://github.com/Neverland-Money/security-audits"],
     oraclesBreakdown: [
       {
-        name: "Chainlink",
+        name: "RedStone",
         type: "Primary",
-        proof: ["https://docs.neverland.money", "https://github.com/DefiLlama/DefiLlama-Adapters/pull/17018"],
+        proof: ["https://docs.neverland.money/smart-contracts#oracle-system"],
       },
     ],
     module: "neverland/index.js",


### PR DESCRIPTION
Hey Lamas,

Kindly asking you to update Oracles for NeverLand

Oracle Provider(s): RedStone.

Implementation details: NeverLand is using RedStone their primary Oracle on Monad.

Documenation/Proof: https://docs.neverland.money/smart-contracts#oracle-system
