### PR TITLE
Add cap price adapters

### DIFF
--- a/coins/src/adapters/other/cap.ts
+++ b/coins/src/adapters/other/cap.ts
@@ -27,7 +27,7 @@ export default async function getTokenPrices(timestamp: number) {
         chain,
         cUSD,
         Number(cUSDPriceRes.output) / (10 ** 8),
-        8,
+        18,
         "cUSD",
         timestamp,
         "cap",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automated price collection for cUSD using an on-chain oracle.
  * Computes derived 4626-based prices for stcUSD from the same snapshot.
  * Aggregates timestamped pricing entries for downstream storage and processing.
  * Returns consolidated price records for the requested timestamp to support reporting and analytics.
  * Provides a single API callable by timestamp for historical price retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->