### PR TITLE
Revert "hide binance cex inflows"

### DIFF
--- a/defi/src/api2/cron-task/cex.ts
+++ b/defi/src/api2/cron-task/cex.ts
@@ -29,7 +29,7 @@ const cexes = protocols.filter(p => p.category === 'CEX')
 const cexNameMap: { [name: string]: any } = {}
 const cexMetadataIdMap: { [id: string]: any } = {}
 
-const HIDE_INFLOWS = new Set(['Binance'])
+
 
 cexes.forEach(c => {
   let name = c.name
@@ -176,8 +176,6 @@ async function addAssetData() {
         console.warn(`CEX with id ${id} not found in protocols data: ${fieldName} ${cexMetadataIdMap[item.id]?.name}`)
         return
       }
-
-      if (HIDE_INFLOWS.has(cex.name)) return
 
       cex[fieldName] = item.outflows
 


### PR DESCRIPTION
Reverts DefiLlama/defillama-server#11374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing inflow data from being collected and displayed for certain cryptocurrency exchanges. Inflow information is now properly populated across all supported exchange platforms, including major CEXs that were previously excluded from data collection. Users now have complete visibility into cryptocurrency inflow patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->