### PR TITLE
chore: update FBTC on Starknet, add USDa on Starknet

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -6224,10 +6224,15 @@
       "decimals": 5,
       "symbol": "EUTBL"
     },
-    "0x062a1600278af88706fab962821051939841a494674319ca19230a784e57bfff": {
+    "0x046e4e83fe6a22f243f73d0f2e4cdbc4e9ebd868050e9f7e9cbd90f1436d8b44": {
       "decimals": "8",
       "symbol": "FBTC",
       "to": "coingecko#ignition-fbtc"
+    },
+    "0x03975bf0ccb0ab5f0a0cc3012234406812824d9d3b890c402ed59609b5f52726": {
+      "decimals": "18",
+      "symbol": "USDa",
+      "to": "coingecko#usda-2"
     }
   },
   "milkomeda": {
@@ -13770,7 +13775,7 @@
       "decimals": 18,
       "symbol": "QUAI"
     }
-  }, 
+  },
   "fogo": {
     "0x0000000000000000000000000000000000000000": {
       "to": "coingecko#fogo",


### PR DESCRIPTION
Update tokens on Starknet: 

- USDa: `0x03975bf0ccb0ab5f0a0cc3012234406812824d9d3b890c402ed59609b5f52726`

- FBTC: `0x046e4e83fe6a22f243f73d0f2e4cdbc4e9ebd868050e9f7e9cbd90f1436d8b44`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for USDa token, expanding available asset options.

* **Chores**
  * Updated FBTC token configuration for improved compatibility.
  * Fixed token mapping file formatting issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->