### PR TITLE
Sort rwa perps outputs by open interest

### DIFF
--- a/defi/src/rwa/perps/cron.ts
+++ b/defi/src/rwa/perps/cron.ts
@@ -28,7 +28,8 @@ import {
     buildVenueHistoricalCharts
 } from './aggregate';
 import { normalizePerpsMetadataInPlace } from './constants';
-import { normalizePerpsAssetGroup } from './server-helpers';
+import { buildPerpsList } from './list';
+import { normalizePerpsAssetGroup, sortPerpsMarketsByOpenInterest } from './server-helpers';
 
 interface PerpsMetadata {
     id: string;
@@ -43,7 +44,7 @@ async function generateCurrentData(metadata: PerpsMetadata[]): Promise<any[]> {
     const metadataMap = new Map<string, any>();
     metadata.forEach((m) => metadataMap.set(m.id, m.data));
 
-    const result = currentData.map((record: any) => {
+    const result = sortPerpsMarketsByOpenInterest(currentData.map((record: any) => {
         const meta = metadataMap.get(record.id) || {};
         const merged = {
             ...(record.data || {}),
@@ -65,7 +66,7 @@ async function generateCurrentData(metadata: PerpsMetadata[]): Promise<any[]> {
             contract: merged.contract || record.id,
             venue: merged.venue || record.id.split(':')[0] || 'unknown',
         };
-    });
+    }));
 
     await storeRouteData('current.json', result);
     console.log(`Generated current.json with ${result.length} markets in ${Date.now() - startTime}ms`);
@@ -143,21 +144,7 @@ async function generateStats(currentData: any[]): Promise<void> {
 
 async function generateList(currentData: any[]): Promise<void> {
     console.log('Generating list...');
-
-    const contracts = [...new Set(currentData.map((m: any) => m.contract).filter(Boolean))].sort();
-    const venues = [...new Set(currentData.map((m: any) => m.venue).filter(Boolean))].sort();
-    const categories = [...new Set(currentData.flatMap((m: any) => {
-        return Array.isArray(m.category) ? m.category : [m.category || 'Other'];
-    }))].sort();
-    const assetGroups = [...new Set(currentData.map((m: any) => normalizePerpsAssetGroup(m.referenceAssetGroup)).filter(Boolean))].sort();
-
-    const list = {
-        contracts,
-        venues,
-        categories,
-        assetGroups,
-        total: currentData.length,
-    };
+    const list = buildPerpsList(currentData);
 
     await storeRouteData('list.json', list);
     console.log(`Generated list.json`);

--- a/defi/src/rwa/perps/list.ts
+++ b/defi/src/rwa/perps/list.ts
@@ -1,0 +1,60 @@
+import { normalizePerpsAssetGroup } from "./server-helpers";
+import { toFiniteNumberOrZero } from "./utils";
+
+interface PerpsListMarket {
+  contract?: unknown;
+  venue?: unknown;
+  category?: unknown;
+  referenceAssetGroup?: unknown;
+  openInterest?: unknown;
+}
+
+interface PerpsListResponse {
+  contracts: string[];
+  venues: string[];
+  categories: string[];
+  assetGroups: string[];
+  total: number;
+}
+
+function sortMetricEntriesDesc(metricMap: Record<string, number>): string[] {
+  return Object.entries(metricMap)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([key]) => key);
+}
+
+export function buildPerpsList(currentData: PerpsListMarket[]): PerpsListResponse {
+  const contractOpenInterest: Record<string, number> = {};
+  const venueOpenInterest: Record<string, number> = {};
+  const categoryOpenInterest: Record<string, number> = {};
+  const assetGroupOpenInterest: Record<string, number> = {};
+
+  for (const market of currentData) {
+    const openInterest = toFiniteNumberOrZero(market.openInterest);
+
+    if (market.contract) {
+      const contract = String(market.contract);
+      contractOpenInterest[contract] = (contractOpenInterest[contract] || 0) + openInterest;
+    }
+
+    const venue = typeof market.venue === "string" && market.venue.trim() ? market.venue : "unknown";
+    venueOpenInterest[venue] = (venueOpenInterest[venue] || 0) + openInterest;
+
+    const categories = Array.isArray(market.category) ? market.category : [market.category || "Other"];
+    for (const category of categories) {
+      const categoryLabel = String(category);
+      categoryOpenInterest[categoryLabel] = (categoryOpenInterest[categoryLabel] || 0) + openInterest;
+    }
+
+    const assetGroup = normalizePerpsAssetGroup(market.referenceAssetGroup);
+    assetGroupOpenInterest[assetGroup] = (assetGroupOpenInterest[assetGroup] || 0) + openInterest;
+  }
+
+  return {
+    contracts: sortMetricEntriesDesc(contractOpenInterest),
+    venues: sortMetricEntriesDesc(venueOpenInterest),
+    categories: sortMetricEntriesDesc(categoryOpenInterest),
+    assetGroups: sortMetricEntriesDesc(assetGroupOpenInterest),
+    total: currentData.length,
+  };
+}

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -4,6 +4,7 @@ jest.mock("../spreadsheet", () => ({
 
 import { toFiniteNumberOrZero, perpsSlug, computeProtocolFees, groupBy } from "./utils";
 import { fileNameNormalizer, mergeHistoricalData } from "./file-cache";
+import { buildPerpsList } from "./list";
 import {
   buildContractBreakdownCharts,
   buildCategoryHistoricalCharts,
@@ -34,6 +35,7 @@ import {
   normalizePerpsAssetGroup,
   parsePerpsChartTarget,
   resolvePerpsLookupId,
+  sortPerpsMarketsByOpenInterest,
 } from "./server-helpers";
 import { HYPERLIQUID_MAKER_FEE, HYPERLIQUID_TAKER_FEE, HYPERLIQUID_DEPLOYER_SHARE } from "./platforms/hyperliquid";
 import {
@@ -793,5 +795,91 @@ describe("server route helpers", () => {
         key: "activeMcap",
       })
     ).toBeNull();
+  });
+
+  it("sorts market arrays by descending open interest with deterministic tie-breakers", () => {
+    expect(
+      sortPerpsMarketsByOpenInterest([
+        { id: "beta:meta", contract: "META", venue: "Beta", openInterest: 8 },
+        { id: "alpha:tsla", contract: "TSLA", venue: "Alpha", openInterest: 12 },
+        { id: "alpha:meta", contract: "META", venue: "Alpha", openInterest: 8 },
+        { id: "gamma:aapl", contract: "AAPL", venue: "Gamma", openInterest: 8 },
+      ])
+    ).toEqual([
+      { id: "alpha:tsla", contract: "TSLA", venue: "Alpha", openInterest: 12 },
+      { id: "gamma:aapl", contract: "AAPL", venue: "Gamma", openInterest: 8 },
+      { id: "alpha:meta", contract: "META", venue: "Alpha", openInterest: 8 },
+      { id: "beta:meta", contract: "META", venue: "Beta", openInterest: 8 },
+    ]);
+  });
+});
+
+describe("buildPerpsList", () => {
+  it("sorts all list facets by descending open interest with alphabetical tie-breakers", () => {
+    expect(
+      buildPerpsList([
+        {
+          contract: "xyz:META",
+          venue: "Beta",
+          category: ["Equities", "RWA Perpetuals"],
+          referenceAssetGroup: "US Equities",
+          openInterest: 20,
+        },
+        {
+          contract: "TSLA",
+          venue: "Alpha",
+          category: ["Equities"],
+          referenceAssetGroup: "US Equities",
+          openInterest: 15,
+        },
+        {
+          contract: "GOLD",
+          venue: "Alpha",
+          category: ["Commodities"],
+          referenceAssetGroup: "Commodities",
+          openInterest: 15,
+        },
+        {
+          contract: "xyz:META",
+          venue: "Alpha",
+          category: null,
+          referenceAssetGroup: " ",
+          openInterest: 10,
+        },
+        {
+          contract: "AAPL",
+          venue: "",
+          category: ["Equities"],
+          referenceAssetGroup: null,
+          openInterest: 5,
+        },
+      ])
+    ).toEqual({
+      contracts: ["xyz:META", "GOLD", "TSLA", "AAPL"],
+      venues: ["Alpha", "Beta", "unknown"],
+      categories: ["Equities", "RWA Perpetuals", "Commodities", "Other"],
+      assetGroups: ["US Equities", "Commodities", "Unknown"],
+      total: 5,
+    });
+  });
+
+  it("skips empty contracts but still counts the row toward fallback group totals", () => {
+    expect(
+      buildPerpsList([
+        {
+          contract: "",
+          venue: undefined,
+          category: undefined,
+          referenceAssetGroup: undefined,
+          openInterest: 7,
+        },
+      ])
+    ).toEqual({
+      contracts: [],
+      venues: ["unknown"],
+      categories: ["Other"],
+      assetGroups: ["Unknown"],
+      total: 1,
+    });
   });
 });

--- a/defi/src/rwa/perps/server-helpers.ts
+++ b/defi/src/rwa/perps/server-helpers.ts
@@ -39,6 +39,21 @@ export function findMarketById(currentData: any[], id: string) {
   );
 }
 
+export function sortPerpsMarketsByOpenInterest(currentData: any[]): any[] {
+  return [...currentData].sort((a: any, b: any) => {
+    const openInterestDiff = Number(b?.openInterest || 0) - Number(a?.openInterest || 0);
+    if (openInterestDiff !== 0) return openInterestDiff;
+
+    const contractDiff = String(a?.contract || "").localeCompare(String(b?.contract || ""));
+    if (contractDiff !== 0) return contractDiff;
+
+    const venueDiff = String(a?.venue || "").localeCompare(String(b?.venue || ""));
+    if (venueDiff !== 0) return venueDiff;
+
+    return String(a?.id || "").localeCompare(String(b?.id || ""));
+  });
+}
+
 export function findMarketsByContract(currentData: any[], contract: string): any[] {
   const contractSlug = perpsSlug(contract);
   return currentData.filter((item: any) =>


### PR DESCRIPTION
## Summary
- sort `rwa-perps /list` arrays by descending aggregate open interest instead of alphabetically
- sort cached `current.json` by descending open interest so `/current` and the filtered market-array endpoints return biggest markets first
- add focused unit coverage for list ordering, market ordering tie-breakers, and fallback buckets

## Why
The perps API was returning list facets alphabetically and market arrays in database `id` order, which made the highest-open-interest markets harder to discover. This aligns the perps API with the existing RWA pattern of ranking list outputs by the primary aggregate metric.

## Testing
- `npx jest src/rwa/perps/perps.test.ts --runInBand --watchman=false`
