### PR TITLE
track valiant lst prices (iFOGO & stFOGO)

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -179,6 +179,7 @@ export default {
   ember: require("./yield/ember"),
   suirewards: require("./markets/suirewards"),
   axlp: require("./liquidStaking/axlp"),
+  valiant: require("./liquidStaking/valiant"),
   altai: require("./rwa/altai"),
   wisdomtree: require("./rwa/wisdomtree"),
   townsquare: require("./townsquare"),

--- a/coins/src/adapters/liquidStaking/valiant/index.ts
+++ b/coins/src/adapters/liquidStaking/valiant/index.ts
@@ -78,6 +78,8 @@ export async function valiant(timestamp: number) {
 
         pricesObject[mint] = {
             underlying: "So11111111111111111111111111111111111111112", // native fogo
+            symbol: config.name,
+            decimals: 9,
             price: exchangeRate,
         };
     }

--- a/coins/src/adapters/solana/utils.ts
+++ b/coins/src/adapters/solana/utils.ts
@@ -144,6 +144,7 @@ const endpointMap = {
   solana: solEndpoint,
   renec: renecEndpoint,
   eclipse: eclipseEndpoint,
+  fogo: () => 'https://mainnet.fogo.io',
 };
 
 export function getConnection(chain = "solana") {

--- a/coins/src/adapters/utils/erc20.ts
+++ b/coins/src/adapters/utils/erc20.ts
@@ -17,7 +17,7 @@ export async function getTokenInfo(
 ): Promise<DbTokenInfos> {
   const { withSupply = false, timestamp } = params;
   targets = targets.map((i) => i.toLowerCase());
-  if (chain === 'solana' || chain === 'sui') {
+  if (["solana", "sui", 'fogo'].includes(chain)) {
     console.error('Solana|sui not supported')
     const decimals = targets.map(() => ({ output: undefined, success: true }))
     const symbols = targets.map(() => ({ output: undefined, success: true }))


### PR DESCRIPTION
Adds price tracking for two LST used by Valiant: [iFOGO](https://explorer.fogo.io/address/iFoGoY5nMWpuMJogR7xjUAWDJtygHDF17zREeP4MKuD) and [stFOGO](https://explorer.fogo.io/address/Brasa3xzkSC9XqMBEcN9v53x4oMkpb1nQwfaGMyJE88b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Valiant Liquid Staking Tokens (LSTs) with automatic exchange-rate-based pricing for staking derivatives.
  * Adds support for the Fogo network for fetching on-chain data used in pricing.

* **Chores**
  * Updated chain handling to recognize Fogo and treat it consistently with other supported chains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->