### PR TITLE
Add Yield AI protocol listing

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -17599,19 +17599,19 @@ const data5: Protocol[] = [
     name: "Yield AI",
     address: null,
     symbol: "-",
-    url: " ", // pending to add url https://yieldai.app/
+    url: "https://yieldai.app/",
     description:
-      "Yield AI is a DeFi dashboard for Aptos that integrates 10+ protocols and an AI Agent in one interface. Track balances and positions, compare APRs, and deposit, withdraw, swap, and claim rewards gaslessly to maximize yield",
+      "Yield AI is a DeFi dashboard for Aptos that integrates 10+ protocols and an AI Agent in one interface. Track balances and positions, compare APRs, and deposit, withdraw, swap, and claim rewards gaslessly — all to maximize your yield.",
     chain: "Aptos",
-    logo: `${baseIconsUrl}/yield-ai.jpg`,
+    logo: `${baseIconsUrl}/yield-ai.png`,
     audits: "0",
     gecko_id: null,
     cmcId: null,
-    category: "Yield Aggregator",
+    category: "AI Agents",
     chains: ["Aptos"],
     module: "yield-ai/index.js",
     twitter: "yieldai_app",
-    listedAt: 1776367461
+    listedAt: 1776370734,
   },
 ];
 export default data5;


### PR DESCRIPTION
## Summary
Adds a new protocol listing for **Yield AI** on **Aptos**.

## Adapter PR
TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/18684  
Module: `yield-ai/index.js`

## Notes
- **Category**: AI Agents
- **Website**: https://yieldai.app/
- **Twitter**: https://x.com/yieldai_app
- **Logo**: `yield-ai.png` via `https://icons.llama.fi/yield-ai.png` (icons PR: https://github.com/DefiLlama/icons/pull/2356 — update if different)

## TVL methodology (high level)
TVL is computed on-chain for Aptos vault safes (FA balances via Aptos Labs indexer + native APT via `0x1::coin::balance`) plus Moar supply positions per safe via Moar lens views. The adapter sets `doublecounted: true` due to overlap with the separate Moar listing.

## Checklist
- [x] `id` is `max(existing ids) + 1` in `data5.ts` at PR time
- [x] `listedAt` updated to current unix timestamp at PR time
- [x] `module` matches merged/merging adapter path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated protocol entry for Yield AI (Aptos): now categorized as "AI Agents" with an updated website, refreshed logo and revised description for improved discovery.

* **Notes**
  * Listing timestamp adjusted and formatting/metadata cleaned; no protocols were removed in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->