### PR TITLE
delist metastable vol

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -1985,7 +1985,7 @@ const data4: Protocol[] = [
     oraclesBreakdown: [{ name: "Pyth", type: "Primary", proof: [] }],
     listedAt: 1737379687,
     dimensions: {
-      dexs: "metastable-musd"
+      // dexs: "metastable-musd", it's not a DEX, the adapter is tracking volume from stablecoin dex pools
     }
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected protocol metadata for Metastable to accurately reflect that it's an adapter tracking stablecoin pool volumes rather than a DEX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->