### PR TITLE
Consolidate Ramses metadata under RamsesX

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -28628,7 +28628,7 @@ const data2: Protocol[] = [
     module: "ramses/index.js",
     twitter: "RamsesExchange",
     forkedFromIds: ["1407"],
-    parentProtocol: "parent#ramses-exchange",
+    parentProtocol: "parent#ramses-exchange-hl",
     listedAt: 1678883899,
     dimensions: {
       fees: "ramses-exchange-v1",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -8767,7 +8767,7 @@ const data3_0: Protocol[] = [
     module: "ramses-cl/index.js",
     twitter: "RamsesExchange",
     forkedFromIds: ["2198", "1407"],
-    parentProtocol: "parent#ramses-exchange",
+    parentProtocol: "parent#ramses-exchange-hl",
     listedAt: 1686345425,
     dimensions: {
       fees: "ramses-exchange-v2",

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -8524,15 +8524,16 @@ const parentProtocols: IParentProtocol[] = [
   },
   {
     id: "parent#ramses-exchange-hl",
-    name: "Ramses Exchange HL",
-    url: "https://ramses.xyz",
+    name: "RamsesX",
+    url: "https://www.ramses.xyz/",
     description:
-      "Ramses is a concentrated liquidity layer and exchange built on HyperEVM, powered by x(3,3)—a more fluid and accessible version of the popular ve(3,3) model",
-    logo: `${baseIconsUrl}/ramses-exchange-hl.jpg`,
-    gecko_id: null,
-    cmcId: null,
+      "RamsesX is a ve(3,3) liquidity layer and exchange with legacy and concentrated liquidity deployments across Arbitrum and HyperEVM.",
+    logo: `${baseIconsUrl}/ramsesx.png`,
+    gecko_id: "ramses-exchange",
+    cmcId: "23858",
     chains: [],
     twitter: "RamsesExchange",
+    github: ["RamsesExchange"],
   },
   {
     id: "parent#fufuture",

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -2030,7 +2030,7 @@ const parentProtocols: IParentProtocol[] = [
     treasury: "sudoswap.js",
     github: ["sudoswap"],
   },
-  {
+  /*{ // unified under new RamsesX parent#ramses-exchange-hl
     id: "parent#ramses-exchange",
     name: "Ramses Exchange",
     url: "https://app.ramses.exchange/",
@@ -2042,7 +2042,7 @@ const parentProtocols: IParentProtocol[] = [
     chains: [],
     twitter: "RamsesExchange",
     github: ["RamsesExchange"],
-  },
+  },*/
   {
     id: "parent#maple-finance",
     name: "Maple Finance",


### PR DESCRIPTION
## Summary
- consolidate the separate Ramses and Ramses HL parent protocol groupings into one parent
- rebrand the combined parent protocol as `RamsesX`

## Related
- icons PR: https://github.com/DefiLlama/icons/pull/2358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Ramses Exchange protocol metadata and consolidated it under the RamsesX parent protocol structure.
  * Unified protocol hierarchy references across protocol configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->