### PR TITLE
Reissue GIFT token as GYTW token

### DIFF
--- a/coins/src/adapters/rwa/axc.ts
+++ b/coins/src/adapters/rwa/axc.ts
@@ -19,8 +19,8 @@ const CHAINS: ChainTokens[] = [
     chain: "bsc",
     tokens: [
       {
-        name: "GIFT",
-        tokenAddress: "0x6Eca9D3B1ef79F5b45572fb8204835C6A4502bE9",
+        name: "GYTW",
+        tokenAddress: "0xfC787d44f3754aDd0242204533b2B4A7eB9876e1",
         pricerAddress: "0xCcaCA7A3b472843016E98db8EAF921A7a770f9eA",
       },
     ],

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -9496,12 +9496,12 @@ const data5: Protocol[] = [
   },
   {
     id: "7322",
-    name: "AXC GIFT",
+    name: "AXC GYTW",
     address: null,
     symbol: "-",
     url: "https://axc.xyz",
     description:
-      "GIFT is a permissioned asset-backed token which seeks to match the performance of the GROW Heritage Fund.",
+      "Growth Yield Token Whitelist (GYTW) is a fund‑of‑hedge‑funds (RWA) product. The fund issuer has partnered up with AXC labs to issue a tokenised fund product.  Its investment strategy allocates capital to top‑performing global hedge funds.  The underlying fund manager has over 20 years of industry experience and has established strategic shareholder relationships with top-tier investment manager.",
     chain: "Binance",
     logo: `${baseIconsUrl}/axc-gift.jpg`,
     audits: "0",
@@ -9509,7 +9509,7 @@ const data5: Protocol[] = [
     cmcId: null,
     tags: ["Private Credit"],
     chains: ["Binance"],
-    module: "axc-gift/index.js",
+    module: "axc-gytw/index.js",
     forkedFromIds: [],
     audit_links: [],
     github: ["accelerate-protocol"],


### PR DESCRIPTION
This is a followup to DefiLlama/DefiLlama-Adapters#17550

We have reissued our GIFT token as GYTW and would like to update the entries on defilama.  Information about the updated token is available via https://dapp.axc.xyz/vault/260416100623001



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Migrated AXC protocol from GIFT to GYTW (Growth Yield Token Whitelist) with updated configuration
  * Updated protocol listing name from AXC GIFT to AXC GYTW
  * Refreshed protocol description to accurately reflect the fund-of-hedge-funds real-world assets (RWA) investment product offering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->