### PR TITLE
Update Stobox adapter to arbitrum with dynamic token list

### DIFF
--- a/coins/src/adapters/rwa/stobox/index.ts
+++ b/coins/src/adapters/rwa/stobox/index.ts
@@ -9,6 +9,13 @@ const config = {
   },
 };
 
+/**
+ * Fetches token prices from Stobox oracle for a specific chain.
+ * Token list is retrieved dynamically from StoboxRWAVaultFactory contract.
+ * @param chain - The blockchain network name
+ * @param timestamp - Unix timestamp for price query (0 for current)
+ * @returns Array of Write objects containing token prices
+ */
 async function getTokenPrices(chain: string, timestamp: number) {
   const api = await getApi(chain, timestamp);
   const { oracle, factory } = config[chain as keyof typeof config];
@@ -39,6 +46,12 @@ async function getTokenPrices(chain: string, timestamp: number) {
   return writes;
 }
 
+/**
+ * Main adapter function for Stobox RWA tokens.
+ * Fetches prices for all configured chains (Arbitrum).
+ * @param timestamp - Unix timestamp for price query (0 for current)
+ * @returns Promise resolving to array of Write objects for all chains
+ */
 export function stobox(timestamp: number = 0) {
   return Promise.all(Object.keys(config).map((chain) => getTokenPrices(chain, timestamp)));
 }


### PR DESCRIPTION
- **Networks**: Removed BSC and Polygon, now only **Arbitrum**
- **Oracle**: Updated to 0x7C48bb52E63fe34C78F0D14Ee6E59BDe95D93645
- **Token list**: Now fetched dynamically from StoboxRWAVaultFactory contract (0x096D75d0501c3B1479FFe15569192CeC998223b4) via generalTokenList() function instead of hardcoded list"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Stobox adapter now dynamically retrieves token lists from the on-chain factory and consolidates support to Arbitrum.
* **Bug Fixes**
  * Price fetching flow made more robust: reads updated config sources and gracefully returns empty results when no tokens are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->