### PR TITLE
Include Gain TVL in KernelDAO aggregate view

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -55928,10 +55928,7 @@ const data3_3: Protocol[] = [
     module: "kelp-gain/index.js",
     twitter: "KelpDAO",
     parentProtocol: "parent#kelp-dao",
-    listedAt: 1729134534,
-    tokensExcludedFromParent: {
-      Ethereum: ["RSETH"],
-    },
+    listedAt: 1729134534
   },
   {
     id: "5245",

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -5795,7 +5795,7 @@ const parentProtocols: IParentProtocol[] = [
     url: "https://kerneldao.com",
     description:
       "KernelDAO is a suite of top restaking products, with over $2 billion in total value locked and live on 10+ chains including Ethereum, BNB Chain, and expanding further. KernelDAO’s three key products include Kernel, Kelp and Gain.",
-    logo: `${baseIconsUrl}/kerneldao.jpg`,
+    logo: `${baseIconsUrl}/kernel.jpg`,
     gecko_id: 'kernel-2',
     cmcId: '36180',
     chains: [],


### PR DESCRIPTION
Updates KernelDAO’s umbrella protocol mapping so Gain TVL is included in the combined KernelDAO page. Also applies the requested logo update for the KernelDAO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token categorization configuration for improved protocol data accuracy.

* **Chores**
  * Updated protocol visual assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->