### PR TITLE
feat: add HypeZion Finance token pricing adapter

### DIFF
--- a/coins/src/adapters/other/hypezion.ts
+++ b/coins/src/adapters/other/hypezion.ts
@@ -18,8 +18,7 @@ const HZUSD = "0x6E2ade6FFc94d24A81406285c179227dfBFc97CE";
 const BULLHYPE = "0x12cF926C3884dda144e18E11e2659c0675cF20eA";
 const STAKED_HZUSD = "0xce01a9B9bc08f0847fb745044330Eff1181360Cd";
 
-// HypeZionExchangeInformation proxy
-// TODO: Verify address after deploying ExchangeInformation upgrade
+// HypeZionExchangeInformation proxy (Hyperliquid Mainnet)
 const EXCHANGE_INFO = "0x9286ABAC7c29e8A183155E961a4E4BBA2E162c7A";
 
 const abis = {

--- a/coins/src/adapters/other/hypezion.ts
+++ b/coins/src/adapters/other/hypezion.ts
@@ -1,0 +1,67 @@
+import { Write } from "../utils/dbInterfaces";
+import { getApi } from "../utils/sdk";
+import getWrites from "../utils/getWrites";
+
+/**
+ * HypeZion Finance — Token Pricing Adapter
+ *
+ * Provides pricing data for HypeZion protocol tokens on Hyperliquid L1:
+ *   - hzUSD: stablecoin pegged to $1, price derived from on-chain NAV
+ *   - BullHYPE: leverage token, price = zHYPE NAV in HYPE × HYPE price
+ *   - shzUSD: staked hzUSD vault share, price = share price from ERC-4626
+ */
+
+const chain = "hyperliquid";
+
+// Token addresses (Hyperliquid Mainnet)
+const HZUSD = "0x6E2ade6FFc94d24A81406285c179227dfBFc97CE";
+const BULLHYPE = "0x12cF926C3884dda144e18E11e2659c0675cF20eA";
+const STAKED_HZUSD = "0xce01a9B9bc08f0847fb745044330Eff1181360Cd";
+
+// HypeZionExchangeInformation proxy
+// TODO: Verify address after deploying ExchangeInformation upgrade
+const EXCHANGE_INFO = "0x9286ABAC7c29e8A183155E961a4E4BBA2E162c7A";
+
+const abis = {
+  getProtocolNavInUSD:
+    "function getProtocolNavInUSD() view returns (uint256 zusdNav, uint256 zhypeNav, uint256 szusdNav, uint256 hypePrice)",
+  totalAssets: "uint256:totalAssets",
+  totalSupply: "uint256:totalSupply",
+};
+
+export default async function getTokenPrices(timestamp: number = 0) {
+  const api = await getApi(chain, timestamp);
+  const pricesObject: any = {};
+
+  // Fetch NAVs from ExchangeInformation
+  const navData = await api.call({
+    target: EXCHANGE_INFO,
+    abi: abis.getProtocolNavInUSD,
+  });
+
+  const zusdNav = Number(navData.zusdNav) / 1e18; // hzUSD NAV in USD (~$1)
+  const zhypeNav = Number(navData.zhypeNav) / 1e18; // BullHYPE NAV in USD
+  const szusdNav = Number(navData.szusdNav) / 1e18; // shzUSD NAV in USD (share price)
+
+  // hzUSD — stablecoin pegged to $1
+  if (zusdNav > 0) {
+    pricesObject[HZUSD] = { price: zusdNav };
+  }
+
+  // BullHYPE — leverage token
+  if (zhypeNav > 0) {
+    pricesObject[BULLHYPE] = { price: zhypeNav };
+  }
+
+  // shzUSD — staked hzUSD vault share price
+  if (szusdNav > 0) {
+    pricesObject[STAKED_HZUSD] = { price: szusdNav };
+  }
+
+  return getWrites({
+    chain,
+    timestamp,
+    pricesObject,
+    projectName: "hypezion-finance",
+  });
+}

--- a/coins/src/adapters/other/index.ts
+++ b/coins/src/adapters/other/index.ts
@@ -560,6 +560,7 @@ async function matrixdock(timestamp: number = 0, writes: Write[] = []) {
 export const adapters = {
   symboitic,
   defiChain,
+  hypezion,
   shlb,
   metronome,
   buck,

--- a/coins/src/adapters/other/index.ts
+++ b/coins/src/adapters/other/index.ts
@@ -35,6 +35,7 @@ import gmdV2 from "./gmdV2";
 import { getApi } from "../utils/sdk";
 import getWrites from "../utils/getWrites";
 import cap from "./cap";
+import hypezionAdapter from "./hypezion";
 
 export { glp };
 
@@ -58,6 +59,9 @@ export function opdx(timestamp: number = 0) {
 }
 export function defiChain(timestamp: number = 0) {
   return defiChainAdapter(timestamp);
+}
+export function hypezion(timestamp: number = 0) {
+  return hypezionAdapter(timestamp);
 }
 export function synthetix(timestamp: number = 0) {
   return synthetixAdapter(timestamp);


### PR DESCRIPTION
## HypeZion Finance — Token Pricing Adapter

**Protocol**: Structured product protocol on Hyperliquid L1, issues
stablecoin (hzUSD) and leverage token (BullHYPE) backed by HYPE reserves.

**Chain**: Hyperliquid

### Tokens priced
| Token | Address | Methodology |
|---|---|---|
| hzUSD | 0x6E2ade6FFc94d24A81406285c179227dfBFc97CE | Stablecoin NAV (reserve/supply), ~$1 |
| BullHYPE | 0x12cF926C3884dda144e18E11e2659c0675cF20eA | zHYPE NAV × HYPE price (leverage token) |
| shzUSD | 0xce01a9B9bc08f0847fb745044330Eff1181360Cd | ERC-4626 share price |

### How it works
Single on-chain call to `getProtocolNavInUSD()` on our `ExchangeInformation`
contract returns all 3 NAVs in USD (18 decimals). All pricing is on-chain —
no off-chain oracle. Uses standard `getWrites()` with default confidence 0.98.

### Local test output
| symbol   | price   |
|----------|---------|
| hzUSD    | 1.00    |
| bullHYPE | 72.11   |
| shzUSD   | 1.0447  |

### Related PRs
- TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/18573
- Yield adapter: https://github.com/DefiLlama/yield-server/pull/2529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HypeZion pricing adapter to retrieve real-time pricing data for HZUSD, BullHYPE, and shzUSD tokens on the Hyperliquid chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->