### PR TITLE
hide binance cex inflows

### DIFF
--- a/defi/src/api2/cron-task/cex.ts
+++ b/defi/src/api2/cron-task/cex.ts
@@ -29,7 +29,7 @@ const cexes = protocols.filter(p => p.category === 'CEX')
 const cexNameMap: { [name: string]: any } = {}
 const cexMetadataIdMap: { [id: string]: any } = {}
 
-
+const HIDE_INFLOWS = new Set(['Binance'])
 
 cexes.forEach(c => {
   let name = c.name
@@ -176,6 +176,8 @@ async function addAssetData() {
         console.warn(`CEX with id ${id} not found in protocols data: ${fieldName} ${cexMetadataIdMap[item.id]?.name}`)
         return
       }
+
+      if (HIDE_INFLOWS.has(cex.name)) return
 
       cex[fieldName] = item.outflows
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Inflows data from specific centralized exchanges (including Binance) are now excluded from aggregated calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->