### PR TITLE
Update Oracles for World Markets, Canonic & Prism.ts

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -8237,6 +8237,12 @@ const data5: Protocol[] = [
     chains: ["MegaETH"],
     module: "prism-dex/index.js",
     twitter: "PrismFi_",
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://prismfi.cc/docs/overview"],
+      },
     forkedFromIds: ["2198"],
     listedAt: 1768842182
   },
@@ -10348,6 +10354,12 @@ const data5: Protocol[] = [
     chains: ["MegaETH"],
     module: "canonic/index.js",
     twitter: "_canonic",
+     oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://docs.canonic.trade/trading/contract-deployments"],
+      },
     dimensions: {
       dexs: "canonic",
       fees: "canonic",
@@ -10820,6 +10832,12 @@ const data5: Protocol[] = [
     chains: ["MegaETH"],
     module: "worldinc/index.js",
     twitter: "worldmarketsinc",
+    oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://docs.world.inc/venue/technical-overview#general"],
+      },
     listedAt: 1770909499,
   },
   {


### PR DESCRIPTION
Hey Llamas, 

Kindly asking you to update the Oracles section to reflect RedStone as primary for World Marekts, Prism & Canonic on MegaETH.

Proof: 
https://docs.world.inc/venue/technical-overview#general
https://docs.canonic.trade/trading/contract-deployments
https://prismfi.cc/docs/overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle breakdown information to selected protocols, displaying oracle sources (e.g., RedStone), types, and proof references for greater transparency on data feeds used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->