### PR TITLE
Update SMARDEX Ecosystem twitter to @every_thing

### DIFF
--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -7356,7 +7356,7 @@ const parentProtocols: IParentProtocol[] = [
     gecko_id: null,
     cmcId: null,
     chains: [],
-    twitter: "SmarDex",
+    twitter: "every_thing",
     stablecoins: ["smardex-usdn"],
   },
   {


### PR DESCRIPTION
Update the twitter handle for SMARDEX Ecosystem parent protocol from `SmarDex` to `every_thing` (https://x.com/every_thing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated social media reference information for a protocol ecosystem entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->