### PR TITLE
Add Chaos Oracle to Hyena

### DIFF
--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -537,7 +537,8 @@ const chainsByOracle: Record<string, Array<string>> = {
     "Base",
     "Polygon",
     "OP Mainnet",
-    "Gnosis"
+    "Gnosis",
+    "Hyperliquid L1"
   ]
 };
 

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -4951,6 +4951,7 @@ const data5: Protocol[] = [
     module: "dummy.js",
     twitter: "hyenatrade",
     audit_links: [],
+    oraclesBreakdown: [{ name: "Chaos", type: "Primary", proof: ["https://docs.hyena.trade/trading/oracle-price-and-mark-price"] }],
     parentProtocol: "parent#based",
     dimensions: {
       derivatives: "hyena",


### PR DESCRIPTION
Oracle Provider(s): Chaos Oracle

Implementation Details: 
Chaos Labs is the primary oracle updater for HyENA perps. HyENA is also running with a backup oracle provider as failsafe.

Oracle price is used to compute funding rates and is also a component of the mark price calculation. On Hyperliquid, the oracle price is a weighted median of CEX prices. Oracle prices are updated by the validators approximately once every three seconds.

Documentation/Proof: https://docs.hyena.trade/trading/oracle-price-and-mark-price