### PR TITLE
add dead chains

### DIFF
--- a/defi/src/config/deadChains.ts
+++ b/defi/src/config/deadChains.ts
@@ -1,10 +1,11 @@
 
 export const deadChains = [
-  'heco', 'astrzk', 'real', 'milkomeda', 'milkomeda_a1', 
-  'eos_evm', 'eon', 'plume', 'bitrock', 'rpg', 'kadena', 'migaloo', 
+  'heco', 'astrzk', 'real', 'milkomeda', 'milkomeda_a1',
+  'eos_evm', 'eon', 'plume', 'bitrock', 'rpg', 'kadena', 'migaloo',
   'kroma', 'qom', 'airdao', 'bevm',
   'milkyway', 'milkyway_rollup', 'boba_bnb',
   'kardia', // deprecated in favor of kai 2.0 https://docs.kardiachain.io/docs/from-kyokai-to-kai-2.0
+  'nos', 'dfs'
 ]
 
 


### PR DESCRIPTION
add [dfs](https://defillama.com/chain/dfs-network) and [nos](https://defillama.com/chain/nos) to dead chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the blockchain chains configuration by adding two new entries: "nos" and "dfs", enabling the platform to manage additional blockchain networks within its ecosystem.
  * Improved the configuration file structure through better formatting and organizational enhancements to ensure code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->