### PR TITLE
Update Takara oracles

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -5104,8 +5104,14 @@ const data4: Protocol[] = [
       },
       {
         name: "Api3",
-        type: "Fallback",
-        proof: ["https://app.takaralend.com/"],
+        type: "Secondary",
+        proof: [
+          "https://takara.gitbook.io/takara-lend/protocol-information/security#takara-security-measures",
+          "https://app.takaralend.com/market/WSEI",
+          "https://app.takaralend.com/market/spSEI",
+          "https://app.takaralend.com/market/USDY",
+        ],
+        startDate: "2025-11-12",
       },
       {
         name: "Pyth",


### PR DESCRIPTION
Hi Llamas,

Api3 never stopped being an oracle for certain assets on TakaraLend. It should still be listed as the secondary oracle provider in general, as it is the primary provider for the following assets:

WSEI - https://app.takaralend.com/market/WSEI
spSEI - https://app.takaralend.com/market/spSEI
USDY - https://app.takaralend.com/market/USDY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation and reference resources for enhanced protocol transparency.

* **Chores**
  * Modified protocol classification status and specified activation date for configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->