### PR TITLE
chore: rename from "Gate Perp DEX" to "Gate DEX", update URLs, and adjust Twitter handle.

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -3616,11 +3616,11 @@ const data5: Protocol[] = [
   },
   {
     id: "7049",
-    name: "Gate Perp DEX",
+    name: "Gate DEX",
     address: null,
     symbol: "-",
-    url: "https://www.gatesite.casa/web3/ref?code=nufLft0L",
-    referralUrl: "https://www.gatesite.casa/web3/ref?code=nufLft0L",
+    url: "https://www.gatedex.com/r/nufLft0L",
+    referralUrl: "https://www.gatedex.com/r/nufLft0L",
     description: "Perp DEX on Gate Layer.",
     chain: "GateLayer",
     logo: `${baseIconsUrl}/gate-perp-dex.jpg`,
@@ -3630,7 +3630,7 @@ const data5: Protocol[] = [
     category: "Derivatives",
     chains: ["GateLayer"],
     module: "dummy.js",
-    twitter: "GatePerpDEX",
+    twitter: "GateDEX",
     dimensions: {
       derivatives: "gate-perps",
     },


### PR DESCRIPTION
I've updated the protocol entry for id: 7049 in data5.ts with the following changes:
- Renamed the protocol name from 'Gate Perp DEX' to 'Gate DEX'
- Updated the URL and referralUrl to the new domain (gatedex.com)
- Changed the Twitter handle from 'GatePerpDEX' to 'GateDEX'