### PR TITLE
rwa: fix treasury protocol names in breakdown metrics

### DIFF
--- a/defi/src/rwa/cron.ts
+++ b/defi/src/rwa/cron.ts
@@ -57,7 +57,9 @@ function convertChainKeysToLabelsNestedNumber(
       for (const [protocolKey, value] of Object.entries(protocols)) {
         const isTreasury = protocolKey.endsWith('-treasury');
         const normalizedProtocolKey = isTreasury ? protocolKey.slice(0, -'-treasury'.length) : protocolKey;
-        const protocolLabel = (normalizedProtocolKey.startsWith('parent#') ? parentProtocolsById[protocolKey]?.name : protocolsById[protocolKey]?.name) ?? protocolKey;
+        const protocolLabel = (normalizedProtocolKey.startsWith('parent#')
+          ? parentProtocolsById[normalizedProtocolKey]?.name
+          : protocolsById[normalizedProtocolKey]?.name) ?? protocolKey;
         const finalProtocolLabel = isTreasury ? `${protocolLabel} (Treasury)` : protocolLabel;
         outProtocols[finalProtocolLabel] = toFiniteNumberOrZero(value);
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where protocol names were inconsistently resolved in certain scenarios, ensuring accurate labeling throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->