### PR TITLE
fix(ethichub): update category to RWA Lending

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -15625,7 +15625,7 @@ const data2: Protocol[] = [
     audits: "2",
     gecko_id: "ethichub",
     cmcId: "8442",
-    category: "Lending",
+    category: "RWA Lending",
     chains: ["Ethereum", "Celo"],
     module: "ethichub/index.js",
     twitter: "EthicHub",


### PR DESCRIPTION
EthicHub is a **Real World Asset (RWA) / ReFi** protocol.
Users deposit stablecoins into Bonding Contracts, and these funds are lent to unbanked farmers in the real world. Our token Ethix represents the capital backing these real-world loans.
Therefore, we kindly request to be categorized under **RWA Lending** instead of generic Lending, as the yield comes from real-world coffee production/commercialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated protocol categorization: One protocol is now classified as "RWA Lending" instead of "Lending," enhancing the accuracy of protocol classification within the ecosystem.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->