### PR TITLE
feat: list Pool Party — Canton Network AMM

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -14592,24 +14592,6 @@ const data5: Protocol[] = [
     listedAt: 1774368695
   },
   {
-    id: "7758",
-    name: "Pool Party",
-    address: null,
-    symbol: "-",
-    url: "https://poolparty.fun",
-    description: "Pool Party is the first AMM on Canton Network, built by Send Foundation. It enables non-custodial swaps and liquidity provision in CC, CUSD (Send's privacy stablecoin), and USDCx (bridged USDC) directly from the Send Canton Wallet. Launched February 2026.",
-    chain: "Canton",
-    logo: `${baseIconsUrl}/pool-party.jpg`,
-    audits: "0",
-    gecko_id: null,
-    cmcId: null,
-    category: "Dexes",
-    chains: ["Canton"],
-    module: "pool-party/index.js",
-    twitter: "send",
-    listedAt: 1777311338
-  },
-  {
     id: "7565",
     name: "Rocket Perp",
     address: null,

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -14592,6 +14592,24 @@ const data5: Protocol[] = [
     listedAt: 1774368695
   },
   {
+    id: "7758",
+    name: "Pool Party",
+    address: null,
+    symbol: "-",
+    url: "https://poolparty.fun",
+    description: "Pool Party is the first AMM on Canton Network, built by Send Foundation. It enables non-custodial swaps and liquidity provision in CC, CUSD (Send's privacy stablecoin), and USDCx (bridged USDC) directly from the Send Canton Wallet. Launched February 2026.",
+    chain: "Canton",
+    logo: `${baseIconsUrl}/pool-party.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Dexes",
+    chains: ["Canton"],
+    module: "pool-party/index.js",
+    twitter: "send",
+    listedAt: 1777311338
+  },
+  {
     id: "7565",
     name: "Rocket Perp",
     address: null,

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1064,5 +1064,23 @@ const data6: Protocol[] = [
     audit_links: ["https://docs.wedefin.com/technical-overview/audits"],
     listedAt: 1777310614,
   },
+  {
+    id: "7758",
+    name: "Pool Party",
+    address: null,
+    symbol: "-",
+    url: "https://poolparty.fun",
+    description: "Pool Party is the first AMM on Canton Network, built by Send Foundation. It enables non-custodial swaps and liquidity provision in CC, CUSD (Send's privacy stablecoin), and USDCx (bridged USDC) directly from the Send Canton Wallet. Launched February 2026.",
+    chain: "Canton",
+    logo: `${baseIconsUrl}/pool-party.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Dexes",
+    chains: ["Canton"],
+    module: "pool-party/index.js",
+    twitter: "send",
+    listedAt: 1777311905,
+  },
 ];
 export default data6;

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1079,7 +1079,7 @@ const data6: Protocol[] = [
     category: "Dexes",
     chains: ["Canton"],
     module: "pool-party/index.js",
-    twitter: "send",
+    twitter: "Send",
     listedAt: 1777311905,
   },
 ];


### PR DESCRIPTION
## Listing for Pool Party — Canton Network AMM

Pool Party is the first AMM on Canton Network, built by Send Foundation. Launched February 2026. Live pairs: CC/CUSD, CC/USDCx, USDCx/CUSD.

Adds one entry to `defi/src/protocols/data6.ts` (id `7758`), placed after the WeDeFin entry. Mirrors the existing `wCC` schema (id `7564` in `data5.ts`) for Canton-chain protocols.

## Companion adapter PR

DefiLlama-Adapters PR with the TVL adapter: **DefiLlama/DefiLlama-Adapters#18900** — mirrors the existing `projects/wcc/index.js` pattern (chain-keyed `canton: { tvl }`, queries the public Lighthouse API for the project's Canton party).

## Methodology

> TVL is the total Canton Coin (CC) balance held by Pool Party's Canton party (`poolparty::1220f1b0d7a8…`), fetched from the public Lighthouse API at `https://lighthouse.cantonloop.com/api/parties/{partyId}/balance`. Stablecoin sides of pools (CUSD, USDCx) are not yet queryable through public Canton APIs and are not included in this listing — same trade-off as the existing wCC adapter.

## Project facts

- **Name**: Pool Party
- **Website**: https://poolparty.fun
- **App**: https://cantonwallet.com/pools/
- **Docs**: https://info.send.it/docs/pool-party/overview
- **Chain**: Canton (already supported via wCC)
- **Category**: Dexes
- **Twitter**: `@send` (confirm if Send Foundation has a different canonical handle)
- **Audits**: none publicly disclosed at submission (set as `audits: "0"`; will update if audit info changes)
- **Logo**: https://info.send.it/img/PoolParty_Icon.png — please mirror to icons repo as `pool-party.jpg`

## Other notes

- Also includes a no-op trailing-newline normalization to `data5.ts` (file previously had no trailing newline). Happy to revert that if undesired.
- File header in `data5.ts` says "use data6.ts for new listings" — followed that.

Author: `@pdoering101`. Will respond promptly to any review feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new protocol entry for Pool Party on the Canton chain (DEX), including metadata and listing timestamp.

* **Style**
  * Fixed file formatting by ensuring proper trailing newline at end of file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->