### PR TITLE
Rename 'StandX Perps' to 'StandX'

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -7988,7 +7988,7 @@ const data5: Protocol[] = [
   },
   {
     id: "7221",
-    name: "StandX Perps",
+    name: "StandX",
     address: null,
     symbol: "-",
     url: "https://standx.com/",


### PR DESCRIPTION
please also help update logo with
https://github.com/standx-labs/stdc_assets/blob/main/images/dusd.png

as it's missing right now.

<img width="720" height="320" alt="image" src="https://github.com/user-attachments/assets/ad0d1323-eff6-4d2f-aa88-27778aa329be" />


