### PR TITLE
fix: typo in Loot DAO name and missing chains array for JetMine DAO

### DIFF
--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -3460,7 +3460,7 @@ const data2: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     category: "Yield",
-    chains: [],
+    chains: ["Fantom"],
     module: "jetmine/index.js",
     twitter: "defi_waterfall",
     audit_links: ["https://paladinsec.co/projects/waterfall-finance/"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -16475,7 +16475,7 @@ const data3_0: Protocol[] = [
   },
   {
     id: "3443",
-    name: "Loot  DAO",
+    name: "Loot DAO",
     address: "0xFF9C1b15B16263C61d017ee9F65C50e4AE0113D7",
     symbol: "LOOT",
     url: "https://www.royaltydao.com/",


### PR DESCRIPTION
Two small data integrity fixes I noticed while reading data2.ts and data3.ts:

1. data2.ts: JetMine DAO has `chain: "Fantom"` but `chains: []`. 
   Module is `jetmine/index.js` (Fantom). Setting chains accordingly.

2. data3.ts: "Loot  DAO" has a double space between words. 
   Removed one space.

Both verifiable from the surrounding context in the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected protocol name formatting by removing extra spacing
  * Added Fantom network support for a yield protocol

<!-- end of auto-generated comment: release notes by coderabbit.ai -->