### PR TITLE
add citrea m token pricing

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -1057,7 +1057,7 @@
       "to": "coingecko#tether-gold"
     },
     "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
-      "to": "coingecko#usd-coin",
+      "to": "coingecko#wrappedm-by-m0",
       "decimals": 6,
       "symbol": "M"
     },


### PR DESCRIPTION
add pricing for [m token on citrea](https://explorer.mainnet.citrea.xyz/address/0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b) (to simplify [#17879](https://github.com/DefiLlama/DefiLlama-Adapters/pull/17879))

**NOTE:** In 'tokenMapping.json', M token is also mapped to USDC on coingecko for hyperliquid and etheruem, alternatively it could be mapped to [wrapped-m coingecko](https://www.coingecko.com/en/coins/wrappedm-by-m0) price (they are 1:1)

```json
"0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
      "to": "coingecko#usd-coin",
      "decimals": 6,
      "symbol": "M"
    },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added token mapping for the Citrea network to enable USD Coin integration.
* **Bug Fixes / Data Updates**
  * Corrected the Ethereum token mapping to point to the wrapped M pricing source, keeping symbol and decimals intact.
* **Style**
  * Minor formatting cleanup in token mapping data for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->