### PR TITLE
Improve search indexing and exact-match relevancy

### DIFF
--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -38,10 +38,10 @@ curl \
   -H 'Content-Type: application/json' \
   --data-binary '[
     "words",
-    "v:desc",
     "typo",
     "proximity",
     "attribute",
+    "v:desc",
     "sort",
     "exactness",
     "r:desc"
@@ -93,10 +93,10 @@ curl \
   -H 'Content-Type: application/json' \
   --data-binary '[
     "words",
-    "v:desc",
     "typo",
     "proximity",
     "attribute",
+    "v:desc",
     "sort",
     "exactness",
     "r:desc"

--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -25,11 +25,11 @@ curl \
   -H "Authorization: Bearer $SEARCH_MASTER_KEY" \
   -H 'Content-Type: application/json' \
   --data-binary '[
-    "name",
     "symbol",
+    "name",
     "previousNames",
     "nameVariants",
-    "type"
+    "subName"
   ]'
 
 curl \
@@ -41,10 +41,10 @@ curl \
     "typo",
     "proximity",
     "attribute",
-    "v:desc",
-    "sort",
     "exactness",
-    "r:desc"
+    "r:desc",
+    "v:desc",
+    "sort"
   ]'
 
 curl \
@@ -96,10 +96,10 @@ curl \
     "typo",
     "proximity",
     "attribute",
-    "v:desc",
-    "sort",
     "exactness",
-    "r:desc"
+    "r:desc",
+    "v:desc",
+    "sort"
   ]'
 
 curl \
@@ -120,10 +120,10 @@ curl \
   -H "Authorization: Bearer $SEARCH_MASTER_KEY" \
   -H 'Content-Type: application/json' \
   --data-binary '[
+    "symbol",
     "name",
     "previousNames",
     "nameVariants",
-    "symbol",
     "route"
   ]'
 

--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -63,7 +63,6 @@ curl \
     "v",
     "tvl",
     "name",
-    "deprecated",
     "mcapRank",
     "r"
   ]'
@@ -135,6 +134,5 @@ curl \
     "v",
     "tvl",
     "name",
-    "r",
-    "deprecated"
+    "r"
   ]'

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -471,8 +471,7 @@ async function generateSearchList() {
     rwaTickerToNameMap,
     rwaPerpsListData,
     rwaPerpContractToNameMap,
-    equitiesData,
-    liquidationsData
+    equitiesData
   ]: [
     {
       chains: string[];
@@ -500,8 +499,7 @@ async function generateSearchList() {
     Record<string, string>,
     { contracts: string[]; venues: string[]; assetGroups: string[] },
     Record<string, string>,
-    Array<{ name: string; ticker: string }>,
-    Array<string>
+    Array<{ name: string; ticker: string }>
   ] = await Promise.all([
     cachedJSONPull("https://api.llama.fi/lite/protocols2"),
     cachedJSONPull("https://stablecoins.llama.fi/stablecoins"),
@@ -563,8 +561,7 @@ async function generateSearchList() {
       }
       return final;
     }),
-    cachedJSONPull(`https://pro-api.llama.fi/${getEnv("INTERNAL_API_KEY")}/equities/v1/companies`),
-    cachedJSONPull(`https://pro-api.llama.fi/${getEnv("INTERNAL_API_KEY")}/liquidations/protocols`),
+    cachedJSONPull(`https://pro-api.llama.fi/${getEnv("INTERNAL_API_KEY")}/equities/v1/companies`)
   ]);
   const slugToProtocolName = new Map<string, string>();
   for (const id in protocolsMetadata) {
@@ -1165,16 +1162,6 @@ async function generateSearchList() {
     type: "Equities",
   }));
 
-  const liquidations: Array<SearchResult> = (Array.isArray(liquidationsData) ? liquidationsData : []).map((slug) => ({
-    id: `liquidations_${normalize(slug)}`,
-    name: slugToProtocolName.get(slug) ?? slug,
-    logo: `https://icons.llamao.fi/icons/protocols/${slug}?w=48&h=48`,
-    route: `/liquidations/${slug}`,
-    r: SEARCH_RANK.collection,
-    v: tastyMetrics[`/liquidations/${slug}`] ?? 0,
-    type: "Liquidations",
-  }));
-
   const sortDesc = (a: any, b: any) => (b.v ?? 0) - (a.v ?? 0);
   const sortedGroups = [
     chains,
@@ -1190,8 +1177,7 @@ async function generateSearchList() {
     dats,
     rwaList,
     rwaPerpsList,
-    equities,
-    liquidations,
+    equities
   ] as const;
   for (const group of sortedGroups) group.sort(sortDesc);
 
@@ -1213,8 +1199,7 @@ async function generateSearchList() {
       ...dats,
       ...rwaList,
       ...rwaPerpsList,
-      ...equities,
-      ...liquidations,
+      ...equities
     ].map((result: any) => ({
       ...result,
       r: result.r ?? 1,

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -459,6 +459,7 @@ async function generateSearchList() {
     rwaPerpsListData,
     rwaPerpContractToNameMap,
     equitiesData,
+    liquidationsData
   ]: [
     {
       chains: string[];
@@ -486,7 +487,8 @@ async function generateSearchList() {
     Record<string, string>,
     { contracts: string[]; venues: string[]; assetGroups: string[] },
     Record<string, string>,
-    Array<{ name: string; ticker: string }>
+    Array<{ name: string; ticker: string }>,
+    Array<string>
   ] = await Promise.all([
     cachedJSONPull("https://api.llama.fi/lite/protocols2"),
     cachedJSONPull("https://stablecoins.llama.fi/stablecoins"),
@@ -549,7 +551,14 @@ async function generateSearchList() {
       return final;
     }),
     cachedJSONPull(`https://pro-api.llama.fi/${getEnv("INTERNAL_API_KEY")}/equities/v1/companies`),
+    cachedJSONPull(`https://pro-api.llama.fi/${getEnv("INTERNAL_API_KEY")}/liquidations/protocols`),
   ]);
+  const slugToProtocolName = new Map<string, string>();
+  for (const id in protocolsMetadata) {
+    const meta = protocolsMetadata[id];
+    if (!meta?.name || !meta?.displayName) continue;
+    slugToProtocolName.set(meta.name, meta.displayName);
+  }
   const parentTvl = {} as any;
   const chainTvl = {} as any;
   const categoryTvl = {} as any;
@@ -898,9 +907,18 @@ async function generateSearchList() {
   }
 
   const categories: Array<SearchResult> = [];
+  const categoriesToExclude = new Set([
+    "RWA",
+    "RWA Perps",
+    "Dex Aggregator",
+    "Bridge Aggregator",
+    "Perp Aggregator",
+    "Derivatives",
+    "Liquidations",
+  ]);
 
   for (const category in categoryTvl) {
-    if (category === "RWA") continue;
+    if (categoriesToExclude.has(category)) continue;
     categories.push({
       id: `category_${normalize(category)}`,
       name: category,
@@ -1110,6 +1128,15 @@ async function generateSearchList() {
     type: "Equities",
   }));
 
+  const liquidations: Array<SearchResult> = (Array.isArray(liquidationsData) ? liquidationsData : []).map((slug) => ({
+    id: `liquidations_${normalize(slug)}`,
+    name: slugToProtocolName.get(slug) ?? slug,
+    logo: `https://icons.llamao.fi/icons/protocols/${slug}?w=48&h=48`,
+    route: `/liquidations/${slug}`,
+    v: tastyMetrics[`/liquidations/${slug}`] ?? 0,
+    type: "Liquidations",
+  }));
+
   const sortDesc = (a: any, b: any) => (b.v ?? 0) - (a.v ?? 0);
   const sortedGroups = [
     chains,
@@ -1126,6 +1153,7 @@ async function generateSearchList() {
     rwaList,
     rwaPerpsList,
     equities,
+    liquidations,
   ] as const;
   for (const group of sortedGroups) group.sort(sortDesc);
 
@@ -1148,6 +1176,7 @@ async function generateSearchList() {
       ...rwaList,
       ...rwaPerpsList,
       ...equities,
+      ...liquidations,
     ].map((result: any) => ({
       ...result,
       r: result.r ?? 1,

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -46,8 +46,17 @@ interface SearchResult {
   mcapRank?: number;
   previousNames?: string[];
   nameVariants?: string[];
+  r?: number;
   v: number;
 }
+
+const SEARCH_RANK = {
+  navPage: 4,
+  entity: 3,
+  collection: 2,
+  subPage: 1,
+  deprecated: -1,
+} as const;
 
 const getProtocolSubSections = ({
   result,
@@ -278,7 +287,7 @@ const getProtocolSubSections = ({
   return subSections.map((result) => ({
     ...result,
     v: tastyMetrics[result.route] ?? 0,
-    r: 0,
+    r: SEARCH_RANK.subPage,
   }));
 };
 
@@ -347,6 +356,7 @@ function buildDirectoryResults(
     id: `others_${normalize(page.name)}`,
     name: page.name,
     route: page.route,
+    r: SEARCH_RANK.navPage,
     v: 1000,
   })) as Array<SearchResult>;
 
@@ -375,6 +385,7 @@ function buildDirectoryResults(
       ...(parent.deprecated ? { deprecated: true } : {}),
       ...(prevNames?.length ? { previousNames: [...prevNames] } : {}),
       ...(variants.length ? { nameVariants: variants } : {}),
+      r: parent.deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.entity,
       v: tastyMetrics[route] ?? 0,
     });
   }
@@ -416,6 +427,7 @@ function buildDirectoryResults(
       ...(protocol.deprecated ? { deprecated: true } : {}),
       ...(prevNames?.length ? { previousNames: [...prevNames] } : {}),
       ...(variants.length ? { nameVariants: variants } : {}),
+      r: protocol.deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.entity,
       v: tastyMetrics[route] ?? 0,
     });
   }
@@ -428,6 +440,7 @@ function buildDirectoryResults(
       ...(cex.coinSymbol ? { symbol: cex.coinSymbol } : {}),
       route: cex.url!,
       logo: `https://icons.llamao.fi/icons/protocols/${sluggifyString(cex.slug!)}?w=48&h=48`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/cex/${sluggifyString(cex.slug!)}`] ?? 0,
     }));
 
@@ -599,6 +612,7 @@ async function generateSearchList() {
       ...(parent.deprecated ? { deprecated: true, r: -1 } : {}),
       ...(prevNames?.length ? { previousNames: [...prevNames] } : {}),
       ...(variants.length ? { nameVariants: variants } : {}),
+      r: parent.deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.entity,
       v: tastyMetrics[`/protocol/${sluggifyString(parent.name)}`] ?? 0,
       type: "Protocol",
     };
@@ -633,6 +647,7 @@ async function generateSearchList() {
       ...(protocol.deprecated ? { deprecated: true, r: -1 } : {}),
       ...(prevNames?.length ? { previousNames: [...prevNames] } : {}),
       ...(variants.length ? { nameVariants: variants } : {}),
+      r: protocol.deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.entity,
       v: tastyMetrics[`/protocol/${sluggifyString(protocol.name)}`] ?? 0,
       type: "Protocol",
     };
@@ -660,6 +675,7 @@ async function generateSearchList() {
       logo: `https://icons.llamao.fi/icons/chains/rsz_${sluggifyString(chain)}?w=48&h=48`,
       tvl: chainTvl[chain],
       route: `/chain/${sluggifyString(chain)}`,
+      r: SEARCH_RANK.entity,
       v: tastyMetrics[`/chain/${sluggifyString(chain)}`] ?? 0,
       type: "Chain",
     };
@@ -903,7 +919,9 @@ async function generateSearchList() {
       });
     }
 
-    subChains.push(...subSections.map((result) => ({ ...result, v: tastyMetrics[result.route] ?? 0, r: 0 })));
+    subChains.push(
+      ...subSections.map((result) => ({ ...result, v: tastyMetrics[result.route] ?? 0, r: SEARCH_RANK.subPage }))
+    );
   }
 
   const categories: Array<SearchResult> = [];
@@ -924,6 +942,7 @@ async function generateSearchList() {
       name: category,
       tvl: categoryTvl[category],
       route: `/protocols/${sluggifyString(category)}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/protocols/${sluggifyString(category)}`] ?? 0,
       type: "Category",
     });
@@ -937,6 +956,7 @@ async function generateSearchList() {
       name: tag,
       tvl: tagTvl[tag],
       route: `/protocols/${sluggifyString(tag)}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/protocols/${sluggifyString(tag)}`] ?? 0,
       type: "Tag",
     });
@@ -949,6 +969,7 @@ async function generateSearchList() {
     mcap: stablecoin.circulating.peggedUSD,
     logo: `https://icons.llamao.fi/icons/pegged/${sluggifyString(stablecoin.name)}?w=48&h=48`,
     route: `/stablecoin/${sluggifyString(stablecoin.name)}`,
+    r: SEARCH_RANK.entity,
     v: tastyMetrics[`/stablecoin/${sluggifyString(stablecoin.name)}`] ?? 0,
     type: "Stablecoin",
   }));
@@ -962,6 +983,7 @@ async function generateSearchList() {
       volume: brg.monthlyVolume,
       logo: `https://icons.llamao.fi/icons/protocols/${brg.icon.split(":")[1]}?w=48&h=48`,
       route: `/bridge/${brg.slug ?? sluggifyString(brg.displayName ?? brg.name)}`,
+      r: SEARCH_RANK.entity,
       v: tastyMetrics[`/bridge/${brg.slug}`] ?? 0,
       type: "Bridge",
     });
@@ -971,6 +993,7 @@ async function generateSearchList() {
     id: `metric_${normalize(i.name)}`,
     name: i.name,
     route: i.route,
+    r: SEARCH_RANK.navPage,
     v: tastyMetrics[i.route] ?? 0,
     type: "Metric",
   }));
@@ -979,6 +1002,7 @@ async function generateSearchList() {
     id: `tool_${normalize(t.name)}`,
     name: t.name,
     route: t.route,
+    r: SEARCH_RANK.navPage,
     v: tastyMetrics[t.route] ?? 0,
     type: "Tool",
   }));
@@ -991,6 +1015,7 @@ async function generateSearchList() {
         id: `others_${normalize(page.name)}`,
         name: page.name,
         route: page.route,
+        r: SEARCH_RANK.navPage,
         v: tastyMetrics[page.route] ?? 0,
         type: "Others",
         hideType: true,
@@ -1004,6 +1029,7 @@ async function generateSearchList() {
       name: c.name,
       route: `/cex/${sluggifyString(c.slug!)}`,
       logo: `https://icons.llamao.fi/icons/protocols/${sluggifyString(c.slug!)}?w=48&h=48`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/cex/${sluggifyString(c.slug!)}`] ?? 0,
       type: "CEX",
     }));
@@ -1016,6 +1042,7 @@ async function generateSearchList() {
       subName: "Token Usage",
       route: `/token-usage?token=${coin.symbol}`,
       mcapRank: coin.mcap_rank ?? 0,
+      r: SEARCH_RANK.subPage,
       v: tastyMetrics[`/token-usage?token=${coin.symbol}`] ?? 0,
       type: "Token Usage",
     });
@@ -1026,6 +1053,7 @@ async function generateSearchList() {
         subName: "Token Yields",
         route: `/yields?token=${coin.symbol}`,
         mcapRank: coin.mcap_rank ?? 0,
+        r: SEARCH_RANK.subPage,
         v: tastyMetrics[`/yields?token=${coin.symbol}`] ?? 0,
         type: "Token Yields",
       });
@@ -1039,6 +1067,7 @@ async function generateSearchList() {
       name: datsData.assetMetadata[asset].name,
       symbol: datsData.assetMetadata[asset].ticker,
       route: `/digital-asset-treasuries/${asset}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/digital-asset-treasuries/${asset}`] ?? 0,
       type: "DAT",
     });
@@ -1049,6 +1078,7 @@ async function generateSearchList() {
       name: datsData.institutionMetadata[institution].name,
       symbol: datsData.institutionMetadata[institution].ticker,
       route: `/digital-asset-treasury/${sluggifyString(datsData.institutionMetadata[institution].ticker)}`,
+      r: SEARCH_RANK.collection,
       v:
         tastyMetrics[`/digital-asset-treasury/${sluggifyString(datsData.institutionMetadata[institution].ticker)}`] ??
         0,
@@ -1063,6 +1093,7 @@ async function generateSearchList() {
       id: `rwa_asset_${normalize(canonicalMarketId)}`,
       ...(name ? { name, symbol: canonicalMarketId } : { name: canonicalMarketId }),
       route: `/rwa/asset/${encodedCanonicalMarketId}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/asset/${encodedCanonicalMarketId}`] ?? 0,
       type: "RWA",
     });
@@ -1073,6 +1104,7 @@ async function generateSearchList() {
       id: `rwa_platform_${normalize(platformSlug)}`,
       name: platform,
       route: `/rwa/platform/${platformSlug}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/platform/${platformSlug}`] ?? 0,
       type: "RWA",
     });
@@ -1084,6 +1116,7 @@ async function generateSearchList() {
       id: `rwa_category_${normalize(categorySlug)}`,
       name: category,
       route: `/rwa/category/${categorySlug}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/category/${categorySlug}`] ?? 0,
       type: "RWA",
     });
@@ -1096,6 +1129,7 @@ async function generateSearchList() {
       id: `rwa_perps_contract_${normalize(contract)}`,
       name: name,
       route: `/rwa/perps/contract/${encodeURIComponent(contract)}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/perps/contract/${encodeURIComponent(contract)}`] ?? 0,
       type: "RWA Perps",
     });
@@ -1105,6 +1139,7 @@ async function generateSearchList() {
       id: `rwa_perps_venue_${normalize(venue)}`,
       name: venue,
       route: `/rwa/perps/venue/${rwaSlug(venue)}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/perps/venue/${rwaSlug(venue)}`] ?? 0,
       type: "RWA Perps",
     });
@@ -1114,6 +1149,7 @@ async function generateSearchList() {
       id: `rwa_perps_asset_group_${normalize(assetGroup)}`,
       name: assetGroup,
       route: `/rwa/perps/asset-group/${rwaSlug(assetGroup)}`,
+      r: SEARCH_RANK.collection,
       v: tastyMetrics[`/rwa/perps/asset-group/${rwaSlug(assetGroup)}`] ?? 0,
       type: "RWA Perps",
     });
@@ -1124,6 +1160,7 @@ async function generateSearchList() {
     symbol: equity.ticker,
     logo: `https://icons.llamao.fi/icons/equities/${equity.ticker}?w=48&h=48`,
     route: `/equities/${equity.ticker.toLowerCase()}`,
+    r: SEARCH_RANK.collection,
     v: tastyMetrics[`/equities/${equity.ticker.toLowerCase()}`] ?? 0,
     type: "Equities",
   }));
@@ -1133,6 +1170,7 @@ async function generateSearchList() {
     name: slugToProtocolName.get(slug) ?? slug,
     logo: `https://icons.llamao.fi/icons/protocols/${slug}?w=48&h=48`,
     route: `/liquidations/${slug}`,
+    r: SEARCH_RANK.collection,
     v: tastyMetrics[`/liquidations/${slug}`] ?? 0,
     type: "Liquidations",
   }));


### PR DESCRIPTION
## Summary
- add liquidations protocols to the search index so liquidation pages are discoverable in search
- tune Meilisearch settings to prioritize symbols and exact protocol-name matches over broad popular fuzzy matches
- assign explicit search rank tiers so important landing pages stay visible without burying exact protocol and entity results

## Test plan
- run `bash -n defi/src/cli/search/setup.sh`
- reapply the updated Meilisearch settings from `defi/src/cli/search/setup.sh`
- rerun the search index update and verify queries like `usdt`, `stabble`, and `markit` surface the expected entity results near the top
