### PR TITLE
Add 24h change fields to the RWA perps API

### DIFF
--- a/defi/src/api2/cron-task/genFormattedChains.ts
+++ b/defi/src/api2/cron-task/genFormattedChains.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 import { LiteProtocol } from "../../types";
 import { chainCoingeckoIds } from "../../utils/normalizeChain";
 import { readRouteData, storeRouteData } from "../cache/file-cache";
+import { getPrevTvlFromChart } from "../utils/tvlChart";
 
 interface IResponse {
   chains: string[];
@@ -17,10 +18,6 @@ interface IChainGroups {
 interface INumOfProtocolsPerChain {
   [protocol: string]: number;
 }
-
-export const getPrevTvlFromChart = (chart: any, daysBefore: number) => {
-  return chart[chart.length - 1 - daysBefore]?.[1] ?? null;
-};
 
 export const getPercentChange = (valueNow: string, value24HoursAgo: string) => {
   const adjustedPercentChange =

--- a/defi/src/api2/routes/getFormattedChains.ts
+++ b/defi/src/api2/routes/getFormattedChains.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import { LiteProtocol } from "../../types";
 import { errorResponse, } from "../../utils/shared";
 import { readRouteData } from "../cache/file-cache";
+import { getPrevTvlFromChart } from "../utils/tvlChart";
 
 interface IResponse {
   chains: string[];
@@ -29,10 +30,6 @@ interface IExtraPropPerChain {
     };
   };
 }
-
-export const getPrevTvlFromChart = (chart: any, daysBefore: number) => {
-  return chart[chart.length - 1 - daysBefore]?.[1] ?? null;
-};
 
 export const getPercentChange = (valueNow: string, value24HoursAgo: string) => {
   const adjustedPercentChange =

--- a/defi/src/api2/utils/tvlChart.test.ts
+++ b/defi/src/api2/utils/tvlChart.test.ts
@@ -1,0 +1,56 @@
+import { getPrevTvlFromChart } from "./tvlChart";
+
+describe("getPrevTvlFromChart", () => {
+  it("returns the latest chart value for day zero", () => {
+    expect(
+      getPrevTvlFromChart(
+        [
+          [1774483200, 100],
+          [1774526400, 110],
+        ],
+        0,
+        new Date("2026-03-25T12:00:00Z").getTime()
+      )
+    ).toBe(110);
+  });
+
+  it("returns the latest point in the requested UTC day window", () => {
+    expect(
+      getPrevTvlFromChart(
+        [
+          [1774483200, 100],
+          [1774526400, 110],
+          [1774569600, 120],
+        ],
+        1,
+        new Date("2026-03-27T12:00:00Z").getTime()
+      )
+    ).toBe(110);
+  });
+
+  it("returns null when the chart is stale", () => {
+    expect(
+      getPrevTvlFromChart(
+        [
+          [1774396800, 90],
+          [1774483200, 100],
+        ],
+        1,
+        new Date("2026-03-27T12:00:00Z").getTime()
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when the requested day is missing", () => {
+    expect(
+      getPrevTvlFromChart(
+        [
+          [1774396800, 90],
+          [1774569600, 120],
+        ],
+        1,
+        new Date("2026-03-27T12:00:00Z").getTime()
+      )
+    ).toBeNull();
+  });
+});

--- a/defi/src/api2/utils/tvlChart.test.ts
+++ b/defi/src/api2/utils/tvlChart.test.ts
@@ -14,13 +14,13 @@ describe("getPrevTvlFromChart", () => {
     ).toBe(110);
   });
 
-  it("returns the latest point in the requested UTC day window", () => {
+  it("returns the point closest to the 24h target within tolerance", () => {
     expect(
       getPrevTvlFromChart(
         [
-          [1774483200, 100],
-          [1774526400, 110],
-          [1774569600, 120],
+          [new Date("2026-03-26T00:02:00Z").getTime(), 100],
+          [new Date("2026-03-26T00:04:00Z").getTime(), 110],
+          [new Date("2026-03-27T00:05:00Z").getTime(), 120],
         ],
         1,
         new Date("2026-03-27T12:00:00Z").getTime()
@@ -41,12 +41,12 @@ describe("getPrevTvlFromChart", () => {
     ).toBeNull();
   });
 
-  it("returns null when the requested day is missing", () => {
+  it("returns null when no point is close enough to the 24h target", () => {
     expect(
       getPrevTvlFromChart(
         [
-          [1774396800, 90],
-          [1774569600, 120],
+          [new Date("2026-03-26T12:00:00Z").getTime(), 90],
+          [new Date("2026-03-27T00:05:00Z").getTime(), 120],
         ],
         1,
         new Date("2026-03-27T12:00:00Z").getTime()

--- a/defi/src/api2/utils/tvlChart.ts
+++ b/defi/src/api2/utils/tvlChart.ts
@@ -1,0 +1,39 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toUnixMsTimestamp(timestamp: number): number {
+  return timestamp > 1e12 ? timestamp : timestamp * 1e3;
+}
+
+function getUtcStartOfDay(timestamp: number): number {
+  const date = new Date(timestamp);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function getPrevTvlFromChart(
+  chart: [number, number][] | null | undefined,
+  daysBefore: number,
+  currentTimeMs: number = Date.now()
+): number | null {
+  if (!chart?.length) return null;
+
+  if (daysBefore === 0) {
+    return chart[chart.length - 1]?.[1] ?? null;
+  }
+
+  const latestTimestamp = toUnixMsTimestamp(Number(chart[chart.length - 1]?.[0]));
+  const todayStart = getUtcStartOfDay(currentTimeMs);
+  if (!Number.isFinite(latestTimestamp) || latestTimestamp < todayStart) return null;
+
+  const targetDayStart = todayStart - daysBefore * DAY_MS;
+  const targetDayEnd = targetDayStart + DAY_MS;
+
+  for (let index = chart.length - 1; index >= 0; index--) {
+    const [timestamp, value] = chart[index];
+    const normalizedTimestamp = toUnixMsTimestamp(Number(timestamp));
+    if (normalizedTimestamp >= targetDayStart && normalizedTimestamp < targetDayEnd) {
+      return value ?? null;
+    }
+  }
+
+  return null;
+}

--- a/defi/src/api2/utils/tvlChart.ts
+++ b/defi/src/api2/utils/tvlChart.ts
@@ -1,4 +1,5 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_LOOKUP_TOLERANCE_MS = 2 * 60 * 60 * 1000;
 
 function toUnixMsTimestamp(timestamp: number): number {
   return timestamp > 1e12 ? timestamp : timestamp * 1e3;
@@ -24,16 +25,22 @@ export function getPrevTvlFromChart(
   const todayStart = getUtcStartOfDay(currentTimeMs);
   if (!Number.isFinite(latestTimestamp) || latestTimestamp < todayStart) return null;
 
-  const targetDayStart = todayStart - daysBefore * DAY_MS;
-  const targetDayEnd = targetDayStart + DAY_MS;
+  const targetTimestamp = latestTimestamp - daysBefore * DAY_MS;
+  let closestValue: number | null = null;
+  let closestTimestamp = -Infinity;
+  let smallestDiff = Infinity;
 
-  for (let index = chart.length - 1; index >= 0; index--) {
+  for (let index = 0; index < chart.length; index++) {
     const [timestamp, value] = chart[index];
     const normalizedTimestamp = toUnixMsTimestamp(Number(timestamp));
-    if (normalizedTimestamp >= targetDayStart && normalizedTimestamp < targetDayEnd) {
-      return value ?? null;
+    const diff = Math.abs(normalizedTimestamp - targetTimestamp);
+    if (diff > DEFAULT_LOOKUP_TOLERANCE_MS) continue;
+    if (diff < smallestDiff || (diff === smallestDiff && normalizedTimestamp > closestTimestamp)) {
+      smallestDiff = diff;
+      closestTimestamp = normalizedTimestamp;
+      closestValue = value ?? null;
     }
   }
 
-  return null;
+  return closestValue;
 }

--- a/defi/src/rwa/perps/cron.ts
+++ b/defi/src/rwa/perps/cron.ts
@@ -18,7 +18,7 @@ import {
     fetchMaxUpdatedAtPG,
     fetchAllDailyIdsPG,
 } from './db';
-import { toFiniteNumberOrZero, groupBy } from './utils';
+import { getPercentChangeOrNull, toFiniteNumberOrZero, groupBy } from './utils';
 import { main as runPipeline } from './perps';
 import {
     buildCategoryHistoricalCharts,
@@ -56,9 +56,15 @@ async function generateCurrentData(metadata: PerpsMetadata[]): Promise<any[]> {
             id: record.id,
             timestamp: record.timestamp,
             openInterest: toFiniteNumberOrZero(record.open_interest),
+            openInterestChange24h: record.is_latest_current
+                ? getPercentChangeOrNull(record.open_interest, record.prev_open_interest)
+                : null,
             volume24h: toFiniteNumberOrZero(record.volume_24h),
+            volume24hChange24h: record.is_latest_current
+                ? getPercentChangeOrNull(record.volume_24h, record.prev_volume_24h)
+                : null,
             price: toFiniteNumberOrZero(record.price),
-            priceChange24h: toFiniteNumberOrZero(record.price_change_24h),
+            priceChange24h: record.is_latest_current ? getPercentChangeOrNull(record.price, record.prev_price) : null,
             fundingRate: toFiniteNumberOrZero(record.funding_rate),
             premium: toFiniteNumberOrZero(record.premium),
             cumulativeFunding: toFiniteNumberOrZero(record.cumulative_funding),

--- a/defi/src/rwa/perps/db.ts
+++ b/defi/src/rwa/perps/db.ts
@@ -1,6 +1,7 @@
 import { getCurrentUnixTimestamp, getTimestampAtStartOfDay, secondsInDay } from "../../utils/date";
 import { DataTypes, Model, Op, QueryTypes, Sequelize } from 'sequelize'
 import { normalizePerpsMetadataInPlace } from "./constants";
+import { PREVIOUS_CHANGE_LOOKUP_TOLERANCE_SECONDS } from "./utils";
 
 class META_RWA_PERPS_DATA extends Model { }
 export class DAILY_RWA_PERPS_DATA extends Model { }
@@ -323,9 +324,8 @@ export async function fetchCurrentPG(): Promise<any[]> {
             SELECT open_interest, volume_24h, price
             FROM "${HOURLY_RWA_PERPS_DATA.getTableName()}" previous
             WHERE previous.id = latest.id
-              AND previous.timestamp >= (latest.timestamp - (latest.timestamp % ${secondsInDay})) - ${secondsInDay}
-              AND previous.timestamp < (latest.timestamp - (latest.timestamp % ${secondsInDay}))
-            ORDER BY previous.timestamp DESC
+              AND ABS(previous.timestamp - (latest.timestamp - ${secondsInDay})) <= ${PREVIOUS_CHANGE_LOOKUP_TOLERANCE_SECONDS}
+            ORDER BY ABS(previous.timestamp - (latest.timestamp - ${secondsInDay})) ASC, previous.timestamp DESC
             LIMIT 1
         ) previous ON true`,
         { type: QueryTypes.SELECT }

--- a/defi/src/rwa/perps/db.ts
+++ b/defi/src/rwa/perps/db.ts
@@ -306,11 +306,28 @@ export async function fetchMetadataPG(): Promise<any[]> {
 
 // Get one record per id with the largest timestamp
 export async function fetchCurrentPG(): Promise<any[]> {
+    const currentDayStart = getTimestampAtStartOfDay(getCurrentUnixTimestamp());
     const data = await HOURLY_RWA_PERPS_DATA.sequelize!.query(
-        `SELECT DISTINCT ON (id) id, timestamp, open_interest, volume_24h, price,
-                price_change_24h, funding_rate, premium, cumulative_funding, data
-         FROM "${HOURLY_RWA_PERPS_DATA.getTableName()}"
-         ORDER BY id, timestamp DESC`,
+        `WITH latest AS (
+            SELECT DISTINCT ON (id) id, timestamp, open_interest, volume_24h, price,
+                    price_change_24h, funding_rate, premium, cumulative_funding, data
+            FROM "${HOURLY_RWA_PERPS_DATA.getTableName()}"
+            ORDER BY id, timestamp DESC
+        )
+        SELECT latest.*,
+               previous.open_interest AS prev_open_interest,
+               previous.volume_24h AS prev_volume_24h,
+               previous.price AS prev_price
+        FROM latest
+        LEFT JOIN LATERAL (
+            SELECT open_interest, volume_24h, price
+            FROM "${HOURLY_RWA_PERPS_DATA.getTableName()}" previous
+            WHERE previous.id = latest.id
+              AND previous.timestamp >= (latest.timestamp - (latest.timestamp % ${secondsInDay})) - ${secondsInDay}
+              AND previous.timestamp < (latest.timestamp - (latest.timestamp % ${secondsInDay}))
+            ORDER BY previous.timestamp DESC
+            LIMIT 1
+        ) previous ON true`,
         { type: QueryTypes.SELECT }
     ) as any[];
 
@@ -321,6 +338,7 @@ export async function fetchCurrentPG(): Promise<any[]> {
         } catch {
             copy.data = {};
         }
+        copy.is_latest_current = Number(copy.timestamp) >= currentDayStart;
         return copy;
     });
 }

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -2,7 +2,7 @@ jest.mock("../spreadsheet", () => ({
   getCsvData: jest.fn(),
 }));
 
-import { toFiniteNumberOrZero, perpsSlug, computeProtocolFees, groupBy } from "./utils";
+import { toFiniteNumberOrZero, getPercentChangeOrNull, perpsSlug, computeProtocolFees, groupBy } from "./utils";
 import { fileNameNormalizer, mergeHistoricalData } from "./file-cache";
 import { buildPerpsList } from "./list";
 import {
@@ -68,6 +68,19 @@ describe("toFiniteNumberOrZero", () => {
     expect(toFiniteNumberOrZero(null)).toBe(0);
     expect(toFiniteNumberOrZero("abc")).toBe(0);
     expect(toFiniteNumberOrZero("")).toBe(0);
+  });
+});
+
+describe("getPercentChangeOrNull", () => {
+  it("computes percent change from the previous value", () => {
+    expect(getPercentChangeOrNull(120, 100)).toBe(20);
+    expect(getPercentChangeOrNull(80, 100)).toBe(-20);
+  });
+
+  it("returns null when the previous value is missing or zero", () => {
+    expect(getPercentChangeOrNull(120, 0)).toBeNull();
+    expect(getPercentChangeOrNull(120, null)).toBeNull();
+    expect(getPercentChangeOrNull(120, undefined)).toBeNull();
   });
 });
 

--- a/defi/src/rwa/perps/utils.ts
+++ b/defi/src/rwa/perps/utils.ts
@@ -3,6 +3,8 @@ export function toFiniteNumberOrZero(value: any): number {
     return Number.isFinite(num) ? num : 0;
 }
 
+export const PREVIOUS_CHANGE_LOOKUP_TOLERANCE_SECONDS = 2 * 60 * 60;
+
 export function getPercentChangeOrNull(currentValue: unknown, previousValue: unknown): number | null {
     const current = typeof currentValue === "number" ? currentValue : Number(currentValue);
     const previous = typeof previousValue === "number" ? previousValue : Number(previousValue);

--- a/defi/src/rwa/perps/utils.ts
+++ b/defi/src/rwa/perps/utils.ts
@@ -3,6 +3,18 @@ export function toFiniteNumberOrZero(value: any): number {
     return Number.isFinite(num) ? num : 0;
 }
 
+export function getPercentChangeOrNull(currentValue: unknown, previousValue: unknown): number | null {
+    const current = typeof currentValue === "number" ? currentValue : Number(currentValue);
+    const previous = typeof previousValue === "number" ? previousValue : Number(previousValue);
+
+    if (!Number.isFinite(current) || !Number.isFinite(previous) || previous === 0) {
+        return null;
+    }
+
+    const percentChange = ((current - previous) / previous) * 100;
+    return Number.isFinite(percentChange) ? percentChange : null;
+}
+
 
 const LEADING_DASH_REGEX = /^-+/;
 const TRAILING_DASH_REGEX = /-+$/;


### PR DESCRIPTION
## Summary
- add `openInterestChange24h`, `volume24hChange24h`, and stricter `priceChange24h` handling to the RWA perps current API payload
- calculate those per-market changes from the latest snapshot matched to the closest snapshot roughly 24h earlier within a tolerance window, returning null when the data is stale or there is no close enough prior point
- also harden `chains2` TVL change lookups so stale or missing near-24h points do not produce misleading percentage changes

## Testing
- ./node_modules/.bin/jest src/rwa/perps/perps.test.ts src/api2/utils/tvlChart.test.ts src/api2/cron-task/genFormattedChains.test.ts --runInBand --watchman=false