### PR TITLE
Update AlphaSec metadata: audit, description, github

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -5907,7 +5907,7 @@ const data5: Protocol[] = [
     address: null,
     symbol: "-",
     url: "https://app.alphasec.trade",
-    description: "AlphaSec is a high performance orderbook DEX on the Kaia network, built on a custom Arbitrum Nitro rollup. It delivers a gasless, CEX-like trading experience with sub-10ms execution and full onchain transparency.",
+    description: "The AlphaSec Bridge enables seamless asset transfers between Kaia mainnet and the AlphaSec Layer 2, a custom Arbitrum Nitro rollup powering a high-performance orderbook DEX.",
     chain: "Kaia",
     logo: `${baseIconsUrl}/alphasec-bridge.jpg`,
     audits: "2",

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -8865,6 +8865,18 @@ const parentProtocols: IParentProtocol[] = [
     chains: [],
     twitter: "XpanseTrade",
   },
+  {
+    id: "parent#alphasec",
+    name: "AlphaSec",
+    url: "https://app.alphasec.trade",
+    description: "AlphaSec is a high performance orderbook DEX on the Kaia network, built on a custom Arbitrum Nitro rollup. It delivers a gasless, CEX-like trading experience with sub-10ms execution and full onchain transparency.",
+    logo: `${baseIconsUrl}/alphasec-spot.jpg`,
+    gecko_id: null,
+    cmcId: null,
+    chains: [],
+    twitter: "AlphaSec_Trade",
+    github: ["alphasec-dex"],
+  },
 ];
 
 export default parentProtocols;


### PR DESCRIPTION
  Thanks for registering AlphaSec on DefiLlama — we really appreciate the support.
                                                                                                                                                                                          
  This PR updates metadata for **AlphaSec Bridge** (id: 7155) and **AlphaSec Spot** (id: 7156).                                                                                           
                                                                                                                                                                                          
  ### Changes
  - Updated project description for both entries
  - Added CertiK audit report link (`audits: "2"`)
  - Added GitHub org (`alphasec-dex`)
  - Added `parentProtocol: "parent#alphasec"` to link Bridge and Spot entries

  ### Project Info
  - **Website**: https://app.alphasec.trade
  - **Twitter**: https://x.com/AlphaSec_Trade
  - **GitHub**: https://github.com/alphasec-dex
  - **Audit**: https://docs.alphasec.trade/assets/files/251220_AlphaSec_CertiK_Audit_Report-588a526784dc5258f1ef915083342775.pdf
  - **Discord**: https://discord.gg/alphasec
  - **Telegram**: https://t.me/AlphaSecOfficial

  If anything needs to be adjusted or improved, please feel free to leave a comment. Happy to make changes as needed.

  Thank you for your time and for maintaining such a great platform!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enriched AlphaSec Bridge and AlphaSec Spot descriptions with expanded details about Kaia and Arbitrum Nitro-based DEX architecture.
  * Added certified audit links and updated audit counts for both protocols.
  * Added repository references and parent protocol association for clearer provenance and navigation.
* **New Features**
  * Introduced AlphaSec as a parent protocol entry to the public protocol list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->