### PR TITLE
Add Stroom as Primary oracle to DIA

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -8998,7 +8998,7 @@ const data5: Protocol[] = [
     module: "stroom/index.js",
     twitter: "StroomNetwork",
     forkedFromIds: [],
-    oraclesBreakdown: [{ name: "DIA", type: "PoR", proof: ["https://docs.google.com/document/d/1CooM513_nJHTZhDF3NCLXbptlOya0wsY3AMbllJMB5s/edit?tab=t.0#heading=h.e29ryp9qtwct"] }],
+    oraclesBreakdown: [{ name: "DIA", type: "Primary", proof: ["https://docs.google.com/document/d/1CooM513_nJHTZhDF3NCLXbptlOya0wsY3AMbllJMB5s/edit?tab=t.0#heading=h.e29ryp9qtwct"] }],
     github: ["stroomnetwork"],
     audit_links: ["https://github.com/TheArcadiaGroup/publications/blob/main/audits/stroom-audit-final.pdf"],
     listedAt: 1768841531


### PR DESCRIPTION
Hello DefiLlama team,

Requesting to add Stroom as Primary oracle to DIA.

Oracles: DIA

Implementation Details: DIA is providing a PoR oracle to Stroom that is used as a checks and balances for the minting of strBTC. The contract checks that the btc is held in reserve via the DIA PoR oracle, and then facilitates the mint request. If the PoR oracle does not work correctly, there is a risk of overminting strBTC and therefore being undercollateralized or causing strBTC to flood the market.

Documentation: https://docs.stroom.network/stroom/smart-contracts/proof-of-reserve-oracle

Thank you,
Josh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oracle classification for the Stroom protocol to improve data accuracy and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->