### PR TITLE
adding Royco Dawn (senior USDC Vault)

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -190,5 +190,6 @@ export default {
   shift: require("./yield/shift"),
   makina: require("./yield/makina"),
   stORE: require("./solana/stORE"),
-  accountable: require("./yield/accountable")
+  accountable: require("./yield/accountable"),
+  roycodawn: require("./yield/roycodawn")
 };

--- a/coins/src/adapters/yield/roycodawn.ts
+++ b/coins/src/adapters/yield/roycodawn.ts
@@ -1,0 +1,10 @@
+import { calculate4626Prices } from "../utils/erc4626";
+
+const chain = "ethereum";
+const tokens = [
+  "0xcd9f5907f92818bc06c9ad70217f089e190d2a32", // srRoycoUSDC
+];
+
+export async function roycodawn(timestamp: number = 0) {
+  return calculate4626Prices(chain, timestamp, tokens, "roycodawn");
+}


### PR DESCRIPTION
Adding a new ERC4626 vault for Royco Dawn.

Contract address here: https://etherscan.io/address/0xba1333333333a1ba1108e8412f11850a5c319ba9

Let me know if anything more is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Roycodawn adapter integration to support additional yield pricing calculations on the Ethereum network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->