### PR TITLE
legit spikes for idle, variational and infinifi

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -1087,8 +1087,11 @@ const data: Protocol[] = [
     ],
     github: ["Idle-Labs"], //check
     dimensions: {
-      fees: "idle"
-    }
+      fees: {
+        adapter: "idle",
+        genuineSpikes: ["1751241600",],
+      },
+    },
   },
   {
     id: "151",

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -16991,7 +16991,10 @@ const data4: Protocol[] = [
     stablecoins: ["infinifi-usd"],
     listedAt: 1748465947,
     dimensions: {
-      fees: "infinifi"
+      fees: {
+        adapter: "infinifi",
+        genuineSpikes: ["1766793600"],
+      },
     }
   },
   {

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -7339,7 +7339,10 @@ const data5: Protocol[] = [
     twitter: "variational_io",
     dimensions: {
       //fees: "variational", 
-      derivatives: "variational-omni"
+      derivatives: {
+        adapter:"variational-omni",
+        genuineSpikes: ["1766793600"],
+      },
     },
     github: ["variational-research"],
   },


### PR DESCRIPTION
Idle : Credit vaults distribute yields at end of month which leads to spike
Variational: New listing , has way more volume than threshold
Infinifi: DSSR had issue before , fixed it which has caused spike