### PR TITLE
Rename Mantle Restaking to mETH Protocol

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -62710,11 +62710,12 @@ const data3_3: Protocol[] = [
   },
   {
     id: "5351",
-    name: "Mantle Restaking",
+    name: "mETH Protocol",
+    previousNames: ["Mantle Restaking"],
     address: null,
     symbol: "-",
     assetToken: "mETH",
-    url: "https://meth.mantle.xyz/restake",
+    url: "https://www.methprotocol.xyz/",
     description:
       "Liquid Restaking on Ethereum",
     chain: "Ethereum",
@@ -62726,8 +62727,9 @@ const data3_3: Protocol[] = [
     category: "Liquid Restaking",
     chains: ["Ethereum"],
     module: "mantle-restaking/index.js",
-    twitter: "Mantle_Official",
+    twitter: "mETHProtocol",
     forkedFrom: [],
+    audit_links: ["https://docs.mantle.xyz/meth/security/audits"],
     listedAt: 1731495743
   },
   {


### PR DESCRIPTION
Mantle Restaking was rebranded to mETH Protocol on 2024-08-19. For more details see https://docs.mantle.xyz/meth/introduction/timeline#id-2024-08-19.