### PR TITLE
Switch RWA asset lookups to canonical market IDs

### DIFF
--- a/defi/src/rwa/cron.ts
+++ b/defi/src/rwa/cron.ts
@@ -98,6 +98,7 @@ async function generateCurrentData(metadata: RWAMetadata[]): Promise<any[]> {
     m.data.onChainMcap = convertChainKeysToLabelsNumber(idCurrent.mcap as any);
     if (m.data.activeMcapData) m.data.activeMcap = convertChainKeysToLabelsNumber(idCurrent.activemcap as any);
     m.data.defiActiveTvl = convertChainKeysToLabelsNestedNumber(idCurrent.defiactivetvl as any);
+    if (!m.data.canonicalMarketId) return;
 
     data.push(m.data);
   });
@@ -112,9 +113,9 @@ function generateIdMap(
   const idMap: { [name: string]: string } = {};
 
   metadata.forEach((m: RWAMetadata) => {
-    const ticker = m.data.ticker
+    const canonicalMarketId = m.data.canonicalMarketId
     const id = m.id
-    if (ticker && id) idMap[ticker] = id;
+    if (canonicalMarketId && id) idMap[canonicalMarketId] = id;
   });
 
   return idMap;
@@ -232,7 +233,7 @@ async function generateAllHistoricalDataIncremental(metadata: RWAMetadata[]): Pr
 
 function sumObjectValues(obj: any): number {
   if (!obj || typeof obj !== 'object') return 0;
-  return Object.values(obj).reduce((sum: number, val) => {
+  return Object.values(obj as Record<string, any>).reduce((sum: number, val: any) => {
     const num = Number(val);
     return sum + (isNaN(num) ? 0 : num);
   }, 0);
@@ -707,13 +708,12 @@ function generateAggregateStats(currentData: any[]): AggregateStats {
       totalActiveMcap += assetActiveTotal;
       totalDefiActiveTvl += assetDefiActiveTotal;
 
-      // Category aggregation: assets with multiple categories have their FULL values
-      // added to each category (not split). Category totals will exceed global totals.
-      const categories: string[] = Array.isArray(item.category) ? item.category : [];
-      for (const cat of categories) {
-        if (!cat) continue;
-        if (!byCategory[cat]) byCategory[cat] = makeBucketGroup();
-        addToBucketGroup(byCategory[cat], assetDelta, issuer, stablecoin, governance);
+      // Category aggregation uses only the primary category to avoid double-counting.
+      const categories: string[] = Array.isArray(item.category) ? item.category.filter(Boolean) : [];
+      const primaryCategory = categories[0];
+      if (primaryCategory) {
+        if (!byCategory[primaryCategory]) byCategory[primaryCategory] = makeBucketGroup();
+        addToBucketGroup(byCategory[primaryCategory], assetDelta, issuer, stablecoin, governance);
       }
 
       // AssetGroup aggregation
@@ -796,7 +796,7 @@ function generateAggregateStats(currentData: any[]): AggregateStats {
 
 
 function generateList(currentData: any[], stats: AggregateStats): {
-  tickers: string[];
+  canonicalMarketIds: string[];
   platforms: string[];
   chains: string[];
   categories: string[];
@@ -806,8 +806,8 @@ function generateList(currentData: any[], stats: AggregateStats): {
   console.log('Generating list data...');
   const startTime = Date.now();
 
-  const tickerMcap: { [ticker: string]: number } = {};
-  const idMap: { [ticker: string]: string } = {};
+  const canonicalMarketIdMcap: { [canonicalMarketId: string]: number } = {};
+  const idMap: { [canonicalMarketId: string]: string } = {};
 
   for (const item of currentData) {
     const assetType = typeof item.type === "string" ? item.type.trim() : "";
@@ -829,15 +829,15 @@ function generateList(currentData: any[], stats: AggregateStats): {
       }
     }
 
-    if (item.ticker) {
-      tickerMcap[item.ticker] = (tickerMcap[item.ticker] || 0) + assetMcap;
-      idMap[item.ticker] = item.id;
+    if (item.canonicalMarketId) {
+      canonicalMarketIdMcap[item.canonicalMarketId] = (canonicalMarketIdMcap[item.canonicalMarketId] || 0) + assetMcap;
+      idMap[item.canonicalMarketId] = item.id;
     }
   }
 
-  const tickerPairs: [string, number][] = [];
-  for (const k in tickerMcap) tickerPairs.push([k, tickerMcap[k]]);
-  const tickersSorted = tickerPairs.sort((a, b) => b[1] - a[1]).map(([k]) => k);
+  const canonicalMarketIdPairs: [string, number][] = [];
+  for (const k in canonicalMarketIdMcap) canonicalMarketIdPairs.push([k, canonicalMarketIdMcap[k]]);
+  const canonicalMarketIdsSorted = canonicalMarketIdPairs.sort((a, b) => b[1] - a[1]).map(([k]) => k);
 
   // Chains: sorted by base onChainMcap only (excludes stablecoins & governance tokens)
   const chainPairs: [string, number][] = [];
@@ -858,7 +858,7 @@ function generateList(currentData: any[], stats: AggregateStats): {
   const assetGroupsSorted = assetGroupPairs.sort((a, b) => b[1] - a[1]).map(([k]) => k);
 
   const list = {
-    tickers: tickersSorted,
+    canonicalMarketIds: canonicalMarketIdsSorted,
     platforms: platformsSorted,
     chains: chainsSorted,
     categories: categoriesSorted,
@@ -929,16 +929,21 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     return map[key][timestamp];
   }
 
-  function ensureBreakdownDataPoint(map: { [category: string]: HistoricalBreakdownDataPoint }, key: string, timestamp: number, ticker: string): HistoricalBreakdownDataPoint {
+  function ensureBreakdownDataPoint(
+    map: { [category: string]: HistoricalBreakdownDataPoint },
+    key: string,
+    timestamp: number,
+    assetKey: string
+  ): HistoricalBreakdownDataPoint {
     if (!map[key]) map[key] = { onChainMcap: {}, activeMcap: {}, defiActiveTvl: {} };
     
     map[key].onChainMcap[timestamp] = map[key].onChainMcap[timestamp] || {};
     map[key].activeMcap[timestamp] = map[key].activeMcap[timestamp] || {};
     map[key].defiActiveTvl[timestamp] = map[key].defiActiveTvl[timestamp] || {};
     
-    map[key].onChainMcap[timestamp][ticker] = map[key].onChainMcap[timestamp][ticker] || 0;
-    map[key].activeMcap[timestamp][ticker] = map[key].activeMcap[timestamp][ticker] || 0;
-    map[key].defiActiveTvl[timestamp][ticker] = map[key].defiActiveTvl[timestamp][ticker] || 0;
+    map[key].onChainMcap[timestamp][assetKey] = map[key].onChainMcap[timestamp][assetKey] || 0;
+    map[key].activeMcap[timestamp][assetKey] = map[key].activeMcap[timestamp][assetKey] || 0;
+    map[key].defiActiveTvl[timestamp][assetKey] = map[key].defiActiveTvl[timestamp][assetKey] || 0;
     
     return map[key];
   }
@@ -988,10 +993,14 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
   // Process each asset's pg-cache for chain breakdown
   let processedCount = 0;
   for (const m of metadata) {
+    const canonicalMarketId = m.data.canonicalMarketId;
+    if (!canonicalMarketId) continue;
+
     const pgCache = await readPGCacheForId(m.id);
     if (!pgCache) continue;
 
-    const categories = m.data.category || [];
+    const categories = Array.isArray(m.data.category) ? m.data.category.filter(Boolean) : [];
+    const primaryCategory = categories[0];
     const platform = m.data.parentPlatform;
     const assetGroup = typeof m.data.assetGroup === "string" && m.data.assetGroup.trim() ? m.data.assetGroup.trim() : null;
 
@@ -1005,7 +1014,6 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
         defiActiveTvl: rawTotalTvl,
         chains,
       } = record as any;
-      const ticker = m.data.ticker;
 
       const totalOnChainMcap = toFiniteNumberOrZero(rawTotalOnChainMcap);
       const totalActiveMcap = toFiniteNumberOrZero(rawTotalActiveMcap);
@@ -1018,10 +1026,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
         chainDp.activeMcap += toFiniteNumberOrZero((chainData as any)?.activeMcap);
         chainDp.defiActiveTvl += toFiniteNumberOrZero((chainData as any)?.defiActiveTvl);
         
-        const dpa = ensureBreakdownDataPoint(byChainTickerBreakdown, chainKey, timestamp, ticker);
-        dpa.onChainMcap[timestamp][ticker] += toFiniteNumberOrZero((chainData as any)?.onChainMcap);
-        dpa.activeMcap[timestamp][ticker] += toFiniteNumberOrZero((chainData as any)?.activeMcap);
-        dpa.defiActiveTvl[timestamp][ticker] += toFiniteNumberOrZero((chainData as any)?.defiActiveTvl);
+        const dpa = ensureBreakdownDataPoint(byChainTickerBreakdown, chainKey, timestamp, canonicalMarketId);
+        dpa.onChainMcap[timestamp][canonicalMarketId] += toFiniteNumberOrZero((chainData as any)?.onChainMcap);
+        dpa.activeMcap[timestamp][canonicalMarketId] += toFiniteNumberOrZero((chainData as any)?.activeMcap);
+        dpa.defiActiveTvl[timestamp][canonicalMarketId] += toFiniteNumberOrZero((chainData as any)?.defiActiveTvl);
       }
 
       // Aggregate to "All"
@@ -1030,29 +1038,29 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
       allDp.activeMcap += totalActiveMcap;
       allDp.defiActiveTvl += totalTvl;
       
-      const allDpa = ensureBreakdownDataPoint(byChainTickerBreakdown, 'all', timestamp, ticker);
-      allDpa.onChainMcap[timestamp][ticker] += totalOnChainMcap;
-      allDpa.activeMcap[timestamp][ticker] += totalActiveMcap;
-      allDpa.defiActiveTvl[timestamp][ticker] += totalTvl;
+      const allDpa = ensureBreakdownDataPoint(byChainTickerBreakdown, 'all', timestamp, canonicalMarketId);
+      allDpa.onChainMcap[timestamp][canonicalMarketId] += totalOnChainMcap;
+      allDpa.activeMcap[timestamp][canonicalMarketId] += totalActiveMcap;
+      allDpa.defiActiveTvl[timestamp][canonicalMarketId] += totalTvl;
 
-      // Aggregate by category: full asset values are added to every category the
-      // asset belongs to (not split), so category totals will exceed global totals.
+      // Aggregate by category using only the primary category to avoid double-counting.
       const categoryItems: Record<string, any> = {};
-      for (const cat of categories) {
-        const dp = ensureDataPoint(byCategory, cat, timestamp);
+      if (primaryCategory) {
+        const dp = ensureDataPoint(byCategory, primaryCategory, timestamp);
         dp.onChainMcap += totalOnChainMcap;
         dp.activeMcap += totalActiveMcap;
         dp.defiActiveTvl += totalTvl;
-        
-        const dpa = ensureBreakdownDataPoint(byCategoryTickerBreakdown, cat, timestamp, ticker);
-        dpa.onChainMcap[timestamp][ticker] += totalOnChainMcap;
-        dpa.activeMcap[timestamp][ticker] += totalActiveMcap;
-        dpa.defiActiveTvl[timestamp][ticker] += totalTvl;
-        
-        categoryItems[cat] = { onChainMcap: 0, activeMcap: 0, defiActiveTvl: 0 };
-        categoryItems[cat].onChainMcap += totalOnChainMcap;
-        categoryItems[cat].activeMcap += totalActiveMcap;
-        categoryItems[cat].defiActiveTvl += totalTvl;
+
+        const dpa = ensureBreakdownDataPoint(byCategoryTickerBreakdown, primaryCategory, timestamp, canonicalMarketId);
+        dpa.onChainMcap[timestamp][canonicalMarketId] += totalOnChainMcap;
+        dpa.activeMcap[timestamp][canonicalMarketId] += totalActiveMcap;
+        dpa.defiActiveTvl[timestamp][canonicalMarketId] += totalTvl;
+
+        categoryItems[primaryCategory] = {
+          onChainMcap: totalOnChainMcap,
+          activeMcap: totalActiveMcap,
+          defiActiveTvl: totalTvl,
+        };
       }
 
       // Aggregate by platform
@@ -1063,10 +1071,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
         dp.activeMcap += totalActiveMcap;
         dp.defiActiveTvl += totalTvl;
         
-        const dpa = ensureBreakdownDataPoint(byPlatformTickerBreakdown, platform, timestamp, ticker);
-        dpa.onChainMcap[timestamp][ticker] += totalOnChainMcap;
-        dpa.activeMcap[timestamp][ticker] += totalActiveMcap;
-        dpa.defiActiveTvl[timestamp][ticker] += totalTvl;
+        const dpa = ensureBreakdownDataPoint(byPlatformTickerBreakdown, platform, timestamp, canonicalMarketId);
+        dpa.onChainMcap[timestamp][canonicalMarketId] += totalOnChainMcap;
+        dpa.activeMcap[timestamp][canonicalMarketId] += totalActiveMcap;
+        dpa.defiActiveTvl[timestamp][canonicalMarketId] += totalTvl;
         
         platformItems[platform] = { onChainMcap: 0, activeMcap: 0, defiActiveTvl: 0 };
         platformItems[platform].onChainMcap += totalOnChainMcap;
@@ -1082,10 +1090,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
         dp.activeMcap += totalActiveMcap;
         dp.defiActiveTvl += totalTvl;
 
-        const dpa = ensureBreakdownDataPoint(byAssetGroupTickerBreakdown, assetGroup, timestamp, ticker);
-        dpa.onChainMcap[timestamp][ticker] += totalOnChainMcap;
-        dpa.activeMcap[timestamp][ticker] += totalActiveMcap;
-        dpa.defiActiveTvl[timestamp][ticker] += totalTvl;
+        const dpa = ensureBreakdownDataPoint(byAssetGroupTickerBreakdown, assetGroup, timestamp, canonicalMarketId);
+        dpa.onChainMcap[timestamp][canonicalMarketId] += totalOnChainMcap;
+        dpa.activeMcap[timestamp][canonicalMarketId] += totalActiveMcap;
+        dpa.defiActiveTvl[timestamp][canonicalMarketId] += totalTvl;
 
         assetGroupItems[assetGroup] = { onChainMcap: 0, activeMcap: 0, defiActiveTvl: 0 };
         assetGroupItems[assetGroup].onChainMcap += totalOnChainMcap;
@@ -1150,11 +1158,11 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     await storeRouteData(`charts/chain/${key}.json`, toSortedArray(timestampMap));
   }
   
-  // Store chain charts - breakdown by tickers
+  // Store chain charts - breakdown by asset key
   for (const [chain, dataMap] of Object.entries(byChainTickerBreakdown)) {
     const chainLabel = getChainLabelFromKey(chain);
     const key = rwaSlug(chainLabel);
-    await storeRouteData(`charts/chain-ticker-breakdown/${key}.json`, {
+    await storeRouteData(`charts/chain-asset-breakdown/${key}.json`, {
       onChainMcap: toSortedArrayBreakdown(dataMap.onChainMcap),
       activeMcap: toSortedArrayBreakdown(dataMap.activeMcap),
       defiActiveTvl: toSortedArrayBreakdown(dataMap.defiActiveTvl),
@@ -1173,10 +1181,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     await storeRouteData(`charts/category/${key}.json`, toSortedArray(timestampMap));
   }
   
-  // Store category charts - breakdown by tickers
+  // Store category charts - breakdown by asset key
   for (const [category, dataMap] of Object.entries(byCategoryTickerBreakdown)) {
     const key = rwaSlug(category);
-    await storeRouteData(`charts/category-ticker-breakdown/${key}.json`, {
+    await storeRouteData(`charts/category-asset-breakdown/${key}.json`, {
       onChainMcap: toSortedArrayBreakdown(dataMap.onChainMcap),
       activeMcap: toSortedArrayBreakdown(dataMap.activeMcap),
       defiActiveTvl: toSortedArrayBreakdown(dataMap.defiActiveTvl),
@@ -1195,10 +1203,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     await storeRouteData(`charts/platform/${key}.json`, toSortedArray(timestampMap));
   }
   
-  // Store platform charts - breakdown by tickers
+  // Store platform charts - breakdown by asset key
   for (const [platform, dataMap] of Object.entries(byPlatformTickerBreakdown)) {
     const key = rwaSlug(platform);
-    await storeRouteData(`charts/platform-ticker-breakdown/${key}.json`, {
+    await storeRouteData(`charts/platform-asset-breakdown/${key}.json`, {
       onChainMcap: toSortedArrayBreakdown(dataMap.onChainMcap),
       activeMcap: toSortedArrayBreakdown(dataMap.activeMcap),
       defiActiveTvl: toSortedArrayBreakdown(dataMap.defiActiveTvl),
@@ -1217,10 +1225,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     await storeRouteData(`charts/assetGroup/${key}.json`, toSortedArray(timestampMap));
   }
 
-  // Store assetGroup charts - breakdown by tickers
+  // Store assetGroup charts - breakdown by asset key
   for (const [ag, dataMap] of Object.entries(byAssetGroupTickerBreakdown)) {
     const key = rwaSlug(ag);
-    await storeRouteData(`charts/assetGroup-ticker-breakdown/${key}.json`, {
+    await storeRouteData(`charts/assetGroup-asset-breakdown/${key}.json`, {
       onChainMcap: toSortedArrayBreakdown(dataMap.onChainMcap),
       activeMcap: toSortedArrayBreakdown(dataMap.activeMcap),
       defiActiveTvl: toSortedArrayBreakdown(dataMap.defiActiveTvl),

--- a/defi/src/rwa/metadataConstants.ts
+++ b/defi/src/rwa/metadataConstants.ts
@@ -31,6 +31,7 @@ export const RWA_ALWAYS_STRING_ARRAY_FIELDS = new Set<string>([
 ]);
 
 export const RWA_STRING_OR_NULL_FIELDS = new Set<string>([
+  "canonicalMarketId",
   "ticker",
   "name",
   "primaryChain",
@@ -81,4 +82,3 @@ export const RWA_GOVERNANCE_ASSET_CLASSES = new Set([
   "Revenue / fee share token (RWA protocol)",
 ]);
 export const RWA_GOVERNANCE_CLASSIFICATIONS = new Set(["Non-RWA (Gov/Utility)"]);
-

--- a/defi/src/rwa/rwa_start.sh
+++ b/defi/src/rwa/rwa_start.sh
@@ -31,7 +31,7 @@ fi
 git pull -q
 
 llama_runner init-defi
-# llama_runner rwa-cron
+llama_runner rwa-cron
 
 # start RWA server
 timeout 6m npx pm2 startOrReload src/rwa/ecosystem.config.js

--- a/defi/src/rwa/rwa_start.sh
+++ b/defi/src/rwa/rwa_start.sh
@@ -31,7 +31,7 @@ fi
 git pull -q
 
 llama_runner init-defi
-llama_runner rwa-cron
+# llama_runner rwa-cron
 
 # start RWA server
 timeout 6m npx pm2 startOrReload src/rwa/ecosystem.config.js

--- a/defi/src/rwa/server.ts
+++ b/defi/src/rwa/server.ts
@@ -67,6 +67,14 @@ function errorWrapper(routeFn: (req: HyperExpress.Request, res: HyperExpress.Res
     };
 }
 
+function safeDecodeRouteParam(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
 function setRoutes(router: HyperExpress.Router): void {
     // Get current RWA data (list of all RWAs with current values)
     router.get(
@@ -132,7 +140,8 @@ function setRoutes(router: HyperExpress.Router): void {
                 return errorResponse(res, 'ID map not found', 500);
             }
 
-            const id = idMap[name];
+            const lookupKey = safeDecodeRouteParam(String(name));
+            const id = idMap[lookupKey] ?? idMap[name];
             if (!id) {
                 return errorResponse(res, `RWA "${name}" not found`, 404);
             }
@@ -156,14 +165,14 @@ function setRoutes(router: HyperExpress.Router): void {
 
     // Get historical chart data by chain (accepts label, converts to key)
     router.get(
-        '/chart/chain/:chain/ticker-breakdown',
+        '/chart/chain/:chain/asset-breakdown',
         errorWrapper(async (req, res) => {
             const { chain } = req.params;
             if (!chain) {
                 return errorResponse(res, 'Missing chain parameter', 400);
             }
             const key = rwaSlug(chain);
-            return fileResponse(`charts/chain-ticker-breakdown/${key}.json`, res, 30);
+            return fileResponse(`charts/chain-asset-breakdown/${key}.json`, res, 30);
         })
     );
 
@@ -200,16 +209,16 @@ function setRoutes(router: HyperExpress.Router): void {
         })
     );
 
-    // Get historical chart data by category - breakdown by tickers
+    // Get historical chart data by category - breakdown by asset key
     router.get(
-        '/chart/category/:category/ticker-breakdown',
+        '/chart/category/:category/asset-breakdown',
         errorWrapper(async (req, res) => {
             const { category } = req.params;
             if (!category) {
                 return errorResponse(res, 'Missing category parameter', 400);
             }
             const key = rwaSlug(category);
-            return fileResponse(`charts/category-ticker-breakdown/${key}.json`, res, 30);
+            return fileResponse(`charts/category-asset-breakdown/${key}.json`, res, 30);
         })
     );
 
@@ -226,16 +235,16 @@ function setRoutes(router: HyperExpress.Router): void {
         })
     );
   
-    // Get historical chart data by platform - breakdown by tickers
+    // Get historical chart data by platform - breakdown by asset key
     router.get(
-        '/chart/platform/:platform/ticker-breakdown',
+        '/chart/platform/:platform/asset-breakdown',
         errorWrapper(async (req, res) => {
             const { platform } = req.params;
             if (!platform) {
                 return errorResponse(res, 'Missing platform parameter', 400);
             }
             const key = rwaSlug(platform);
-            return fileResponse(`charts/platform-ticker-breakdown/${key}.json`, res, 30);
+            return fileResponse(`charts/platform-asset-breakdown/${key}.json`, res, 30);
         })
     );
 
@@ -252,16 +261,16 @@ function setRoutes(router: HyperExpress.Router): void {
         })
     );
 
-    // Get historical chart data by assetGroup - breakdown by tickers
+    // Get historical chart data by assetGroup - breakdown by asset key
     router.get(
-        '/chart/assetGroup/:assetGroup/ticker-breakdown',
+        '/chart/assetGroup/:assetGroup/asset-breakdown',
         errorWrapper(async (req, res) => {
             const { assetGroup } = req.params;
             if (!assetGroup) {
                 return errorResponse(res, 'Missing assetGroup parameter', 400);
             }
             const key = rwaSlug(assetGroup);
-            return fileResponse(`charts/assetGroup-ticker-breakdown/${key}.json`, res, 30);
+            return fileResponse(`charts/assetGroup-asset-breakdown/${key}.json`, res, 30);
         })
     );
 
@@ -294,13 +303,13 @@ function setRoutes(router: HyperExpress.Router): void {
         })
     );
 
-    // Get specific RWA data by ID from current data
+    // Get specific RWA data by canonical market id from current data
     router.get(
-        '/asset/:ticker',
+        '/asset/:canonicalMarketId',
         errorWrapper(async (req, res) => {
-            const { ticker } = req.params;
-            if (!ticker) {
-                return errorResponse(res, 'Missing ticker parameter', 400);
+            const { canonicalMarketId } = req.params;
+            if (!canonicalMarketId) {
+                return errorResponse(res, 'Missing canonicalMarketId parameter', 400);
             }
 
             const currentData = await readRouteData('current.json');
@@ -308,15 +317,15 @@ function setRoutes(router: HyperExpress.Router): void {
                 return errorResponse(res, 'Data not found', 500);
             }
 
-            const tickerParam = rwaSlug(ticker);
+            const canonicalMarketIdParam = safeDecodeRouteParam(String(canonicalMarketId));
 
             const rwa = currentData.find((item: any) => {
-                const itemTicker = item?.ticker;
-                return typeof itemTicker !== 'undefined' && rwaSlug(itemTicker) === tickerParam;
+                const itemCanonicalMarketId = item?.canonicalMarketId;
+                return typeof itemCanonicalMarketId === 'string' && itemCanonicalMarketId === canonicalMarketIdParam;
             });
 
             if (!rwa) {
-                return errorResponse(res, `Asset "${ticker}" not found`, 404);
+                return errorResponse(res, `Asset "${canonicalMarketId}" not found`, 404);
             }
 
             return successResponse(res, rwa, 20);

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -478,7 +478,7 @@ async function generateSearchList() {
       institutionMetadata: Record<string, { name: string; ticker: string }>;
     },
     {
-      tickers: Array<string>;
+      canonicalMarketIds: Array<string>;
       platforms: Array<string>;
       categories: Array<string>;
       chains: Array<string>;
@@ -521,14 +521,15 @@ async function generateSearchList() {
       defaultResponse: [],
     }).then((res) => {
       if (!Array.isArray(res)) {
-        console.log("Unexpected response while fetching RWA ticker to name map:", res);
-        throw new Error("Failed to fetch RWA ticker to name map from RWA API");
+        console.log("Unexpected response while fetching RWA canonical market id to name map:", res);
+        throw new Error("Failed to fetch RWA canonical market id to name map from RWA API");
       }
       const final = {} as Record<string, string>;
       for (const rwa of res) {
         if (rwa.category?.includes("RWA Perps")) continue;
-        if (final[rwa.ticker]) continue;
-        final[rwa.ticker] = rwa.assetName;
+        if (!rwa.canonicalMarketId) continue;
+        if (final[rwa.canonicalMarketId]) continue;
+        final[rwa.canonicalMarketId] = rwa.assetName;
       }
       return final;
     }),
@@ -1037,15 +1038,14 @@ async function generateSearchList() {
     });
   }
   const rwaList: Array<SearchResult> = [];
-  for (const ticker of rwaListData.tickers) {
-    const name = rwaTickerToNameMap[ticker];
-    if (!name) continue;
-    const tickerSlug = rwaSlug(ticker);
+  for (const canonicalMarketId of rwaListData.canonicalMarketIds) {
+    const name = rwaTickerToNameMap[canonicalMarketId];
+    const encodedCanonicalMarketId = encodeURIComponent(canonicalMarketId);
     rwaList.push({
-      id: `rwa_asset_${normalize(tickerSlug)}`,
-      ...(name ? { name, symbol: ticker } : { name: ticker }),
-      route: `/rwa/asset/${tickerSlug}`,
-      v: tastyMetrics[`/rwa/asset/${tickerSlug}`] ?? 0,
+      id: `rwa_asset_${normalize(canonicalMarketId)}`,
+      ...(name ? { name, symbol: canonicalMarketId } : { name: canonicalMarketId }),
+      route: `/rwa/asset/${encodedCanonicalMarketId}`,
+      v: tastyMetrics[`/rwa/asset/${encodedCanonicalMarketId}`] ?? 0,
       type: "RWA",
     });
   }

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -1077,8 +1077,8 @@ async function generateSearchList() {
     rwaPerpsList.push({
       id: `rwa_perps_contract_${normalize(contract)}`,
       name: name,
-      route: `/rwa/perps/contract/${contract}`,
-      v: tastyMetrics[`/rwa/perps/contract/${contract}`] ?? 0,
+      route: `/rwa/perps/contract/${encodeURIComponent(contract)}`,
+      v: tastyMetrics[`/rwa/perps/contract/${encodeURIComponent(contract)}`] ?? 0,
       type: "RWA Perps",
     });
   }


### PR DESCRIPTION
## Summary
- move RWA list and id-map generation to canonicalMarketId keys
- swap grouped breakdown caches and routes from ticker-based keys to asset-breakdown payloads
- attribute category stats and category historical metrics only to the primary category
- update RWA search entries to point at canonicalMarketId asset routes

## Testing
- npx tsc --noEmit --skipLibCheck --module commonjs --moduleResolution node --target es2020 --esModuleInterop src/rwa/server.ts src/rwa/cron.ts src/updateSearch.ts