### PR TITLE
Add borrowed breakdown route

### DIFF
--- a/defi/src/api2/routes/getBorrowedBreakdown.ts
+++ b/defi/src/api2/routes/getBorrowedBreakdown.ts
@@ -1,0 +1,79 @@
+import { getChainDisplayName } from "../../utils/normalizeChain";
+import { getCachedHistoricalTvlForAllProtocols } from "../../storeGetCharts";
+import { getClosestDayStartTimestamp, secondsInHour } from "../../utils/date";
+import { _InternalProtocolMetadataMap } from "../../protocols/data";
+
+export async function getBorrowedProtocolBreakdownInternal(rawChain: string | null, params: any = {}) {
+  const globalChain = !rawChain || rawChain === "All" ? null : getChainDisplayName(rawChain.toLowerCase(), true);
+
+  let categorySelected: string | undefined = undefined;
+  if (params.category) {
+    categorySelected = decodeURI(String(params.category)).replace(/_/g, " ");
+  }
+
+  const sumDailyBorrowed: { [ts: number]: { [protocol: string]: number } } = {};
+
+  const historicalProtocolTvlsData = await getCachedHistoricalTvlForAllProtocols(
+    categorySelected === "Bridge",
+    categorySelected === undefined,
+    { getHistTvlMeta: params.getHistTvlMeta }
+  );
+  const { historicalProtocolTvls, lastDailyTimestamp } = historicalProtocolTvlsData;
+
+  historicalProtocolTvls.forEach((protocolTvl: any) => {
+    if (!protocolTvl) return;
+
+    const protocolMetadata = _InternalProtocolMetadataMap[protocolTvl.protocol.id];
+    if (!protocolMetadata) {
+      console.error(`Protocol metadata not found for ${protocolTvl.protocol.id}, skipping it`);
+      return;
+    }
+
+    if (categorySelected !== undefined && protocolMetadata.category !== categorySelected) {
+      return;
+    }
+
+    let { historicalTvl, protocol, lastTimestamp } = protocolTvl;
+
+    const lastTvl = historicalTvl[historicalTvl.length - 1];
+
+    while (lastTimestamp < lastDailyTimestamp) {
+      lastTimestamp = getClosestDayStartTimestamp(lastTimestamp + 24 * secondsInHour);
+      historicalTvl.push({
+        ...lastTvl,
+        SK: lastTimestamp,
+      });
+    }
+
+    historicalTvl.forEach((item: any) => {
+      let dayBorrowed = 0;
+
+      if (globalChain === null) {
+        const v = item.borrowed;
+        if (typeof v === "number" && !Number.isNaN(v)) dayBorrowed += v;
+      } else {
+        const targetKey = `${globalChain}-borrowed`;
+        Object.entries(item).forEach(([chainKey, value]) => {
+          if (typeof value !== "number" || Number.isNaN(value)) return;
+          const chainName = getChainDisplayName(chainKey, true);
+          if (chainName === targetKey) {
+            dayBorrowed += value as number;
+          }
+        });
+      }
+
+      if (dayBorrowed !== 0) {
+        const timestamp = getClosestDayStartTimestamp(item.SK);
+        if (!sumDailyBorrowed[timestamp]) sumDailyBorrowed[timestamp] = {};
+        sumDailyBorrowed[timestamp][protocol.name] =
+          (sumDailyBorrowed[timestamp][protocol.name] ?? 0) + dayBorrowed;
+      }
+    });
+  });
+
+  const timestamps = Object.keys(sumDailyBorrowed)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  return timestamps.map((ts) => [ts, sumDailyBorrowed[ts]] as [number, Record<string, number>]);
+}

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -4,6 +4,7 @@ import { getCategoryChartByChainData, getTagChartByChainData } from "../../getCa
 // import { chainAssetHistoricalFlows, chainAssetFlows, chainAssetChart } from "../../api2ChainAssets";
 import { pgGetInflows } from "../db/inflows";
 import { getSimpleChainDatasetInternal } from "./getSimpleChainDataset";
+import { getBorrowedProtocolBreakdownInternal } from "./getBorrowedBreakdown";
 import { getTokensInProtocolsInternal } from "../../getTokenInProtocols";
 import craftCsvDataset from "../../storeTvlUtils/craftCsvDataset";
 import { getTweetStats } from "../../twitter/db";
@@ -170,6 +171,10 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/v2/metrics/fork", ew(getForksRoutes('overview')))
   router.get("/v2/chart/fork/protocol-breakdown", ew(getForksRoutes('chart-total')))
   router.get("/v2/chart/fork/protocol/:protocol", ew(getForksRoutes('chart-total')))
+
+  // v2 - borrowed protocol breakdown 
+  router.get("/v2/chart/borrowed/protocol-breakdown", ew(getBorrowedProtocolBreakdown));
+  router.get("/v2/chart/borrowed/chain/:chain/protocol-breakdown", ew(getBorrowedProtocolBreakdown));
 
   // v2 - dimensions
 
@@ -402,6 +407,19 @@ async function getSimpleChainDataset(req: HyperExpress.Request, res: HyperExpres
   res.setHeader('Content-Disposition', `attachment; filename=${filename}`)
 
   return successResponse(res, csv, 30, { isJson: false })
+}
+
+async function getBorrowedProtocolBreakdown(req: HyperExpress.Request, res: HyperExpress.Response) {
+  const chainParam = req.path_parameters.chain
+    ? getChainLabelFromKey(decodeURIComponent(req.path_parameters.chain))
+    : null;
+
+  const data = await getBorrowedProtocolBreakdownInternal(chainParam, {
+    category: req.query_parameters.category,
+    getHistTvlMeta: () => cache.historicalTvlForAllProtocolsMeta,
+  });
+
+  return successResponse(res, data, 30);
 }
 
 async function getDataset(req: HyperExpress.Request, res: HyperExpress.Response) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new API endpoints for borrowed protocol breakdown data:
    * `/v2/chart/borrowed/protocol-breakdown` - Retrieve borrowed amounts by protocol
    * `/v2/chart/borrowed/chain/:chain/protocol-breakdown` - Retrieve borrowed amounts by protocol filtered by chain
  * Both endpoints support optional category filtering parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->