### PR TITLE
Add stacks usdcx token

### DIFF
--- a/coins/src/adapters/tokenMapping_added.json
+++ b/coins/src/adapters/tokenMapping_added.json
@@ -7879,6 +7879,16 @@
       "symbol": "aeUSDC",
       "to": "coingecko#usd-coin"
     },
+    "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx::usdcx-token": {
+      "decimals": "6",
+      "symbol": "USDCx",
+      "to": "coingecko#usd-coin"
+    },
+    "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx": {
+      "decimals": "6",
+      "symbol": "USDCx",
+      "to": "coingecko#usd-coin"
+    },
     "SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin::wrapped-bitcoin": {
       "decimals": "8",
       "symbol": "BTC",


### PR DESCRIPTION
USDCx is Circle's xReserve token on Stacks https://www.circle.com/blog/usdcx-on-stacks-now-available-via-circle-xreserve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USDCx token support on Stacks network with proper decimal precision and price feed integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->