### PR TITLE
enable li.fi bridge agg

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -12210,7 +12210,8 @@ const data4: Protocol[] = [
     twitter: "lifiprotocol",
     audit_links: ["https://docs.li.fi/smart-contracts/audits"],
     dimensions: {
-      fees: "lifi"
+      fees: "lifi",
+      "bridge-aggregators": "lifi",
     }
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * LIFI Protocol is now classified as a bridge aggregator.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->