### PR TITLE
Add ENI chain metadata and WEGAS price mapping

### DIFF
--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -5017,9 +5017,9 @@ export const chainCoingeckoIds = {
     },
   },
   "ENI": {
-    geckoId: "eni",
+    geckoId: null,
     symbol: "ENI",
-    cmcId: "36784",
+    cmcId: null,
     categories: ["EVM"],
     twitter: "ENI__Official",
     url: "https://eni.top/",


### PR DESCRIPTION
Adds pricing support for ENI (chainId 173) by:
- Mapping WEGAS to CoinGecko (`wrapped-egas`)
- Registering ENI chain metadata (geckoId, cmcId)

This enables correct USD pricing for ENI-based protocols, including DEX volume and fee calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the WEGAS token on the ENI chain, including metadata and price mapping to an external market source.

* **Chores**
  * Updated ENI chain identifiers (CoinGecko and CoinMarketCap IDs) for improved asset discovery and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->