### PR TITLE
Refactor genuineSpikes data structure to use date strings

### DIFF
--- a/defi/src/adaptors/data/types.ts
+++ b/defi/src/adaptors/data/types.ts
@@ -12,13 +12,13 @@ export type ChartBreakdownOptions = 'daily' | 'weekly' | 'monthly'
 export type ProtocolDimensionsExtraConfig = {
     defaultChartView?: ChartBreakdownOptions;
     adapter: string;
-    genuineSpikes?: string[]  // list of unix timestamps with valid spikes,
+    genuineSpikes?: [string, string][]  // list of [yyyy-mm-dd date, reason] with valid spikes
 }
 
 export type DimensionsConfig = {
     [K in AdapterType]?: string | ProtocolDimensionsExtraConfig;
 }
-export interface ProtocolAdaptor extends Protocol {
+export type ProtocolAdaptor = Protocol & {
     defillamaId: string
     displayName: string
     defaultChartView?: ChartBreakdownOptions
@@ -26,7 +26,7 @@ export interface ProtocolAdaptor extends Protocol {
     id2: string
     isProtocolInOtherCategories?: boolean
     protocolType?: ProtocolType
-    adapterType?: ProtocolType
+    adapterType?: AdapterType
     methodologyURL: string
     methodology?: string | IJSON<string> | any
     breakdownMethodology?: IJSON<IJSON<string>> | any

--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -895,7 +895,7 @@ function mergeSpikeConfigs(childProtocols: any[]) {
   childProtocols.forEach((childConfig: any = {}) => {
     if (Array.isArray(childConfig.genuineSpikes)) {
       childConfig.genuineSpikes.forEach((key: any) => {
-        genuineSpikesSet.add(key)
+        genuineSpikesSet.add(key[0])
       })
     }
   })
@@ -906,7 +906,7 @@ function mergeSpikeConfigs(childProtocols: any[]) {
 function getSpikeConfig(protocol: any): SpikeConfig {
   if (!protocol?.genuineSpikes) return {}
   let info = (protocol as any)?.genuineSpikes ?? []
-  const whitelistedSpikeSet = new Set(info.map(unixTimeToTimeS)) as Set<string>
+  const whitelistedSpikeSet = new Set(info.map((i: any) => i[0])) as Set<string>
   return { whitelistedSpikeSet }
 }
 

--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -87,7 +87,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "curve",
       dexs: {
-        genuineSpikes: ["1758758400"],
+        genuineSpikes: [["2025-09-25", "-"]],
         adapter: "curve"
       }
     }
@@ -233,7 +233,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "synthetix",
       derivatives: {
-        genuineSpikes: ["1689292800", "1689379200", "1689465600", "1689638400", "1689811309"],
+        genuineSpikes: [["2023-07-14", "-"], ["2023-07-15", "-"], ["2023-07-16", "-"], ["2023-07-18", "-"], ["2023-07-20", "-"]],
         adapter: "synthetix"
       },
       "open-interest": "synthetix"
@@ -260,7 +260,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "balancer-v1",
       dexs: {
-        genuineSpikes: ["1718755200", "1722297600", "1722816000", "1738540800"],
+        genuineSpikes: [["2024-06-19", "-"], ["2024-07-30", "-"], ["2024-08-05", "-"], ["2025-02-03", "-"]],
         adapter: "balancer-v1"
       }
     }
@@ -1046,7 +1046,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "idle",
-        genuineSpikes: ["1751241600",],
+        genuineSpikes: [["2025-06-30", "-"],],
       },
     },
   },
@@ -1856,7 +1856,7 @@ const data: Protocol[] = [
     github: ["1inch"],
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1747699200"],
+        genuineSpikes: [["2025-05-20", "-"]],
         adapter: "1inch-agg"
       }
     }
@@ -2540,7 +2540,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "defi-swap",
       dexs: {
-        genuineSpikes: ["1700524800"],
+        genuineSpikes: [["2023-11-21", "-"]],
         adapter: "defi-swap"
       }
     }
@@ -4369,7 +4369,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "quickswap-v2",
       dexs: {
-        genuineSpikes: ["1706918400"],
+        genuineSpikes: [["2024-02-03", "-"]],
         adapter: "quickswap-v2"
       }
     }
@@ -5051,11 +5051,11 @@ const data: Protocol[] = [
     oraclesBreakdown: [{ name: "Chainlink", type: "Primary", proof: [] }],
     dimensions: {
       fees: {
-        genuineSpikes: ["1743984000", "1744070398"],
+        genuineSpikes: [["2025-04-07", "-"], ["2025-04-07", "-"]],
         adapter: "gmx"
       },
       derivatives: {
-        genuineSpikes: ["1692230400"],
+        genuineSpikes: [["2023-08-17", "-"]],
         adapter: "gmx-derivatives"
       },
       "open-interest": "gmx-derivatives"
@@ -6076,7 +6076,7 @@ const data: Protocol[] = [
     dimensions: {
       fees: "pendle",
       dexs: {
-        genuineSpikes: ["1746230400"],
+        genuineSpikes: [["2025-05-03", "-"]],
         adapter: "pendle"
       }
     }
@@ -6154,11 +6154,11 @@ const data: Protocol[] = [
     parentProtocol: "parent#meteora",
     dimensions: {
       fees: {
-        genuineSpikes: ["1747180800"],
+        genuineSpikes: [["2025-05-14", "-"]],
         adapter: "meteora"
       },
       dexs: {
-        genuineSpikes: ["1714867200", "1714953600", "1747180800"],
+        genuineSpikes: [["2024-05-05", "-"], ["2024-05-06", "-"], ["2025-05-14", "-"]],
         adapter: "meteora"
       }
     }
@@ -8323,7 +8323,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     parentProtocol: "parent#marinade-finance",
     dimensions: {
       fees: {
-        genuineSpikes: ["1708387200", "1708473600", "1708560000", "1708646400"],
+        genuineSpikes: [["2024-02-20", "-"], ["2024-02-21", "-"], ["2024-02-22", "-"], ["2024-02-23", "-"]],
         adapter: "marinade-liquid-staking"
       }
     }
@@ -8410,7 +8410,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     audit_links: ["https://docs.ubeswap.org/code-and-contracts/security#audits"],
     dimensions: {
       dexs: {
-        genuineSpikes: ["1675555200"],
+        genuineSpikes: [["2023-02-05", "-"]],
         adapter: "ubeswap"
       }
     }
@@ -10368,7 +10368,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     dimensions: {
       fees: "allbridge-classic",
       dexs: {
-        genuineSpikes: ["1747872000"],
+        genuineSpikes: [["2025-05-22", "-"]],
         adapter: "allbridge-classic"
       }
     }
@@ -16959,7 +16959,7 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
     github: ["paraswap"],
     dimensions: {
       fees: {
-        genuineSpikes: ["1684800000"],
+        genuineSpikes: [["2023-05-23", "-"]],
         adapter: "paraswap"
       },
       aggregators: "paraswap"

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -4793,7 +4793,7 @@ const data2: Protocol[] = [
     wrongLiquidity: true,
     dimensions: {
       fees: {
-        genuineSpikes: ["1722816000", "1738540800"],
+        genuineSpikes: [["2024-08-05", "-"], ["2025-02-03", "-"]],
         adapter: "aave-v3"
       }
     }
@@ -10844,7 +10844,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "apex",
       derivatives: {
-        genuineSpikes: ["1697328000", "1697414400", "1722816000", "1738540800"],
+        genuineSpikes: [["2023-10-15", "-"], ["2023-10-16", "-"], ["2024-08-05", "-"], ["2025-02-03", "-"]],
         adapter: "apex"
       },
       "open-interest": "apex"
@@ -10963,7 +10963,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "iziswap",
       dexs: {
-        genuineSpikes: ["1700524800", "1700611200", "1700697600", "1700784000", "1700870400"],
+        genuineSpikes: [["2023-11-21", "-"], ["2023-11-22", "-"], ["2023-11-23", "-"], ["2023-11-24", "-"], ["2023-11-25", "-"]],
         adapter: "iziswap"
       }
     }
@@ -13025,7 +13025,7 @@ const data2: Protocol[] = [
       fees: "saucerswap",
       dexs: {
         adapter: "saucerswap",
-        genuineSpikes: ["1760400000"],
+        genuineSpikes: [["2025-10-14", "-"]],
       },
     }
   },
@@ -16660,7 +16660,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "jupiter",
       aggregators: {
-        genuineSpikes: ["1741564800"],
+        genuineSpikes: [["2025-03-10", "-"]],
         adapter: "jupiter-aggregator"
       }
     }
@@ -16810,12 +16810,12 @@ const data2: Protocol[] = [
     dimensions: {
       derivatives: {
         genuineSpikes: [
-          "1676678400",
-          "1715126400",
-          "1716336000",
-          "1717718400",
-          "1722297600",
-          "1724457600"
+          ["2023-02-18", "-"],
+          ["2024-05-08", "-"],
+          ["2024-05-22", "-"],
+          ["2024-06-07", "-"],
+          ["2024-07-30", "-"],
+          ["2024-08-24", "-"]
         ],
         adapter: "ipor"
       }
@@ -17938,23 +17938,23 @@ const data2: Protocol[] = [
     dimensions: {
       fees: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v1"
       },
       dexs: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v1"
       }
@@ -17986,23 +17986,23 @@ const data2: Protocol[] = [
     dimensions: {
       fees: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v2"
       },
       dexs: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v2"
       }
@@ -18034,23 +18034,23 @@ const data2: Protocol[] = [
     dimensions: {
       fees: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v3"
       },
       dexs: {
         genuineSpikes: [
-          "1603670400",
-          "1661990400",
-          "1665446400",
-          "1670630400",
-          "1722816000",
-          "1725580800"
+          ["2020-10-26", "-"],
+          ["2022-09-01", "-"],
+          ["2022-10-11", "-"],
+          ["2022-12-10", "-"],
+          ["2024-08-05", "-"],
+          ["2024-09-06", "-"]
         ],
         adapter: "uniswap-v3"
       }
@@ -18965,7 +18965,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "quickswap-v3",
       dexs: {
-        genuineSpikes: ["1751587200"],
+        genuineSpikes: [["2025-07-04", "-"]],
         adapter: "quickswap-v3"
       }
     }
@@ -19305,7 +19305,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "mux",
       derivatives: {
-        genuineSpikes: ["1746489600"],
+        genuineSpikes: [["2025-05-06", "-"]],
         adapter: "mux-protocol-perps"
       }
     }
@@ -25198,7 +25198,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "pancakeswap-stableswap",
       dexs: {
-        genuineSpikes: ["1747612800"],
+        genuineSpikes: [["2025-05-19", "-"]],
         adapter: "pancakeswap-stableswap"
       }
     }
@@ -27004,7 +27004,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "balancer-v2",
       dexs: {
-        genuineSpikes: ["1718755200", "1722297600", "1722816000", "1738540800"],
+        genuineSpikes: [["2024-06-19", "-"], ["2024-07-30", "-"], ["2024-08-05", "-"], ["2025-02-03", "-"]],
         adapter: "balancer-v2"
       }
     }
@@ -27136,7 +27136,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "dedust",
       dexs: {
-        genuineSpikes: ["1721606400"],
+        genuineSpikes: [["2024-07-22", "-"]],
         adapter: "dedust"
       },
       aggregators: "dedust"
@@ -27722,7 +27722,7 @@ const data2: Protocol[] = [
     dimensions: {
       fees: "cow-protocol",
       aggregators: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "cowswap"
       }
     }

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -636,7 +636,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "syncswap",
       dexs: {
-        genuineSpikes: ["1748390400"],
+        genuineSpikes: [["2025-05-28", "-"]],
         adapter: "syncswap"
       }
     }
@@ -2120,7 +2120,7 @@ const data3_0: Protocol[] = [
     listedAt: 1681122429,
     dimensions: {
       derivatives: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "aevo"
       },
       "open-interest": "aevo-perps-oi"
@@ -4058,12 +4058,12 @@ const data3_0: Protocol[] = [
     dimensions: {
       derivatives: {
         genuineSpikes: [
-          "1700179200",
-          "1700265600",
-          "1700352000",
-          "1700438400",
-          "1700524800",
-          "1749600000"
+          ["2023-11-17", "-"],
+          ["2023-11-18", "-"],
+          ["2023-11-19", "-"],
+          ["2023-11-20", "-"],
+          ["2023-11-21", "-"],
+          ["2025-06-11", "-"]
         ],
         adapter: "rabbitx"
       },
@@ -4523,7 +4523,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "joe-v2.1",
       dexs: {
-        genuineSpikes: ["1682812800", "1682899200", "1769731200"],
+        genuineSpikes: [["2023-04-30", "-"], ["2023-05-01", "-"], ["2026-01-30", "-"]],
         adapter: "joe-v2.1"
       }
     }
@@ -5302,7 +5302,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "turbos",
       dexs: {
-        genuineSpikes: ["1697328000"],
+        genuineSpikes: [["2023-10-15", "-"]],
         adapter: "turbos"
       }
     }
@@ -6185,7 +6185,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "satori",
       derivatives: {
-        genuineSpikes: ["1691625600"],
+        genuineSpikes: [["2023-08-10", "-"]],
         adapter: "satori"
       },
       "open-interest": "satori-oi"
@@ -6479,7 +6479,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "pulsex-v1",
       dexs: {
-        genuineSpikes: ["1686009600"],
+        genuineSpikes: [["2023-06-06", "-"]],
         adapter: "pulsex-v1"
       }
     }
@@ -7881,7 +7881,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "pulsex-v2",
       dexs: {
-        genuineSpikes: ["1686009600"],
+        genuineSpikes: [["2023-06-06", "-"]],
         adapter: "pulsex-v2"
       }
     }
@@ -8937,7 +8937,7 @@ const data3_0: Protocol[] = [
     listedAt: 1686776222,
     dimensions: {
       fees: {
-        genuineSpikes: ["1729209600"],
+        genuineSpikes: [["2024-10-18", "-"]],
         adapter: "eigenlayer"
       }
     }
@@ -10253,7 +10253,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "phoenix",
       dexs: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "phoenix"
       }
     }
@@ -10358,7 +10358,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "mango-v4",
       derivatives: {
-        genuineSpikes: ["1695081600"],
+        genuineSpikes: [["2023-09-19", "-"]],
         adapter: "mango-v4-perp"
       }
     }
@@ -11310,7 +11310,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       dexs: {
         adapter: "swaap-v2",
-        genuineSpikes: ["1761350400"],
+        genuineSpikes: [["2025-10-25", "-"]],
       }
     }
   },
@@ -12671,11 +12671,11 @@ const data3_0: Protocol[] = [
     listedAt: 1690193404,
     dimensions: {
       fees: {
-        genuineSpikes: ["1722211200"],
+        genuineSpikes: [["2024-07-29", "-"]],
         adapter: "dexswap"
       },
       dexs: {
-        genuineSpikes: ["1722211200"],
+        genuineSpikes: [["2024-07-29", "-"]],
         adapter: "dexswap"
       }
     }
@@ -13238,7 +13238,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "velodrome-v2",
       dexs: {
-        genuineSpikes: ["1690156800", "1690243200", "1690329600", "1690416000"],
+        genuineSpikes: [["2023-07-24", "-"], ["2023-07-25", "-"], ["2023-07-26", "-"], ["2023-07-27", "-"]],
         adapter: "velodrome-v2"
       }
     }
@@ -14225,7 +14225,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "dackieswap",
       dexs: {
-        genuineSpikes: ["1691712000", "1691798400", "1691884800", "1691971200"],
+        genuineSpikes: [["2023-08-11", "-"], ["2023-08-12", "-"], ["2023-08-13", "-"], ["2023-08-14", "-"]],
         adapter: "dackieswap"
       }
     }
@@ -14922,7 +14922,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "aark",
       derivatives: {
-        genuineSpikes: ["1691884800", "1691971200"],
+        genuineSpikes: [["2023-08-13", "-"], ["2023-08-14", "-"]],
         adapter: "aark"
       }
     }
@@ -15191,7 +15191,7 @@ const data3_0: Protocol[] = [
     dimensions: {
       fees: "sanctum",
       dexs: {
-        genuineSpikes: ["1704240000", "1760054400", "1769817600"],
+        genuineSpikes: [["2024-01-03", "-"], ["2025-10-10", "-"], ["2026-01-31", "-"]],
         adapter: "sanctum"
       }
     }
@@ -18099,7 +18099,7 @@ const data3_1: Protocol[] = [
     github: ["jumperexchange"],
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1698883200"],
+        genuineSpikes: [["2023-11-02", "-"]],
         adapter: "jumper-exchange"
       },
       "bridge-aggregators": "jumper.exchange"
@@ -18455,7 +18455,7 @@ const data3_1: Protocol[] = [
     listedAt: 1695222044,
     dimensions: {
       derivatives: {
-        genuineSpikes: ["1736640000"],
+        genuineSpikes: [["2025-01-12", "-"]],
         adapter: "panacakeswap-perp"
       }
     }
@@ -19881,7 +19881,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "contango",
       derivatives: {
-        genuineSpikes: ["1697328000", "1697414400"],
+        genuineSpikes: [["2023-10-15", "-"], ["2023-10-16", "-"]],
         adapter: "contango"
       },
       "open-interest": "contango"
@@ -20804,11 +20804,11 @@ const data3_1: Protocol[] = [
     listedAt: 1697592311,
     dimensions: {
       fees: {
-        genuineSpikes: ["1715817600"],
+        genuineSpikes: [["2024-05-16", "-"]],
         adapter: "ociswap-basic"
       },
       dexs: {
-        genuineSpikes: ["1715817600"],
+        genuineSpikes: [["2024-05-16", "-"]],
         adapter: "ociswap-basic"
       }
     }
@@ -22968,7 +22968,7 @@ const data3_1: Protocol[] = [
       fees: "intent-x",
       derivatives: {
         adapter: "intent-x",
-        genuineSpikes: ["1760054400", "1761868800"],
+        genuineSpikes: [["2025-10-10", "-"], ["2025-10-31", "-"]],
       }
     }
   },
@@ -25809,7 +25809,7 @@ const data3_1: Protocol[] = [
     listedAt: 1701694470,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1707177600"],
+        genuineSpikes: [["2024-02-06", "-"]],
         adapter: "starkdefi"
       }
     }
@@ -25879,7 +25879,7 @@ const data3_1: Protocol[] = [
       fees: "stormtrade",
       derivatives: {
         adapter: "stormtrade",
-        genuineSpikes: ["1761350400"],
+        genuineSpikes: [["2025-10-25", "-"]],
       }
     }
   },
@@ -27150,7 +27150,7 @@ const data3_1: Protocol[] = [
     listedAt: 1703074387,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1710288000"],
+        genuineSpikes: [["2024-03-13", "-"]],
         adapter: "archly-finance-v2"
       }
     }
@@ -27413,7 +27413,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "odos",
       aggregators: {
-        genuineSpikes: ["1708128000", "1708214400", "1708300800", "1708387200"],
+        genuineSpikes: [["2024-02-17", "-"], ["2024-02-18", "-"], ["2024-02-19", "-"], ["2024-02-20", "-"]],
         adapter: "odos"
       }
     }
@@ -28104,7 +28104,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "kyberswap-aggregator",
       aggregators: {
-        genuineSpikes: ["1704067200", "1704153600"],
+        genuineSpikes: [["2024-01-01", "-"], ["2024-01-02", "-"]],
         adapter: "kyberswap"
       }
     }
@@ -30031,7 +30031,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "dydx-v4",
       derivatives: {
-        genuineSpikes: ["1706140800"],
+        genuineSpikes: [["2024-01-25", "-"]],
         adapter: "dydx-v4"
       },
       "open-interest": "dydx-v4"
@@ -30223,7 +30223,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "equation-v2",
       derivatives: {
-        genuineSpikes: ["1706227200", "1706313600", "1706400000"],
+        genuineSpikes: [["2024-01-26", "-"], ["2024-01-27", "-"], ["2024-01-28", "-"]],
         adapter: "equation-v2"
       }
     }
@@ -30693,7 +30693,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "hyperionx",
       derivatives: {
-        genuineSpikes: ["1706832000"],
+        genuineSpikes: [["2024-02-02", "-"]],
         adapter: "hyperionx"
       }
     }
@@ -30870,7 +30870,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "pingu",
       derivatives: {
-        genuineSpikes: ["1716422400"],
+        genuineSpikes: [["2024-05-23", "-"]],
         adapter: "pingu"
       }
     }
@@ -31010,7 +31010,7 @@ const data3_1: Protocol[] = [
     dimensions: {
       fees: "avantis",
       derivatives: {
-        genuineSpikes: ["1743552000"],
+        genuineSpikes: [["2025-04-02", "-"]],
         adapter: "avantis"
       },
       "open-interest": "avantis"
@@ -31678,7 +31678,7 @@ const data3_1: Protocol[] = [
     listedAt: 1708016301,
     dimensions: {
       fees: {
-        genuineSpikes: ["1754524800"],
+        genuineSpikes: [["2025-08-07", "-"]],
         adapter: "ethena"
       }
     }
@@ -32036,7 +32036,7 @@ const data3_1: Protocol[] = [
     listedAt: 1708387360,
     dimensions: {
       fees: {
-        genuineSpikes: ["1755734400"],
+        genuineSpikes: [["2025-08-21", "-"]],
         adapter: "meteora-dlmm"
       },
       dexs: "meteora-dlmm"
@@ -33047,7 +33047,7 @@ const data3_2: Protocol[] = [
     dimensions: {
       fees: "cellana-finance",
       dexs: {
-        genuineSpikes: ["1747785600", "1748476800"],
+        genuineSpikes: [["2025-05-21", "-"], ["2025-05-29", "-"]],
         adapter: "cellana-finance"
       }
     }
@@ -35812,7 +35812,7 @@ const data3_2: Protocol[] = [
     dimensions: {
       fees: "myx-finance",
       derivatives: {
-        genuineSpikes: ["1712534400", "1712620800"],
+        genuineSpikes: [["2024-04-08", "-"], ["2024-04-09", "-"]],
         adapter: "myx-finance"
       },
       "open-interest": "myx-finance"
@@ -36890,7 +36890,7 @@ const data3_2: Protocol[] = [
       fees: "sanctum-infinity",
       dexs: {
         adapter: "sanctum-infinity",
-        genuineSpikes: ["1761782400"]
+        genuineSpikes: [["2025-10-30", "-"]]
       }
     }
   },
@@ -38661,11 +38661,11 @@ const data3_2: Protocol[] = [
     listedAt: 1712427917,
     dimensions: {
       fees: {
-        genuineSpikes: ["1752537600", "1754956800"],
+        genuineSpikes: [["2025-07-15", "-"], ["2025-08-12", "-"]],
         adapter: "pumpdotfun"
       },
       dexs: {
-        genuineSpikes: ["1732320000", "1732406400", "1732492800"],
+        genuineSpikes: [["2024-11-23", "-"], ["2024-11-24", "-"], ["2024-11-25", "-"]],
         adapter: "pumpfun"
       }
     }
@@ -39051,7 +39051,7 @@ const data3_2: Protocol[] = [
     listedAt: 1712786283,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1712793600"],
+        genuineSpikes: [["2024-04-11", "-"]],
         adapter: "hbarsuite-dex"
       }
     }
@@ -39885,11 +39885,11 @@ const data3_2: Protocol[] = [
     parentProtocol: "parent#fjord-foundry",
     dimensions: {
       fees: {
-        genuineSpikes: ["1713657600", "1713744000"],
+        genuineSpikes: [["2024-04-21", "-"], ["2024-04-22", "-"]],
         adapter: "fjord-foundry-v2"
       },
       dexs: {
-        genuineSpikes: ["1713657600", "1713744000"],
+        genuineSpikes: [["2024-04-21", "-"], ["2024-04-22", "-"]],
         adapter: "fjord-foundry-v2"
       }
     }
@@ -40310,11 +40310,11 @@ const data3_2: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "aerodrome-slipstream",
-        genuineSpikes: ["1757548800"],
+        genuineSpikes: [["2025-09-11", "-"]],
       },
       dexs: {
         adapter: "aerodrome-slipstream",
-        genuineSpikes: ["1757548800"]
+        genuineSpikes: [["2025-09-11", "-"]]
       }
     }
   },
@@ -41023,11 +41023,11 @@ const data3_2: Protocol[] = [
     parentProtocol: "parent#fjord-foundry",
     dimensions: {
       fees: {
-        genuineSpikes: ["1713657600", "1713744000"],
+        genuineSpikes: [["2024-04-21", "-"], ["2024-04-22", "-"]],
         adapter: "fjord-foundry-v1"
       },
       dexs: {
-        genuineSpikes: ["1713657600", "1713744000"],
+        genuineSpikes: [["2024-04-21", "-"], ["2024-04-22", "-"]],
         adapter: "fjord-foundry-v1"
       }
     }
@@ -42062,7 +42062,7 @@ const data3_2: Protocol[] = [
     openSource: false,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1715731200"],
+        genuineSpikes: [["2024-05-15", "-"]],
         adapter: "cropper-clmm"
       }
     }
@@ -42552,7 +42552,7 @@ const data3_2: Protocol[] = [
     github: ["0xProject"],
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1674172800", "1678492800", "1680739200"],
+        genuineSpikes: [["2023-01-20", "-"], ["2023-03-11", "-"], ["2023-04-06", "-"]],
         adapter: "zrx"
       }
     }
@@ -42578,11 +42578,11 @@ const data3_2: Protocol[] = [
     listedAt: 1715954045,
     dimensions: {
       fees: {
-        genuineSpikes: ["1715817600"],
+        genuineSpikes: [["2024-05-16", "-"]],
         adapter: "ociswap-precision"
       },
       dexs: {
-        genuineSpikes: ["1715817600"],
+        genuineSpikes: [["2024-05-16", "-"]],
         adapter: "ociswap-precision"
       }
     }
@@ -46016,11 +46016,11 @@ const data3_3: Protocol[] = [
     listedAt: 1718803914,
     dimensions: {
       fees: {
-        genuineSpikes: ["1718755200", "1718841600"],
+        genuineSpikes: [["2024-06-19", "-"], ["2024-06-20", "-"]],
         adapter: "dusa"
       },
       dexs: {
-        genuineSpikes: ["1718755200", "1718841600"],
+        genuineSpikes: [["2024-06-19", "-"], ["2024-06-20", "-"]],
         adapter: "dusa"
       }
     }
@@ -46780,7 +46780,7 @@ const data3_3: Protocol[] = [
     dimensions: {
       fees: "apex-omni",
       derivatives: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "apex-omni"
       },
       "open-interest": "apex-omni",
@@ -46827,7 +46827,7 @@ const data3_3: Protocol[] = [
     github: ["coinhall"],
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1724457600"],
+        genuineSpikes: [["2024-08-24", "-"]],
         adapter: "hallswap"
       }
     }
@@ -47216,12 +47216,12 @@ const data3_3: Protocol[] = [
     dimensions: {
       "aggregator-derivatives": {
         genuineSpikes: [
-          "1724198400",
-          "1724284800",
-          "1724371200",
-          "1724457600",
-          "1724544000",
-          "1724630400"
+          ["2024-08-21", "-"],
+          ["2024-08-22", "-"],
+          ["2024-08-23", "-"],
+          ["2024-08-24", "-"],
+          ["2024-08-25", "-"],
+          ["2024-08-26", "-"]
         ],
         adapter: "bitoro"
       }
@@ -48120,7 +48120,7 @@ const data3_3: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "usual",
-        genuineSpikes: ["1760054400"],
+        genuineSpikes: [["2025-10-10", "-"]],
       }
     }
   },
@@ -49749,7 +49749,7 @@ const data3_3: Protocol[] = [
     parentProtocol: "parent#cetus",
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1724803200"],
+        genuineSpikes: [["2024-08-28", "-"]],
         adapter: "cetus-aggregator"
       }
     }
@@ -51823,7 +51823,7 @@ const data3_3: Protocol[] = [
     listedAt: 1724762254,
     dimensions: {
       "aggregator-derivatives": {
-        genuineSpikes: ["1749686400", "1760054400"],
+        genuineSpikes: [["2025-06-12", "-"], ["2025-10-10", "-"]],
         adapter: "mux-protocol-agge"
       }
     }
@@ -52009,7 +52009,7 @@ const data3_3: Protocol[] = [
     dimensions: {
       aggregators: {
         adapter: "dodo-agg",
-        genuineSpikes: ["1769299200"],
+        genuineSpikes: [["2026-01-25", "-"]],
       }
     }
   },
@@ -52193,7 +52193,7 @@ const data3_3: Protocol[] = [
     listedAt: 1724921375,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1722902400", "1722988800", "1723075200"],
+        genuineSpikes: [["2024-08-06", "-"], ["2024-08-07", "-"], ["2024-08-08", "-"]],
         adapter: "gmx-v2-gmx-v2-swap"
       }
     }
@@ -52219,7 +52219,7 @@ const data3_3: Protocol[] = [
     listedAt: 1724922727,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1749081600"],
+        genuineSpikes: [["2025-06-05", "-"]],
         adapter: "drift-protocol-swap"
       }
     }
@@ -52301,7 +52301,7 @@ const data3_3: Protocol[] = [
     dimensions: {
       derivatives: {
         adapter: "helix-helix-perp",
-        genuineSpikes: ["1759104000"],
+        genuineSpikes: [["2025-09-29", "-"]],
       },
       "open-interest": "helix-helix-perp"
     }
@@ -53201,7 +53201,7 @@ const data3_3: Protocol[] = [
     parentProtocol: "parent#Edge",
     dimensions: {
       dexs: {
-        genuineSpikes: ["1689811200"],
+        genuineSpikes: [["2023-07-20", "-"]],
         adapter: "vertex-protocol-swap"
       }
     }
@@ -53308,7 +53308,7 @@ const data3_3: Protocol[] = [
     deadUrl: true,
     dimensions: {
       dexs: {
-        genuineSpikes: ["1695081600"],
+        genuineSpikes: [["2023-09-19", "-"]],
         adapter: "mango-v4-spot"
       }
     }
@@ -55031,7 +55031,7 @@ const data3_3: Protocol[] = [
     parentProtocol: "parent#okx-dex",
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1746403200"],
+        genuineSpikes: [["2025-05-05", "-"]],
         adapter: "okx"
       },
       fees: "okx-swap"

--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -468,7 +468,7 @@ const data4: Protocol[] = [
       fees: "SwapX-algebra",
       dexs: {
         adapter: "SwapX-algebra",
-        genuineSpikes: ["1760054400"],
+        genuineSpikes: [["2025-10-10", "-"]],
       },
     }
   },
@@ -4126,7 +4126,7 @@ const data4: Protocol[] = [
     listedAt: 1738858207,
     dimensions: {
       aggregators: {
-        genuineSpikes: ["1738540800", "1738627200", "1738713600", "1746489600"],
+        genuineSpikes: [["2025-02-03", "-"], ["2025-02-04", "-"], ["2025-02-05", "-"], ["2025-05-06", "-"]],
         adapter: "enso"
       }
     }
@@ -5729,7 +5729,7 @@ const data4: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "flashbot",
-        genuineSpikes: ["1760054400"]
+        genuineSpikes: [["2025-10-10", "-"]]
       }
     }
   },
@@ -6318,7 +6318,7 @@ const data4: Protocol[] = [
       fees: "hyperswap-v2",
       dexs: {
         adapter: "hyperswap-v2",
-        genuineSpikes: ["1759104000"],
+        genuineSpikes: [["2025-09-29", "-"]],
       },
     }
   },
@@ -11766,7 +11766,7 @@ const data4: Protocol[] = [
     dimensions: {
       fees: "launchlab",
       dexs: {
-        genuineSpikes: ["1745539200"],
+        genuineSpikes: [["2025-04-25", "-"]],
         adapter: "launchlab"
       }
     }
@@ -15803,7 +15803,7 @@ const data4: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "infinifi",
-        genuineSpikes: ["1766793600", "1766880000","1766966400"],
+        genuineSpikes: [["2025-12-27", "-"], ["2025-12-28", "-"],["2025-12-29", "-"]],
       },
     }
   },
@@ -18952,7 +18952,7 @@ const data4: Protocol[] = [
       aggregators: "rango",
       "bridge-aggregators": {
         adapter: "rango",
-        genuineSpikes: ["1770163200"]
+        genuineSpikes: [["2026-02-04", "-"]]
       }
     }
   },
@@ -19547,7 +19547,7 @@ const data4: Protocol[] = [
       fees: "carbon",
       derivatives: {
         adapter: "carbon",
-        genuineSpikes: ["1760054400"]
+        genuineSpikes: [["2025-10-10", "-"]]
       }
     }
   },
@@ -22438,11 +22438,11 @@ const data4: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "boros",
-        genuineSpikes: ["1759449600"],
+        genuineSpikes: [["2025-10-03", "-"]],
       },
       derivatives: {
         adapter: "boros",
-        genuineSpikes: ["1759449600"],
+        genuineSpikes: [["2025-10-03", "-"]],
       },
       "open-interest": "boros-oi"
     },
@@ -22842,7 +22842,7 @@ const data4: Protocol[] = [
     twitter: "humidifi",
     dimensions: {
       dexs: {
-        genuineSpikes: ["1755129600"],
+        genuineSpikes: [["2025-08-14", "-"]],
         adapter: "humidifi"
       }
     }
@@ -24600,7 +24600,7 @@ const data4: Protocol[] = [
     parentProtocol: "parent#opensea",
     dimensions: {
       "bridge-aggregators": {
-        genuineSpikes: ["1751414400", "1752105600"],
+        genuineSpikes: [["2025-07-02", "-"], ["2025-07-10", "-"]],
         adapter: "opensea"
       }
     }
@@ -25126,7 +25126,7 @@ const data4: Protocol[] = [
     dimensions: {
       fees: "woofi-pro-perp",
       derivatives: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "woofi-pro-perp"
       }
     }
@@ -25245,7 +25245,7 @@ const data4: Protocol[] = [
     dimensions: {
       fees: "edgex",
       derivatives: {
-        genuineSpikes: ["1722988800", "1723075200"],
+        genuineSpikes: [["2024-08-07", "-"], ["2024-08-08", "-"]],
         adapter: "edgeX"
       },
       "open-interest": "edgeX",
@@ -25285,11 +25285,11 @@ const data4: Protocol[] = [
     dimensions: {
       fees: "paradex",
       derivatives: {
-        genuineSpikes: ["1722816000"],
+        genuineSpikes: [["2024-08-05", "-"]],
         adapter: "paradex"
       },
       "open-interest": {
-        genuineSpikes: ["1759190400"],
+        genuineSpikes: [["2025-09-30", "-"]],
         adapter: "paradex"
       },
       "normalized-volume": "paradex"
@@ -27106,7 +27106,7 @@ const data4: Protocol[] = [
     dimensions: {
       derivatives: {
         adapter: "injective-derivatives",
-        genuineSpikes: ["1759104000"],
+        genuineSpikes: [["2025-09-29", "-"]],
       },
       "open-interest": "injective-derivatives"
     },

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -5488,7 +5488,7 @@ const data5: Protocol[] = [
     dimensions: {
       fees: {
         adapter: "grayscale",
-        genuineSpikes: ["1765929600"]
+        genuineSpikes: [["2025-12-17", "-"]]
       }
     },
   },

--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -116,9 +116,9 @@ export const chainCoingeckoIds = {
     dimensions: {
       fees: {
         genuineSpikes: [
-          "1651449600",
-          "1651363200", // otherside mint
-          "1760054400", // 2025-10-10 - sharp drop in the market - Black Friday
+          ["2022-05-02", "-"],
+          ["2022-05-01", "Otherside mint"], // otherside mint
+          ["2025-10-10", "Sharp drop in the market - Black friday"], // 2025-10-10 - sharp drop in the market - Black Friday
         ],
         adapter: "ethereum",
       },

--- a/defi/utils/dimension-scripts/moveConfig.ts
+++ b/defi/utils/dimension-scripts/moveConfig.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { visit } from "ast-types";
 import loadAdaptorsData from "../../src/adaptors/data";
 import { ADAPTER_TYPES } from "../../src/adaptors/data/types";
+import { unixTimeToTimeS } from "../../src/api2/utils/time";
 
 const TS_PARSER = require("recast/parsers/typescript");
 const b = R.builders;
@@ -71,10 +72,10 @@ function initData() {
           case 'cleanRecordsConfig':
             const genuineSpikes = otherConfig.cleanRecordsConfig.genuineSpikes
             if (!genuineSpikes) break;
-            const spikes: any = []
+            const spikes: [string, string][] = []
             Object.entries(genuineSpikes).forEach(([ts, bool]) => {
               if (bool) {
-                spikes.push(ts)
+                spikes.push([unixTimeToTimeS(Number(ts)), "-"])
               }
             })
             if (spikes.length)


### PR DESCRIPTION
Update the genuineSpikes data structure across multiple protocol files to utilize date strings instead of timestamps, improving readability and maintainability. Adjust normalization logic and related utility functions for consistency with the new format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Protocol spike metadata format updated: changed from Unix timestamp strings to structured date-reason tuples using YYYY-MM-DD format.
  * Protocol adapter configuration expanded with new optional properties for address management, timeline initialization, protocol hierarchies, and lifecycle status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->