### PR TITLE
Update Oracles for Kinetic.ts

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -49079,6 +49079,12 @@ const data3_3: Protocol[] = [
     module: "kinetic/index.js",
     twitter: "Kinetic_Markets",
     audit_links: ["https://kinetic.market/assets/Kinetic-audit-reports.pdf"],
+	  oraclesBreakdown: [
+      {
+        name: "RedStone",
+        type: "Primary",
+        proof: ["https://docs.kinetic.market/oracles-and-pricing"],
+      },
     github: ["kinetic-market"],
     listedAt: 1721723353,
     dimensions: {

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -49082,7 +49082,7 @@ const data3_3: Protocol[] = [
 	  oraclesBreakdown: [
       {
         name: "RedStone",
-        type: "Primary",
+        type: "Secondary",
         proof: ["https://docs.kinetic.market/oracles-and-pricing"],
       },
     github: ["kinetic-market"],


### PR DESCRIPTION
Hey Llamas,

Kindly asking you to update the Oracles for Kinetic

Oracle Provider(s): RedStone.

Implementation details: "RedStone the primary external oracle."

Documenation/Proof: https://docs.kinetic.market/oracles-and-pricing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kinetic protocol metadata to include oracle provider information, identifying RedStone as a secondary oracle and adding proof/reference links for improved data-source transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->