### PR TITLE
add NextRare

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1045,5 +1045,27 @@ const data6: Protocol[] = [
       options: "kyan",
     },
   },
+  {
+    id: "7757",
+    name: "NextRare",
+    address: null,
+    symbol: "-",
+    url: "https://nextrare.cards",
+    description:
+      "NextRare is the onchain home for serious TCG collectors & traders. Backed by a local partner with over 20mil GMV, NextRare comes with real inventory, real odds, and access most platforms simply can't offer.",
+    chain: "MegaETH",
+    logo: `${baseIconsUrl}/nextrare.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Physical TCG",
+    chains: ["MegaETH"],
+    module: "dummy.js",
+    twitter: "Nextrare_cards",
+    dimensions: {
+      fees: "nextrare",
+    },
+    listedAt: 1776683811,
+  },
 ];
 export default data6;


### PR DESCRIPTION
## Summary

Adds **NextRare** (id `7721`) to `defi/src/protocols/data6.ts` — a cross-chain NFT gacha protocol. Metadata-only listing (same pattern as Collector Crypt id 6675); no TVL adapter. Volume/fees come from the dimension adapter at DefiLlama/dimension-adapters#6432.

## Description

> NextRare is the onchain home for serious TCG collectors & traders. Backed by a local partner with over 20mil GMV, NextRare comes with real inventory, real odds, and access most platforms simply can't offer.

## Details

- **Category:** Physical TCG
- **Primary chain:** MegaETH (cards mint here as ERC-721 NFTs)
- **Payment chains:** Base, Arbitrum, BSC, Mantle, HyperEVM, Monad (USDC/USDT) — CREATE2 Collector at `0x0000000032B93DAf5c6Ff220cB2D03624CB56302` forwards deposits directly to treasury in the same transaction
- **Website:** https://nextrare.cards
- **iOS app:** https://apps.apple.com/app/nextrare/id6756167956
- **Twitter:** https://x.com/Nextrare_cards
- **Discord:** https://t.co/N63AgdqQkl
- **Dimensions:** `fees: "nextrare"` → links to `fees/nextrare/index.ts` in DefiLlama/dimension-adapters#6432 (open)

## Logo

Source PNG (1024×1024): https://cdn.nr.cards/nr2-icon.png

![NextRare logo](https://cdn.nr.cards/nr2-icon.png)

Please host at `icons.llama.fi/nextrare.jpg`. JPG version available on request — happy to attach as a separate PR to DefiLlama/icons if preferred.

## Test plan

- [x] Next unused id verified: `7721` (data6 tail is 7720 = Milk Finance)
- [x] Shape matches existing `Physical TCG` entry (Collector Crypt id 6675)
- [x] Companion fees adapter PR open: DefiLlama/dimension-adapters#6432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NextRare as a supported protocol on the MegaETH network, including site link, description, logo, audit status, fee details, multi-chain metadata, and verified social handles for improved discovery and transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->