### PR TITLE
Add Chaos Oracle to Nado Perps

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -5041,6 +5041,7 @@ const data5: Protocol[] = [
     chains: ["Ink"],
     module: "dummy.js", 
     twitter: "nadohq",
+    oraclesBreakdown: [{ name: "Chaos", type: "Primary", proof: ["https://docs.nado.xyz/oracles#how-nados-oracle-model-works"] }],
     forkedFromIds: [],
     parentProtocol: "parent#nado",
     dimensions: {


### PR DESCRIPTION
Oracle Provider(s): Chaos Oracle

Implementation Details: Oracles update continuously via Nado's sequencer, bundling prices with actions for seamless on-chain settlement on the Ink L2 – minimizing gas and maximizing precision across Nado markets.

Documentation/Proof: https://docs.nado.xyz/oracles#how-nados-oracle-model-works