### PR TITLE
feat: update Maia DAO Ecosystem projects info

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -111,8 +111,8 @@ const data2: Protocol[] = [
   },
   {
     id: "1384",
-    name: "Hermes Protocol",
-    address: "arbitrum:0x45940000009600102a1c002f0097c4a500fa00ab",
+    name: "Hermes V1",
+    address: "metis:0xb27BbeaACA2C00d6258C3118BAB6b5B6975161c8",
     symbol: "HERMES",
     url: "https://hermes.maiadao.io/",
     description:
@@ -133,7 +133,8 @@ const data2: Protocol[] = [
     parentProtocol: "parent#maia-dao-ecosystem",
     dimensions: {
       dexs: "hermes-protocol"
-    }
+    },
+    deprecated: true
   },
   {
     id: "1385",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -1412,7 +1412,7 @@ const data3_0: Protocol[] = [
   },
   {
     id: "2760",
-    name: "Maia V3",
+    name: "Maia CL",
     address: "metis:0x72c232D56542Ba082592DEE7C77b1C6CFA758BCD",
     symbol: "MAIA",
     url: "https://uni.maiadao.io/#/swap",
@@ -1433,7 +1433,8 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "maia-v3",
       dexs: "maia-v3"
-    }
+    },
+    deprecated: true
   },
   {
     id: "2761",
@@ -58435,7 +58436,8 @@ const data3_3: Protocol[] = [
       "https://code4rena.com/audits/2023-09-maia-dao-ulysses",
       "https://github.com/Zellic/publications/blob/master/Maia%20DAO%20Ulysses%20Protocol%20-%20Zellic%20Audit%20Report.pdf"
     ],
-    listedAt: 1726861385
+    listedAt: 1726861385,
+    deprecated: true
   },
   {
     id: "5164",


### PR DESCRIPTION
update Hermes Protocol to Hermes V1 and mark as deprecated; 

rename Maia V3 to Maia CL and mark as deprecated; 

mark Ulysses as deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hermes Protocol listing: renamed to Hermes V1 with migrated network address.
  * Marked several protocols (including Maia CL, Mooncake, and Vallu) as deprecated or inactive to reflect their current operational status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->