### PR TITLE
Loosen restriction to include prices for more vaults in Euler V2

### DIFF
--- a/coins/src/adapters/moneyMarkets/euler/eulerV2.ts
+++ b/coins/src/adapters/moneyMarkets/euler/eulerV2.ts
@@ -151,7 +151,7 @@ function formWrites(
     if (coinData == null || rate == null || !m.currentAmount) return;
 
     const tvl = (m.currentAmount * coinData.price) / 10 ** coinData.decimals;
-    if (tvl < 1e5) return; // filtering out small markets
+    if (tvl < 100) return; // filtering out small markets
 
     const eTokenPrice: number = coinData.price * rate;
 


### PR DESCRIPTION
Only getting prices for vault with $100K in them is too restrictive. There are some Euler Vaults like [VII Finance](https://www.vii.finance/markets?chain=Ethereum&market=vii-ethereum) Euler vaults that will benefit from Defillama being able to price their vault tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded market coverage by adjusting the filtering criteria to include smaller markets in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->