### PR TITLE
add mRe7ETH on OP

### DIFF
--- a/coins/src/adapters/rwa/midas.ts
+++ b/coins/src/adapters/rwa/midas.ts
@@ -133,6 +133,14 @@ const contracts: Record<string, TokenConfig[]> = {
       denomination: "BTC",
     },
   ],
+  optimism: [
+    {
+      name: "mRe7ETH",
+      token: "0xE7Ba07519dFA06e60059563F484d6090dedF21B3",
+      oracle: "0xcFfe26979e96B9E0454cC83aa03FC973C9Eb0E5E",
+      denomination: "ETH",
+    },
+  ],
   // base: [
   //   {
   //     name: "mTBILL",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mRe7ETH token on Optimism, enabling price fetching and aggregation for this asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->