### PR TITLE
Add HYBR token pricing via V3 pool on HyperEVM

### DIFF
--- a/coins/src/adapters/other/unknownTokensV3.ts
+++ b/coins/src/adapters/other/unknownTokensV3.ts
@@ -75,6 +75,8 @@ const config: any = {
   hyperliquid: {
     "0x876e7F2f30935118a654fc0E1f807aFc49EFe500":
       "0xe9c02ca07931f9670fa87217372b3c9aa5a8a934", // PUP
+    "0x067b0C72aa4C6Bd3BFEFfF443c536DCd6a25a9C8":
+      "0x006418DcD73f6Da03A667ad161cCB9B39CeEEa60", // HYBR
   },
 };
 


### PR DESCRIPTION
Add HYBR (Hybra Finance) token to the `unknownTokensV3` adapter for price discovery on HyperEVM.

## Changes

- Added HYBR token (`0x067b0C72aa4C6Bd3BFEFfF443c536DCd6a25a9C8`) mapped to HYBR/WHYPE V3 pool (`0x006418DcD73f6Da03A667ad161cCB9B39CeEEa60`) on HyperEVM (hyperliquid chain)

## Context

HYBR currently has no price in DefiLlama's pricing system. The token trades on Hybra Finance V3 DEX on HyperEVM with ~$161k liquidity. This change enables price discovery via the existing `slot0()` mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added token mapping for HYBR on Hyperliquid to expand supported token pairings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->