### PR TITLE
Fix search ranking to prioritize exact matches over popularity

### DIFF
--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -38,12 +38,12 @@ curl \
   -H 'Content-Type: application/json' \
   --data-binary '[
     "words",
-    "v:desc",
     "typo",
+    "exactness",
     "proximity",
     "attribute",
+    "v:desc",
     "sort",
-    "exactness",
     "r:desc"
   ]'
 
@@ -93,12 +93,12 @@ curl \
   -H 'Content-Type: application/json' \
   --data-binary '[
     "words",
-    "v:desc",
     "typo",
+    "exactness",
     "proximity",
     "attribute",
+    "v:desc",
     "sort",
-    "exactness",
     "r:desc"
   ]'
 

--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -39,11 +39,11 @@ curl \
   --data-binary '[
     "words",
     "typo",
-    "exactness",
     "proximity",
     "attribute",
     "v:desc",
     "sort",
+    "exactness",
     "r:desc"
   ]'
 
@@ -94,11 +94,11 @@ curl \
   --data-binary '[
     "words",
     "typo",
-    "exactness",
     "proximity",
     "attribute",
     "v:desc",
     "sort",
+    "exactness",
     "r:desc"
   ]'
 


### PR DESCRIPTION
## Summary
- Reorder Meilisearch ranking rules so `typo` and `exactness` come before `v:desc` (popularity) for both `pages` and `directory` indexes
- Fixes exact-match protocols (e.g. "Stabble", "Market") being buried behind popular fuzzy matches (e.g. "Stablecoins by Market Cap", "Prediction Market")

## Test plan
- After merging, run the two ranking-rules `curl` commands from `setup.sh` with `SEARCH_MASTER_KEY` to apply the new settings to Meilisearch
- Search "stabble" and verify the Stabble protocol appears near the top
- Search "market" and verify protocols named "Market" appear before unrelated popular pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the ordering of search ranking rules to change the priority of specific ranking criteria, improving search result ordering while preserving all existing rules and their behavior. No public APIs or exports were affected and the change is configuration-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->