### PR TITLE
skip wrapper assets in overall stats and update access model logic

### DIFF
--- a/defi/src/rwa/cron.ts
+++ b/defi/src/rwa/cron.ts
@@ -504,6 +504,9 @@ function generateAggregateStats(currentData: any[]): AggregateStats {
   for (const item of currentData || []) {
     if (!item || typeof item !== "object") continue;
 
+    const assetType = typeof item.type === "string" ? item.type.trim() : "";
+    if (assetType.toLowerCase() === "wrapper") continue;
+
     assetCount += 1;
 
     const issuer: string | null = typeof item.issuer === "string" && item.issuer.trim() ? item.issuer.trim() : null;

--- a/defi/src/rwa/utils.ts
+++ b/defi/src/rwa/utils.ts
@@ -300,10 +300,7 @@ function getAccessModel(asset: {
     return "Non-transferable";
   }
 
-  if (
-    asset.transferable === false &&
-    asset.selfCustody === false
-  ) {
+  if (asset.selfCustody === false) {
     return "Custodial Only";
   }
 


### PR DESCRIPTION
- exclude assets whose type is 'wrapper' from aggregate stats so they are not counted

- update access model logic for custodial assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Wrapper-type assets are now excluded from aggregate statistics calculations
  * Improved accuracy of custodial asset classification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->