### PR TITLE
Update Resolv protocol Oracle.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2217,7 +2217,7 @@ const data4: Protocol[] = [
       },
       {
         name: "RedStone",
-        type: "Secondary", // listed as a market oracle only, not part of the Fundamental oracle
+        type: "Primary", // listed as a market oracle only, not part of the Fundamental oracle
         proof: ["https://docs.resolv.xyz/litepaper/for-developers/smart-contracts/price-oracles"],
       },
     ],


### PR DESCRIPTION
Hey Llamas,
kindly asking to update Resolv as RedStone protocol.

RedStone is used alongside other providers for USR market (~70% of TVL)

Documentation: https://docs.resolv.xyz/litepaper/for-developers/smart-contracts/price-oracles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RedStone oracle classification from secondary to primary status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->