### PR TITLE
kaching: proper audit URL updated

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -3666,7 +3666,7 @@ const data5: Protocol[] = [
     twitter: "kachingvip",
     forkedFromIds: [],
     audit_links: [
-      "https://github.com/kaching-contract-audit-report.pdf",
+      "https://github.com/KachingSupport/kaching_audit_report",
     ],
     listedAt: 1764008727,
   },


### PR DESCRIPTION
This PR is raised by the Kaching team. We want to update the audit URL to the proper official link instead of using a personal GitHub URL.