### PR TITLE
chore: deprecate yeth project

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -29967,7 +29967,8 @@ const data3_1: Protocol[] = [
       "https://chainsecurity.com/security-audit/yearn-yeth-governance/",
       "https://github.com/mixbytes/audits_public/tree/master/Yearn%20Finance/yETH-bootstrap",
     ],
-    parentProtocol: "parent#yearn",
+    // parentProtocol: "parent#yearn",
+    deprecated: true,
     listedAt: 1703852065,
     dimensions: {
       fees: "yearn-ether"


### PR DESCRIPTION
Deprecate the hack yETH project. 

Should we also delete its adapter folder in DefiLlama-adaprters repository? https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/projects/yearn-ether 