### PR TITLE
Update Oracles for Curvance.ts

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -3986,6 +3986,12 @@ const data5: Protocol[] = [
     module: "curvance/index.js",
     twitter: "Curvance",
     forkedFromIds: [],
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://docs.curvance.com/cve/developer-docs/copy-of-dynamic-liquidation-engine-dle/orderflow-auction-system#oracle-data-flow"]
+      }
     audit_links: [
       "https://github.com/curvance/curvance-contracts/tree/develop/contracts/audits",
       "https://docs.curvance.com/cve/security/bug-bounty-and-audits",


### PR DESCRIPTION
Hey Lamas,

Kindly asking you to update Oracles for Curvance

Oracle Provider(s): RedStone.

Implementation details: Curvance leverages RedStone as it's primary data provider across all feeds.

Documenation/Proof: https://docs.curvance.com/cve/developer-docs/copy-of-dynamic-liquidation-engine-dle/orderflow-auction-system#oracle-data-flow

"RedStone push feeds are the primary integration target."
