### PR TITLE
ctUSD coin pricing

### DIFF
--- a/coins/src/adapters/other/ctusd.ts
+++ b/coins/src/adapters/other/ctusd.ts
@@ -31,7 +31,7 @@ export async function ctusd(timestamp: number) {
         6,
         "ctUSD",
         timestamp,
-        "ctUSD",
+        "ctusd",
         0.9,
     );
 


### PR DESCRIPTION
tracks [ctUSD](https://docs.citrea.xyz/developer-documentation/citrea-usd-ctusd) price as `value of M tokens in ctUSD contract / ctUSD total supply`

- sets confidence to `0.9`, alternatively it could be set to `mData[0].confidence` from [M token price](https://coins.llama.fi/prices/current/citrea:0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ctUSD token with automated price calculation and data recording capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->