### PR TITLE
Update Oracles for Seamless V2.ts

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -16742,6 +16742,13 @@ const data4: Protocol[] = [
     audit_links: ["https://github.com/seamless-protocol/audits"],
     parentProtocol: "parent#seamless-protocol",
     listedAt: 1749485042,
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://docs.seamlessprotocol.com/technical/oracles",],
+      },
+    ],
     dimensions: {
       fees: "seamless-v2",
     },


### PR DESCRIPTION
Hey Llamas,
Kindly asking to update oracles for Seamless V2.

Oracle Provider(s): RedStone

Implementation Details: Seamless is using RedStone as the primary oracle.

Documentation/Proof: https://docs.seamlessprotocol.com/technical/oracles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added oracle source information for Seamless V2 protocol, specifying RedStone as the primary oracle provider with supporting documentation reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->