### PR TITLE
add afiUSD tokenmapping

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -1041,6 +1041,11 @@
     }
   },
   "ethereum": {
+    "0x0b4c655bc989baafe728f8270ff988a7c2b40fd1": {
+      "decimals": "18",
+      "symbol": "afiUSD",
+      "to": "asset#ethereum:0x0b4c655bc989baafe728f8270ff988a7c2b40fd1"
+    },
     "0xa39986f96b80d04e8d7aeaaf47175f47c23fd0f4": {
       "decimals": "6",
       "symbol": "rwaUSDi",
@@ -13803,7 +13808,7 @@
       "decimals": 18,
       "symbol": "QUAI"
     }
-  }, 
+  },
   "fogo": {
     "0x0000000000000000000000000000000000000000": {
       "to": "coingecko#fogo",


### PR DESCRIPTION
- add afiUSD token to be used in adapter for afiprotocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for afiUSD token on the Ethereum network, enabling users to interact with and transact using this new token. The token has been configured with 18 decimal places to ensure proper transaction precision.

* **Style**
  * Minor formatting adjustments to improve consistency and readability in configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->