### PR TITLE
temp disable standx dusd fees

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -8586,7 +8586,8 @@ const data5: Protocol[] = [
     parentProtocol: "parent#standx",
     stablecoins: ["standx-dusd"],
     dimensions: {
-      fees: "standx-dusd",
+      //fees: "standx-dusd", // it includes only withdrawl fees which misrepresents overall parent adapter stats, so disabling until perp fee stats are available
+                             // more info https://github.com/DefiLlama/dimension-adapters/pull/6461 & https://github.com/DefiLlama/dimension-adapters/pull/6477#discussion_r3137067079
     },
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled fee metrics for StandX DUSD protocol to address data accuracy issues. The previous fee configuration captured only a subset of applicable fees, leading to incomplete and potentially misleading calculations. This correction ensures more reliable protocol reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->