### PR TITLE
feat: update mapping for HELOC+ pool

### DIFF
--- a/coins/src/adapters/zeroDecimalTokenMapping.json
+++ b/coins/src/adapters/zeroDecimalTokenMapping.json
@@ -41,9 +41,9 @@
             "symbol": "FIGR_HELOC"
         },
         "pm.pool.asset.3hjz8rcr3pejdc3msntlvy": {
-            "to": "coingecko#ylds",
+            "to": "coingecko#figure-heloc",
             "decimals": 0,
-            "symbol": "YLDS"
+            "symbol": "FIGR_HELOC"
         },
         "pm.pool.asset.1y3flutqcyuf8duew1vj2g": {
             "to": "coingecko#ylds",


### PR DESCRIPTION
The HELOC+ pool in the zeroDecimalTokenMapping JSON object should be mapped to the FIGR_HELOC token instead of YLDS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token mapping configuration to use the proper data source reference and updated the associated token symbol for accurate identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->