### PR TITLE
Fix raises cache loading

### DIFF
--- a/defi/src/api2/cache/index.ts
+++ b/defi/src/api2/cache/index.ts
@@ -183,7 +183,7 @@ async function updateMetadata() {
 async function updateRaises() {
   try {
 
-    const { raises } = await readRouteData("/raises").then((res) => res.json())
+    const { raises } = await readRouteData("/raises")
     const raisesObject: any = {}
     raises.forEach((r: any) => {
       const id = r.defillamaId


### PR DESCRIPTION
## Summary
- load parsed /raises route data directly when building the API cache
- keep the existing defillamaId indexing used by protocol overview responses

## Verification
- git diff --check -- defi/src/api2/cache/index.ts
- ./node_modules/.bin/tsc --noEmit --skipLibCheck --target es2020 --module commonjs --esModuleInterop src/api2/cache/index.ts

Full ./node_modules/.bin/tsc --noEmit still fails on existing repo-wide issues outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->