### PR TITLE
fix: off-by-one day data in charts

### DIFF
--- a/defi/src/getCategories.ts
+++ b/defi/src/getCategories.ts
@@ -1,7 +1,7 @@
 import { getCachedHistoricalTvlForAllProtocols, getHistoricalTvlForAllProtocols, IProtocol } from "./storeGetCharts";
 import { successResponse, wrap, IResponse } from "./utils/shared";
 import { extraSections } from "./utils/normalizeChain";
-import { DAY, getClosestDayStartTimestamp } from "./utils/date";
+import { DAY, getTimestampAtStartOfDayUTC } from "./utils/date";
 import { _InternalProtocolMetadata, _InternalProtocolMetadataMap } from "./protocols/data";
 import { hiddenCategoriesFromUISet } from "./utils/excludeProtocols";
 
@@ -105,8 +105,8 @@ export async function getCategoriesInternal({ ...options }: any = {}) {
 
     let previousItem: Item = { SK: 0 }
     protocolTvl.historicalTvl.forEach((item) => {
-      const timestamp = getClosestDayStartTimestamp(item.SK);
-      const previousTimestamp = getClosestDayStartTimestamp(previousItem.SK)
+      const timestamp = getTimestampAtStartOfDayUTC(item.SK);
+      const previousTimestamp = getTimestampAtStartOfDayUTC(previousItem.SK)
       const daysDifference = previousTimestamp ? (timestamp - previousTimestamp) / DAY : 0
 
       for (let i = 1; i < daysDifference; i++) {

--- a/defi/src/getCategoryChartByChainData.ts
+++ b/defi/src/getCategoryChartByChainData.ts
@@ -1,7 +1,7 @@
 import { errorResponse, successResponse } from "./api2/routes/utils";
 import * as HyperExpress from "hyper-express";
 import { sluggifyString } from "./utils/sluggify";
-import { getClosestDayStartTimestamp } from "./utils/date";
+import { getTimestampAtStartOfDayUTC } from "./utils/date";
 import { get20MinDate } from "./utils/shared";
 import { getHistoricalTvlForAllProtocolsOptionalOptions, IProtocol, processProtocols, TvlItem } from "./storeGetCharts";
 import { chainCoingeckoIds, extraSections, getChainDisplayName, transformNewChainName } from "./utils/normalizeChain";
@@ -18,7 +18,7 @@ interface SumCategoriesOrTagsByChainTvls {
 }
 
 function sum(sumDailyTvls: SumCategoriesOrTagsByChainTvls, tvlSection: string, timestampRaw: number, itemTvl: number) {
-  const timestamp = getClosestDayStartTimestamp(timestampRaw);
+  const timestamp = getTimestampAtStartOfDayUTC(timestampRaw);
   if (!sumDailyTvls[tvlSection]) {
     sumDailyTvls[tvlSection] = {};
   }

--- a/defi/src/getSimpleChainDataset.ts
+++ b/defi/src/getSimpleChainDataset.ts
@@ -1,7 +1,7 @@
 import { wrap, IResponse, errorResponse } from "./utils/shared";
 import { getChainDisplayName, chainCoingeckoIds, transformNewChainName, isDoubleCounted } from "./utils/normalizeChain";
 import { getCachedHistoricalTvlForAllProtocols, getHistoricalTvlForAllProtocols } from "./storeGetCharts";
-import { formatTimestampAsDate, getClosestDayStartTimestamp, secondsInHour } from "./utils/date";
+import { formatTimestampAsDate, getTimestampAtStartOfDayUTC, secondsInHour } from "./utils/date";
 import { buildRedirectR2, getR2, storeDatasetR2 } from "./utils/r2";
 import { _InternalProtocolMetadataMap } from "./protocols/data";
 
@@ -48,7 +48,7 @@ export async function getSimpleChainDatasetInternal(rawChain: string, params: an
     const lastTvl = historicalTvl[historicalTvl.length - 1];
 
     while (lastTimestamp < lastDailyTimestamp) {
-      lastTimestamp = getClosestDayStartTimestamp(lastTimestamp + 24 * secondsInHour);
+      lastTimestamp = getTimestampAtStartOfDayUTC(lastTimestamp + 24 * secondsInHour);
       historicalTvl.push({
         ...lastTvl,
         SK: lastTimestamp,
@@ -102,7 +102,7 @@ export async function getSimpleChainDatasetInternal(rawChain: string, params: an
       });
 
       if (dayTvl !== 0) {
-        const timestamp = getClosestDayStartTimestamp(item.SK);
+        const timestamp = getTimestampAtStartOfDayUTC(item.SK);
         if (sumDailyTvls[timestamp] === undefined) {
           sumDailyTvls[timestamp] = {};
         }

--- a/defi/src/storeTvlUtils/craftCsvDataset.ts
+++ b/defi/src/storeTvlUtils/craftCsvDataset.ts
@@ -1,7 +1,7 @@
 import { getHistoricalValues } from "../utils/shared/dynamodb";
 import { Protocol } from "../protocols/data";
 import { dailyTvl, dailyUsdTokensTvl, dailyTokensTvl } from "../utils/getLastRecord";
-import { formatTimestampAsDate, getClosestDayStartTimestamp } from "../utils/date";
+import { formatTimestampAsDate, getTimestampAtStartOfDayUTC } from "../utils/date";
 import { normalizeChain } from "../utils/normalizeChain";
 import { PassThrough } from "stream";
 import { getProtocolAllTvlData } from "../api2/utils/cachedFunctions";
@@ -34,7 +34,7 @@ function addTokenRows(
         grid[nextRowNumber] = [protocol.name, protocol.category, normalizeChainTotal(chain), rowName, token];
         // TODO: Optimize this
         historicalTokenTvls.forEach((historicalTvl) => {
-          const timestamp = getClosestDayStartTimestamp(historicalTvl.SK);
+          const timestamp = getTimestampAtStartOfDayUTC(historicalTvl.SK);
           if (timeToColumn[timestamp] === undefined) {
             timeToColumn[timestamp] = {};
           }
@@ -109,7 +109,7 @@ export default async function (protocols: Protocol[], vertical = false, stream =
         }
         grid[nextRowNumber] = [protocol.name, protocol.category, normalizeChainTotal(chain), "TVL"];
         usd.forEach((historicalTvl) => {
-          const timestamp = getClosestDayStartTimestamp(historicalTvl.SK);
+          const timestamp = getTimestampAtStartOfDayUTC(historicalTvl.SK);
           if (timeToColumn[timestamp] === undefined) {
             timeToColumn[timestamp] = {};
           }


### PR DESCRIPTION
Using `getClosestDayStartTimestamp` was rounding up or down depending on time of day meaning it was possible to get dates in the future. See last item in https://api.llama.fi/lite/charts/Story.

This switches to using `getTimestampAtStartOfDayUTC` instead to always round down to start of the day the data is from.

Same issue was present in a few places, not just /lite/charts/

Fixes #9655 