### PR TITLE
update polygon listing name

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -2934,7 +2934,7 @@ const data: Protocol[] = [
   },
   {
     id: "240",
-    name: "Polygon Bridge & Staking",
+    name: "Polygon Bridge",
     address: "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
     symbol: "POL",
     url: "https://polygon.technology/",


### PR DESCRIPTION
Removed the "&" from the name because i think it's causing the error on the unlocks page: https://defillama.com/unlocks/polygon-bridge-&-staking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Corrected protocol display name for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->