### PR TITLE
bump TVL_CACHE_FOLDER version to v0.10

### DIFF
--- a/defi/src/api2/cache/file-cache.ts
+++ b/defi/src/api2/cache/file-cache.ts
@@ -140,7 +140,7 @@ export async function writeToPGCache(key: string, data: any) {
 
 // it is no longer needed thanks to change to deleteFromPGCache
 // ANY CHANGE TO THIS VALUE NEEDS TO BE SYNCED WITH A CHANGE ON https://github.com/DefiLlama/born-to-llama/blob/master/src/commands/deleteCache.ts#L30 TOO
-let TVL_CACHE_FOLDER = 'tvl-cache-daily-v0.9'  // update the version number to reset the cache
+let TVL_CACHE_FOLDER = 'tvl-cache-daily-v0.10'  // update the version number to reset the cache
 if (process.env.LLAMA_RUN_LOCAL === 'true') {
   TVL_CACHE_FOLDER = 'tvl-cache-daily'
 }


### PR DESCRIPTION
Updated TVL_CACHE_FOLDER version to v0.10 to reset the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache version to optimize data handling and storage across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->