### PR TITLE
bl usd+ on un-continue chains

### DIFF
--- a/coins/src/adapters/other/distressed.ts
+++ b/coins/src/adapters/other/distressed.ts
@@ -102,7 +102,7 @@ export const contracts: { [chain: string]: { [token: string]: string } } = {
     SFUND:"0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
   },
   bsc: {
-    'USD+': "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65", // mint out of think air, very low liquiity
+    'USD+': "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65", // https://x.com/overnight_fi/status/2000631797848187322
     USD_T: "0x5e0a1d876557cf43c66c08c8a247bc4954eca8bd", // mint out of think air, very low liquiity
     SFUND: "0x477bc8d23c634c154061869478bce96be6045d12",
     SFUND_1: "0x560363bda52bc6a44ca6c8c9b4a5fadbda32fa60",
@@ -223,7 +223,7 @@ export const contracts: { [chain: string]: { [token: string]: string } } = {
     BIFI: "0x765277eebeca2e31912c9946eae1021199b39c61",
   },
   polygon: {
-    'USD+': "0x236eec6359fb44cce8f97e99387aa7f8cd5cde1f",
+    'USD+': "0x236eec6359fb44cce8f97e99387aa7f8cd5cde1f", // https://x.com/overnight_fi/status/2000631797848187322
     FEVR: "0xe6b9d092223f39013656702a40dbe6b7decc5746",
     BELUGA: "0x47536f17f4ff30e64a96a7555826b8f9e66ec468",
     BIFI: "0xfbdd194376de19a88118e84e279b977f165d01b8",
@@ -252,13 +252,13 @@ export const contracts: { [chain: string]: { [token: string]: string } } = {
     MIM: "0x218c3c3d49d0e7b37aff0d8bb079de36ae61a4c0",
   },
   optimism: {
-    'USD+': "0x73cb180bf0521828d8849bc8CF2B920918e23032",
+    'USD+': "0x73cb180bf0521828d8849bc8CF2B920918e23032", // https://x.com/overnight_fi/status/2000631797848187322
     MIM: "0xb153fb3d196a8eb25522705560ac152eeec57901",
     GRAIN: "0xfd389dc9533717239856190f42475d3f263a270d",
     clBTC: "0x1792865d493fe4dfdd504010d3c0f6da11e8046d", // IS NOT BACKED
   },
   era: {
-    'USD+': "0x8E86e46278518EFc1C5CEd245cBA2C7e3ef11557",
+    'USD+': "0x8E86e46278518EFc1C5CEd245cBA2C7e3ef11557", // https://x.com/overnight_fi/status/2000631797848187322
     MVX: "0xc8ac6191cdc9c7bf846ad6b52aaaa7a0757ee305",
   },
   metis: {
@@ -366,7 +366,7 @@ export const contracts: { [chain: string]: { [token: string]: string } } = {
     ESBTC: "0xaFB068838136358CFa6B54BEa580B86DF70BBA7f",
   },
   linea: {
-    'USD+': "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
+    'USD+': "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376", // https://x.com/overnight_fi/status/2000631797848187322
   },
   // merlin: {
   //   'SolvBTC.BBN': "0x1760900aca15b90fa2eca70ce4b4ec441c2cf6c5"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added USD+ token support across BSC, Polygon, Optimism, Era and XSat (Linea) networks.
  * Integrated Linea as a supported chain under XSat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->