### PR TITLE
hide RWA category page from search list

### DIFF
--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -675,6 +675,7 @@ async function generateSearchList() {
   const categories: Array<SearchResult> = [];
 
   for (const category in categoryTvl) {
+    if (category === "RWA") continue;
     categories.push({
       id: `category_${normalize(category)}`,
       name: category,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search category filtering has been refined. When viewing search results, a specific category option is no longer displayed in the available category filter list. This provides users with a more streamlined set of filtering options when performing searches, making the selection process clearer and more focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->