### PR TITLE
Add FXRP on Monad

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -16466,6 +16466,11 @@
       "to": "coingecko#midas-hyperithm-btc",
       "decimals": 18,
       "symbol": "mHyperBTC"
+    },
+    "0xCE6170EA245dC8D1f275A710a062b70f125F0110": {
+      "decimals": "6",
+      "symbol": "FXRP",
+      "to": "coingecko#flare-bridged-xrp-flare"
     }
   },
   "stable": {


### PR DESCRIPTION
[$2.13M in Euler on Monad](https://app.euler.finance/lend/0x144290085Da25E3078425C6F4A477fD8caB0c43e?network=143)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FXRP (Flare-bridged XRP) token is now supported on Monad network. The token includes proper decimal configuration and seamless integration with external pricing services, allowing users to track, view, and interact with FXRP tokens across the platform with accurate, real-time pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->