### PR TITLE
Update Oracles for Yuzu.ts

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -2385,6 +2385,13 @@ const data5: Protocol[] = [
     chains: ["Plasma"],
     module: "yuzu-money/index.js",
     twitter: "YuzuMoneyX",
+     oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://yuzu-money.gitbook.io/yuzu-money/transparency/oracles"]
+      }
+    ],
     audit_links: [
       "https://yuzu-money.gitbook.io/yuzu-money/security-infrastructure/audits",
       "https://github.com/pashov/audits/blob/master/team/pdf/YuzuUSD-security-review_2025-08-28.pdf",


### PR DESCRIPTION
Hey Lamas,

Kindly asking you to update Oracles for Yuzu Money.

Oracle Provider(s): RedStone.

Implementation details and quote:  "Yuzu Money utilizes RedStone Oracles as its primary data provider to ensure high-fidelity, real-time market feeds. Yuzu Money leverages multiple oracle data sources and all strategies undergo a rigorous review prior to on-chain deployment." 

[Documenation/Proof: https://docs.cap.app/concepts/oracles](https://yuzu-money.gitbook.io/yuzu-money/transparency/oracles)

Appreciative as always for your work.

Isaac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle information for Yuzu Money, displaying RedStone as the primary oracle with transparency documentation reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->