### PR TITLE
add algorand case to coingeckoUtils

### DIFF
--- a/coins/src/scripts/coingeckoUtils.ts
+++ b/coins/src/scripts/coingeckoUtils.ts
@@ -185,6 +185,18 @@ export async function getSymbolAndDecimals(
           decimals: await ethApi.call({ target: tokenAddress, abi: "erc20:decimals" }),
         };
       } else { return; }
+    case 'algorand':
+      try {
+        const { asset: { params: algoParams } } = await fetch(
+          `https://mainnet-api.algonode.cloud/v2/assets/${tokenAddress}`,
+        ).then((r) => r.json()) as any;
+        return {
+          symbol: algoParams['unit-name'] ?? algoParams.name ?? coingeckoSymbol.toUpperCase(),
+          decimals: algoParams.decimals,
+        };
+      } catch (e) {
+        return;
+      }
   }
 
 


### PR DESCRIPTION
adds algorand case to `getSymbolAndDecimals()`
- uses https://mainnet-api.algonode.cloud/v2/assets/ to fetch token info ([USDC example](https://mainnet-api.algonode.cloud/v2/assets/31566704))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Algorand tokens with automatic symbol and decimal precision retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->