### PR TITLE
Add v2 routesfor tvl and treasury

### DIFF
--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -495,7 +495,7 @@ interface TvlProtocolRequestParams {
   currency: string; // token/raw, usd, default = usd
 }
 
-const AllowedProtocolKeys = ['tvl', 'staking', 'borrowed', 'pool2', 'all'];
+const AllowedProtocolKeys = ['tvl', 'staking', 'borrowed', 'pool2', 'vesting', 'all'];
 const AllowedTreasuryKeys = ['tvl', 'OwnTokens', 'all'];
 const AllowedCurrencies = ['token', 'raw', 'usd'];
 


### PR DESCRIPTION
Add new v2 routes for tvl and treasury

```text
// tvl

/v2/metrics/tvl/protocol/aave                  --- overview tvl data for aave

/v2/chart/tvl/protocol/uniswap --- timeserie chart for total uniswap tvl
/v2/chart/tvl/protocol/uniswap?key=all --- timeserie chart for total uniswap tvl total (sum of tvl, borrowed, staking, pool2, vesting)
/v2/chart/tvl/protocol/uniswap?key=staking --- timeserie chart for total uniswap staking
/v2/chart/tvl/protocol/morpho?key=borrowed --- timeserie chart for total morpho borrowed
/v2/chart/tvl/protocol/llamapay?key=vesting --- timeserie chart for total llamapay vesting

/v2/chart/tvl/protocol/euler/chain-breakdown --- timeserie chart for total euler tvl chain breakdown
/v2/chart/tvl/protocol/euler/chain-breakdown?key=borrowed --- timeserie chart for total euler borrowed chain breakdown

/v2/chart/tvl/protocol/aave/token-breakdown --- timeserie chart for total aave tvl token breakdown, value in USD
/v2/chart/tvl/protocol/aave/token-breakdown?currency=token --- timeserie chart for total aave tvl token breakdown, value in tokens


// treasury

/v2/metrics/treasury/protocol/aave  --- overview treasury data for aave

/v2/chart/treasury/protocol/uniswap --- timeserie chart for total uniswap treasury - excluding OwnTokens
/v2/chart/treasury/protocol/uniswap?key=OwnTokens  --- timeserie chart for total uniswap treasury - return OwnTokens only
/v2/chart/treasury/protocol/uniswap?key=all --- timeserie chart for total uniswap treasury - sum all tokens (including OwnTokens)

/v2/chart/treasury/protocol/aave/chain-breakdown --- timeserie chart for total aave treasury chain breakdown - excluding OwnTokens
/v2/chart/treasury/protocol/aave/chain-breakdown?key=OwnTokens --- timeserie chart for total aave treasury chain breakdown - only OwnTokens
/v2/chart/treasury/protocol/aave/chain-breakdown?key=all --- timeserie chart for total aave treasury chain breakdown - sum all tokens (including OwnTokens)

/v2/chart/treasury/protocol/aave/token-breakdown --- timeserie chart for total aave treasury token breakdown, value in USD
/v2/chart/treasury/protocol/aave/token-breakdown?currency=tokens --- timeserie chart for total aave treasury token breakdown, value in tokens
/v2/chart/treasury/protocol/aave/token-breakdown?key=OwnTokens&currency=tokens --- timeserie chart for total aave treasury OwnTokens breakdown, value in tokens
/v2/chart/treasury/protocol/aave/token-breakdown?key=all --- timeserie chart for total aave treasury breakdown, value in USD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New v2 TVL endpoints for protocol and treasury with overview, total charts, chain breakdowns, and token breakdowns
  * Multi-currency support and per-request filtering options
* **Improvements**
  * Input validation and clearer error handling for invalid parameters
  * Normalized protocol name lookup and 20-minute response caching for TVL endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->