### PR TITLE
Update oracle for beraborrow .ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -4588,7 +4588,7 @@ const data4: Protocol[] = [
       },
       {
         name: "RedStone",
-        type: "Secondary",
+        type: "Primary",
         proof: [
           "https://app.redstone.finance/app/feeds/?page=1&sortBy=popularity&sortDesc=false&perPage=32&networks=80094",
           "https://berascan.com//address/0x83c6f7F61A55Fc7A1337AbD45733AD9c1c68076D",


### PR DESCRIPTION
Hey Llamas,

kindly asking to update beraborrow oracle setup to include RedStone as a primary oracle provider. RedStone Oracle is used for NECT stablecoin which is a primary asset for borrowing across all the markets.


Documenation/Proof: 
https://beraborrow.gitbook.io/docs/pricing-assets#single-sided-assets
https://app.beraborrow.com/dens