### PR TITLE
Add Mycelia Signal — sovereign HTTP oracle with MSVI volatility index

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -16422,7 +16422,7 @@ const data5: Protocol[] = [
     openSource: true,
     github: ["jonathanbulkeley"],
     oracles: [],
-    listedAt: 1744200000,
+    listedAt: 1775795858, // 2026-04-10T04:37:38Z (PR created time)
     methodology: "Each oracle response contains a canonical string signed with Ed25519. Signatures independently verifiable against published public key. Price feeds use median aggregation across 3-9 exchanges. MSVI is a 5-component weighted volatility index (Parkinson RV 30%, Deribit IV 25%, term structure 15%, funding rate 20%, put/call ratio 10%).",
   },
 ];

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -16404,7 +16404,7 @@ const data5: Protocol[] = [
     listedAt: 1775776709
   },
   {
-    id: 7650,
+    id: "7650",
     name: "Mycelia Signal",
     address: null,
     symbol: "-",
@@ -16413,8 +16413,12 @@ const data5: Protocol[] = [
     chain: "Multi-Chain",
     logo: "https://myceliasignal.com/logo.png",
     audits: "0",
+    gecko_id: null,
+    cmcId: null,
     category: "Oracle",
+    chains: ["Multi-Chain"],
     twitter: "myceliasignal",
+    module: "dummy.js",
     openSource: true,
     github: ["jonathanbulkeley"],
     oracles: [],

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -16403,5 +16403,23 @@ const data5: Protocol[] = [
     parentProtocol: "parent#dexfinance",
     listedAt: 1775776709
   },
+  {
+    id: 7650,
+    name: "Mycelia Signal",
+    address: null,
+    symbol: "-",
+    url: "https://myceliasignal.com",
+    description: "Sovereign HTTP oracle serving cryptographically signed price data, economic indicators, and the MSVI volatility index. 63 endpoints. Pay-per-query via Lightning (L402) or USDC on Base (x402). No API keys. Ed25519 signed attestations independently verifiable against published public keys.",
+    chain: "Multi-Chain",
+    logo: "https://myceliasignal.com/logo.png",
+    audits: "0",
+    category: "Oracle",
+    twitter: "myceliasignal",
+    openSource: true,
+    github: ["jonathanbulkeley"],
+    oracles: [],
+    listedAt: 1744200000,
+    methodology: "Each oracle response contains a canonical string signed with Ed25519. Signatures independently verifiable against published public key. Price feeds use median aggregation across 3-9 exchanges. MSVI is a 5-component weighted volatility index (Parkinson RV 30%, Deribit IV 25%, term structure 15%, funding rate 20%, put/call ratio 10%).",
+  },
 ];
 export default data5;


### PR DESCRIPTION
## Mycelia Signal — Sovereign HTTP Oracle

Adding Mycelia Signal as an Oracle protocol (id: 7650).

**What it is:**
Mycelia Signal is a pay-per-query sovereign oracle serving cryptographically  signed price attestations, economic indicators, and the MSVI volatility index  over standard HTTP.

**Key properties:**
- 63 paid endpoints — crypto, FX, stablecoin pegs, economic indicators,  commodities, and MSVI volatility index
- Two payment rails: L402 (Lightning) and x402 (USDC on Base)
- Every response signed with Ed25519 — independently verifiable against  published public key
- No API keys, no subscriptions, no vendor trust required
- MSVI: first cryptographically signed crypto volatility index (BTC + ETH) — 5-component weighted model (Parkinson RV, Deribit IV, term structure,  funding rate, put/call ratio)

**Links:**
- Website: https://myceliasignal.com
- Docs: https://myceliasignal.com/docs
- OpenAPI: https://myceliasignal.com/openapi.json
- Live preview: https://api.myceliasignal.com/oracle/price/btc/usd/preview
- MSVI: https://api.myceliasignal.com/oracle/volatility/btc/usd/preview
- Methodology: https://myceliasignal.com/docs/volatility/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mycelia Signal — a new multi‑chain Oracle integration offering cryptographically signed (Ed25519) data responses and a volatility index for market signals, expanding oracle data sources, providing cross‑chain coverage, and improving data reliability. External links and metadata for the integration are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->