### PR TITLE
Update Oracle for Seamless V2

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -16814,7 +16814,7 @@ const data4: Protocol[] = [
         name: "Chainlink",
         type: "Primary",
         proof: ["https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/wsteth-eth-25x", "https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/susds-usdt-25x", "https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/siusd-usdc-11x", "https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/rlp-usdc-6.75x"],
-        startDate: "2024-02-25"
+        startDate: "2026-02-25"
       },
     ],
     dimensions: {


### PR DESCRIPTION
Hi,
I noticed that Seamless’ TVL has been attributed to Redstone, but this appears to be based on [outdated documentation](https://docs.seamlessprotocol.com/technical/oracles) and is no longer accurate.

While Seamless was initially built on an Aave V3 fork, the protocol has since [migrated its core lending activity to Morpho](https://morpho.org/blog/seamless-2-0-powered-by-morpho/). This transition enabled the team to focus on developing its primary DeFi primitive, Leverage Tokens (LTs).

The oracle infrastructure supporting the LTs is powered by Chainlink, as reflected in the relevant documentation pages below:

- https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/wsteth-eth-25
- https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/susds-usdt-25
- https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/siusd-usdc-11
- https://docs.seamlessprotocol.com/overview/leverage-tokens-lts/ethereum-mainnet-lts/rlp-usdc-6.75

Given this, the TVL should be attributed to Chainlink as the oracle provider rather than to Redstone.
Please let me know if any additional clarification would be helpful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected oracle label from RedStone to Chainlink so displayed oracle names are accurate.

* **New Features**
  * Added an explicit start date and a second Chainlink entry with proof sources so users can see oracle timing and source references in the protocol breakdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->