### PR TITLE
feat: list FrenFlow protocol

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -923,7 +923,7 @@ const data6: Protocol[] = [
     name: "FrenFlow",
     address: null,
     symbol: "-",
-    url: "https://frenflow.com",
+    url: "https://www.frenflow.com",
     description: "FrenFlow is the social + execution layer for prediction markets. A unified trading UI and Telegram bot with self-custody routing across Polymarket, Kalshi (via DFlow), and Predict.fun — plus native copytrading, social feed, and leaderboards.",
     chain: "Polygon",
     logo: `${baseIconsUrl}/frenflow.jpg`,

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -918,5 +918,27 @@ const data6: Protocol[] = [
       fees: "flying-tulip-lend"
     }
   },
+  {
+    id: "7751",
+    name: "FrenFlow",
+    address: null,
+    symbol: "-",
+    url: "https://frenflow.com",
+    description: "FrenFlow is the social + execution layer for prediction markets. A unified trading UI and Telegram bot with self-custody routing across Polymarket, Kalshi (via DFlow), and Predict.fun — plus native copytrading, social feed, and leaderboards.",
+    chain: "Polygon",
+    logo: `${baseIconsUrl}/frenflow.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Interface",
+    chains: ["Polygon"],
+    module: "dummy.js",
+    twitter: "frenflow",
+    listedAt: 1777000000,
+    dimensions: {
+      dexs: "frenflow",
+      fees: "frenflow",
+    },
+  },
 ];
 export default data6;


### PR DESCRIPTION
## FrenFlow

The social + execution layer for prediction markets. A unified trading UI and Telegram bot with self-custody routing across Polymarket, Kalshi (via DFlow), and Predict.fun — plus native copytrading, social feed, and leaderboards.

- **Website**: https://frenflow.com
- **Twitter**: https://x.com/frenflow
- **Repo**: https://github.com/frenflow/frenflow_v1

## Entry summary

- `id: "7751"` (next available after Flying Tulip Lend / 7750)
- `category: "Interface"` — matches the Polymarket-builder cohort (Betmoar, Polycule, Based Predict, PolyTraderPro, DFlow Prediction Market)
- `chains: ["Polygon"]` — conservative; reflects the adapters submitted today. Solana (Kalshi/DFlow) and Binance (Predict.fun) fee paths are on our roadmap and will be added via follow-up metadata updates once their dimension adapters land.
- `dimensions`: `dexs: "frenflow"` and `fees: "frenflow"` — both routed through the corresponding dimension-adapter entries.

## Companion PRs

This PR is the third leg of the FrenFlow listing:

1. ✅ **dimension-adapters #6481** — `fees/frenflow.ts` (1% service fee via FeeCollector on Polygon) + `factory/polymarket.ts` entry for builder volume via the official Polymarket builders API. Verified via local test: Apr 22 volume = \$446, matches \`data-api.polymarket.com/v1/builders/volume\`.
2. ✅ **icons #2361** — `assets/protocols/frenflow.jpg` (512×512, 27 KB).
3. 👉 **this PR** — protocol metadata entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)