### PR TITLE
fix(protocols): add website URL for FrenFlow

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -944,7 +944,7 @@ const data6: Protocol[] = [
     name: "FrenFlow",
     address: null,
     symbol: "-",
-    url: " ", // pending to add url https://frenflow.com
+    url: "https://www.frenflow.com",
     description: "The social hub of Prediction Markets. Predict with frens, copy and win together. No CA. Only flow.",
     chain: "Polygon",
     logo: `${baseIconsUrl}/frenflow.jpg`,


### PR DESCRIPTION
The FrenFlow protocol entry in `defi/src/protocols/data6.ts` had `url: " "` with a `// pending to add url https://frenflow.com` comment, so https://defillama.com/protocol/frenflow shows GitHub and Twitter but no website link.

Setting the canonical URL to `https://www.frenflow.com`.

No other fields touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the FrenFlow protocol's website information with the proper URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->