### PR TITLE
Update GrelfSwap listing (id 7713): metadata + fees dimension

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -127,20 +127,19 @@ const data6: Protocol[] = [
   {
     id: "7713",
     name: "GrelfSwap",
-    address: null,
-    symbol: "-",
-    url: " ", // pending to add url https://grelfswap.com/
-    description:
-      "GrelfSwap is a DEX aggregator on Hedera",
+    address: "hedera:0.0.1159074",
+    symbol: "GRELF",
+    url: "https://grelfswap.com",
+    description: "GrelfSwap is a DEX aggregator on Hedera",
     chain: "Hedera",
     logo: `${baseIconsUrl}/grelfswap.jpg`,
     audits: "0",
-    gecko_id: null,
+    gecko_id: "grelf",
     cmcId: null,
     category: "DEX Aggregator",
     chains: ["Hedera"],
     module: "dummy.js",
-    twitter: null,
+    twitter: "GRELF_",
     dimensions: {
       aggregators: "grelfswap",
     },

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -142,6 +142,7 @@ const data6: Protocol[] = [
     twitter: "GRELF_",
     dimensions: {
       aggregators: "grelfswap",
+      fees: "grelfswap",
     },
   },
   {


### PR DESCRIPTION
Updates entry id 7713 (GrelfSwap) on data6.ts:

- `address`: `hedera:0.0.1159074`
- `symbol`: `GRELF`
- `url`: `https://grelfswap.com`
- `gecko_id`: `grelf`
- `twitter`: `GRELF_`
- `description`: `GrelfSwap is a DEX aggregator on Hedera`
- `dimensions`: adds `fees: "grelfswap"` alongside the existing `aggregators: "grelfswap"`, complementing the fees adapter PR at DefiLlama/dimension-adapters#6471.

Logo PR to follow on DefiLlama/icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed GrelfSwap protocol configuration by populating all required metadata fields, including the official website URL, asset symbol identifier, and verified social media accounts. Further enhanced protocol dimensionality to include comprehensive fee tracking information alongside existing aggregator support, enabling more accurate and complete protocol analysis with improved financial data representation across the entire platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->