### PR TITLE
Added a bunch of missing chains to Chainlink on chainsByOracle.ts

### DIFF
--- a/defi/src/constants/chainsByOracle.ts
+++ b/defi/src/constants/chainsByOracle.ts
@@ -241,7 +241,7 @@ const chainsByOracle: Record<string, Array<string>> = {
     "Canto",
     "CLV",
     "Conflux",
-    "Core",
+    "CORE",
     "Cronos",
     "Dogechain",
     "Elastos",


### PR DESCRIPTION
Hello Defillama team,

This PR is to add a bunch of chains that were missing for Chainlink in the chainsByOracle.ts file. Chainlink is not appearing on the chain-specific TVS page for each of these chains (ie. for Aptos, it is missing here: https://defillama.com/oracles/chain/aptos). This should fix these errors.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Chainlink oracle support to include a large set of additional blockchain networks, increasing network coverage and compatibility. This broadens the range of chains available for oracle-backed integrations and improves flexibility for multi-chain workflows, enabling more connections and use cases across a wider ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->