### PR TITLE
Rename Morpho V0 -> Morpho Optimizer and Morpho V1 -> Morpho Blue

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -13505,8 +13505,8 @@ const data2: Protocol[] = [
   },
   {
     id: "1997",
-    name: "Morpho V0 CompoundV2",
-    previousNames: ["Morpho Compound"],
+    name: "Morpho Optimizer CompoundV2",
+    previousNames: ["Morpho Compound", "Morpho V0 CompoundV2"],
     address: "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
     symbol: "MORPHO",
     url: "https://compound.morpho.org/?network=mainnet",
@@ -17383,8 +17383,8 @@ const data2: Protocol[] = [
   },
   {
     id: "2168",
-    name: "Morpho V0 AaveV2",
-    previousNames: ["Morpho Aave"],
+    name: "Morpho Optimizer AaveV2",
+    previousNames: ["Morpho Aave", "Morpho V0 AaveV2"],
     address: "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
     symbol: "MORPHO",
     url: "https://aavev2.morpho.org/?network=mainnet",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -6923,8 +6923,8 @@ const data3_0: Protocol[] = [
   },
   {
     id: "3014",
-    name: "Morpho V0 AaveV3",
-    previousNames: ["Morpho AaveV3"],
+    name: "Morpho Optimizer AaveV3",
+    previousNames: ["Morpho AaveV3", "Morpho V0 AaveV3"],
     address: "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
     symbol: "MORPHO",
     url: "https://aavev3.morpho.org/",
@@ -29271,8 +29271,8 @@ const data3_1: Protocol[] = [
   },
   {
     id: "4025",
-    name: "Morpho V1",
-    previousNames: ["Morpho Blue"],
+    name: "Morpho Blue",
+    previousNames: ["Morpho V1"],
     address: "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
     symbol: "MORPHO",
     url: "https://app.morpho.org",


### PR DESCRIPTION
## Summary
Align DefiLlama display names with Morpho's external branding, reverting / re-renaming the entries changed in https://github.com/DefiLlama/defillama-server/commit/a771755ad96fbad0ef617691d45c7191cb726dc1:

| id | before (current) | after (this PR) |
| --- | --- | --- |
| 1997 | Morpho V0 CompoundV2 | **Morpho Optimizer CompoundV2** |
| 2168 | Morpho V0 AaveV2 | **Morpho Optimizer AaveV2** |
| 3014 | Morpho V0 AaveV3 | **Morpho Optimizer AaveV3** |
| 4025 | Morpho V1 | **Morpho Blue** |

## Rationale
- `Morpho Optimizer` is the actual external / product name for the deprecated V0 products (Compound V2 / Aave V2 / Aave V3 optimizers). The `Morpho V0 …` naming was internal-only.
- `Morpho Blue` is the live product name used everywhere (docs, app, partners, audits); `Morpho V1` is not the public display name.
- `previousNames` is preserved so historical DefiLlama URL slugs keep resolving.

## Scope
Only edits `defi/src/protocols/data2.ts` and `defi/src/protocols/data3.ts` (4 entries, `name` + `previousNames` only). No logo/URL/description changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated protocol names for Morpho Optimizer CompoundV2, Morpho Optimizer AaveV2, Morpho Optimizer AaveV3, and Morpho Blue to reflect current naming conventions.
  * Enhanced protocol naming history to track previous version names for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->