### PR TITLE
uni decimals patch

### DIFF
--- a/coins/src/adapters/utils/uniV2.ts
+++ b/coins/src/adapters/utils/uniV2.ts
@@ -205,7 +205,7 @@ export function getUniV2Adapter({
         if (skipToken(token)) return;
         if (!price) return;
         const liquidity = price * pair.totalSupply / 2;
-        const supply = token.id === token0.id ? token0Balances[i] : token1Balances[i];
+        const supply = (token.id === token0.id ? token0Balances[i] : token1Balances[i]) / 10 ** token.decimals
         if (!tokenData[token.id]) {
           tokenData[token.id] = {
             metadata: token,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LP token supply calculations for UniV2 adapters to properly account for token decimals, improving accuracy of liquidity and token supply metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->