### PR TITLE
Add Chainlink as Primary Oracle for Mento

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -8839,17 +8839,19 @@ The eWIT token is a custodial, wrapped version of the Witnet coin managed by the
       {
         name: "cLabs",
         type: "Aggregator",
+        endDate: "2026-04-21",
         proof: ["https://celo.stake.id/#/proposal/145"]
       },
       {
         name: "RedStone",
         type: "Aggregator",
+        endDate: "2026-04-21",
         proof: ["https://celo.stake.id/#/proposal/145"]
       },
        {
         name: "Chainlink",
-        type: "Aggregator",
-        proof: ["https://docs.mento.org/mento/overview/core-concepts/oracles-and-price-feeds#oracle-providers"]
+        type: "Primary",
+        proof: ["https://docs.mento.org/mento-v3?q=oracle#fixed-price-market-makers-fpmms-the-core-of-v3"]
       }
     ],
     dimensions: {

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -14172,6 +14172,13 @@ const data5: Protocol[] = [
     module: "mento-v3/index.js",
     twitter: "MentoLabs",
     parentProtocol: "parent#mento",
+    oraclesBreakdown: [
+      {
+        name: "Chainlink",
+        type: "Primary",
+        proof: ["https://docs.mento.org/mento-v3?q=oracle#fixed-price-market-makers-fpmms-the-core-of-v3"]
+      }
+    ],
     listedAt: 1773583724,
     audit_links: [
       "https://www.chainsecurity.com/security-audit/mento-core-v3",


### PR DESCRIPTION
Hello DefiLlama team, this PR is to add Chainlink as the primary oracle for Mento V2 and Mento V3 and remove all other oracles.
Mento V2 and V3 rely on external oracle pricing to operate their fixed-price market makers (FPMMs), which are the core mechanism for swaps and stable asset conversions. According to the Mento V3 documentation, FPMMs depend on reliable price inputs to maintain correct exchange rates and system solvency.
Chainlink Price Feeds are used as the primary onchain oracle source for these price inputs, providing the reference rates that underpin trading, minting, and redemption across Mento markets. Because these oracle prices directly determine exchange rates and the value users receive when interacting with the protocol, Chainlink is a critical component in securing Mento’s TVL.
Docs: https://docs.mento.org/mento-v3?q=oracle#fixed-price-market-makers-fpmms-the-core-of-v3

Screenshot from docs:
<img width="1634" height="930" alt="chainlink-mento-primary-oracle" src="https://github.com/user-attachments/assets/8178fe8c-76c3-4672-bfbb-c44605781ded" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated protocol end dates for cLabs and RedStone entries to April 2026
  * Modified Chainlink protocol classification from Aggregator to Primary with updated proof documentation link
  * Added oracle source metadata to Mento V3 protocol, designating Chainlink as the Primary oracle provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->