### PR TITLE
Add token rights flags by token symbol

### DIFF
--- a/defi/src/api2/cache/index.ts
+++ b/defi/src/api2/cache/index.ts
@@ -183,7 +183,7 @@ async function updateMetadata() {
 async function updateRaises() {
   try {
 
-    const { raises } = await readRouteData("/raises").then((res) => res.json())
+    const { raises } = await readRouteData("/raises")
     const raisesObject: any = {}
     raises.forEach((r: any) => {
       const id = r.defillamaId

--- a/defi/src/api2/cron-task/generateToken.test.ts
+++ b/defi/src/api2/cron-task/generateToken.test.ts
@@ -1,0 +1,23 @@
+import { getTokenExtras, getTokenRightsSymbols } from "./generateToken";
+
+describe("generateToken token rights flags", () => {
+  it("marks token-rights rows by token symbol when protocol metadata is missing", () => {
+    const tokenRightsSymbols = getTokenRightsSymbols([{ Token: ["BP", "sBP"] }]);
+
+    expect(getTokenExtras({ symbol: "BP", token_nk: "coingecko:backpack" }, new Map(), tokenRightsSymbols)).toEqual({
+      tokenRights: true,
+    });
+  });
+
+  it("does not mark tokens whose symbol is missing from token-rights rows", () => {
+    const tokenRightsSymbols = getTokenRightsSymbols([{ Token: ["BP"] }]);
+
+    expect(
+      getTokenExtras(
+        { symbol: "BPT", token_nk: "coingecko:balancer-pool-token" },
+        new Map([["balancer-pool-token", { protocolId: "balancer" }]]),
+        tokenRightsSymbols
+      )
+    ).toEqual({ protocolId: "balancer" });
+  });
+});

--- a/defi/src/api2/cron-task/generateToken.test.ts
+++ b/defi/src/api2/cron-task/generateToken.test.ts
@@ -20,4 +20,35 @@ describe("generateToken token rights flags", () => {
       )
     ).toEqual({ protocolId: "balancer" });
   });
+
+  it("returns existing tokenRights extras without overwriting", () => {
+    const tokenRightsSymbols = getTokenRightsSymbols([{ Token: ["BP"] }]);
+    const extras = { tokenRights: true };
+
+    expect(
+      getTokenExtras(
+        { symbol: "BP", token_nk: "coingecko:backpack" },
+        new Map([["backpack", extras]]),
+        tokenRightsSymbols
+      )
+    ).toBe(extras);
+  });
+
+  it("merges tokenRights with existing protocol and chain metadata", () => {
+    const tokenRightsSymbols = getTokenRightsSymbols([{ Token: ["BP"] }]);
+
+    expect(
+      getTokenExtras(
+        { symbol: "BP", token_nk: "coingecko:backpack" },
+        new Map([["backpack", { protocolId: "4266", chainId: "backpack" }]]),
+        tokenRightsSymbols
+      )
+    ).toEqual({ protocolId: "4266", chainId: "backpack", tokenRights: true });
+  });
+
+  it("returns extras when symbol is missing", () => {
+    const tokenRightsSymbols = getTokenRightsSymbols([{ Token: ["BP"] }]);
+
+    expect(getTokenExtras({ token_nk: "coingecko:backpack" }, new Map(), tokenRightsSymbols)).toEqual({});
+  });
 });

--- a/defi/src/api2/cron-task/generateToken.ts
+++ b/defi/src/api2/cron-task/generateToken.ts
@@ -9,6 +9,7 @@ import { runWithRuntimeLogging } from "../utils";
 const SOURCE_URL = "https://ask.llama.fi/coins";
 const PROTOCOLS_URL = "/config/smol/appMetadata-protocols.json";
 const CHAINS_URL = "/config/smol/appMetadata-chains.json";
+const TOKEN_RIGHTS_URL = "/token-rights";
 const OUTPUT_ROUTE = "config/smol/token.json";
 
 const slug = (value = "") =>
@@ -40,7 +41,22 @@ const shouldPreferProtocolId = (currentProtocolId: string | undefined, nextProto
   return false;
 };
 
-const getTokenMetadataExtrasByGeckoId = (protocolsMetadata: Record<string, any>, chainsMetadata: Record<string, any>) => {
+export const getTokenRightsSymbols = (tokenRightsData: any[] | null) => {
+  const symbols = new Set<string>();
+  for (const item of tokenRightsData ?? []) {
+    if (!Array.isArray(item?.Token)) continue;
+    for (const token of item.Token) {
+      if (typeof token !== "string" || !token.trim()) continue;
+      symbols.add(token.trim().toLowerCase());
+    }
+  }
+  return symbols;
+};
+
+const getTokenMetadataExtrasByGeckoId = (
+  protocolsMetadata: Record<string, any>,
+  chainsMetadata: Record<string, any>
+) => {
   const extrasByGeckoId = new Map<string, any>();
 
   for (const [protocolId, item] of Object.entries(protocolsMetadata ?? {})) {
@@ -66,6 +82,12 @@ const getTokenMetadataExtrasByGeckoId = (protocolsMetadata: Record<string, any>,
   }
 
   return extrasByGeckoId;
+};
+
+export const getTokenExtras = (item: any, extrasByGeckoId: Map<string, any>, tokenRightsSymbols: Set<string>) => {
+  const extras = extrasByGeckoId.get(getCoingeckoId(item.token_nk)!) ?? {};
+  if (!tokenRightsSymbols.has(item.symbol.trim().toLowerCase()) || extras.tokenRights) return extras;
+  return { ...extras, tokenRights: true };
 };
 
 const inferRouteSource = (key: string, item: any) => {
@@ -121,10 +143,11 @@ const createTokenRecord = (item: any, routeSource: string, extras: any = {}) => 
 });
 
 async function generateToken() {
-  const [coins, protocolsMetadata, chainsMetadata] = await Promise.all([
+  const [coins, protocolsMetadata, chainsMetadata, tokenRightsData] = await Promise.all([
     fetchJson(SOURCE_URL),
     readRouteData(PROTOCOLS_URL),
     readRouteData(CHAINS_URL),
+    readRouteData(TOKEN_RIGHTS_URL),
   ]);
 
   if (!Array.isArray(coins)) {
@@ -132,6 +155,7 @@ async function generateToken() {
   }
 
   const extrasByGeckoId = getTokenMetadataExtrasByGeckoId(protocolsMetadata, chainsMetadata);
+  const tokenRightsSymbols = getTokenRightsSymbols(tokenRightsData);
   const previousTokens = await loadPreviousTokens();
   const uniqueCoins: any[] = [];
   const seenTokenNks = new Set<string>();
@@ -150,8 +174,8 @@ async function generateToken() {
   const nextTokensByTokenNk = new Map<string, { item: any; extras: any }>();
   let includedWithoutMetadataCount = 0;
   for (const item of uniqueCoins) {
-    const extras = extrasByGeckoId.get(getCoingeckoId(item.token_nk)!) ?? {};
-    if (Object.keys(extras).length === 0) {
+    const extras = getTokenExtras(item, extrasByGeckoId, tokenRightsSymbols);
+    if (!extras.protocolId && !extras.chainId) {
       includedWithoutMetadataCount++;
     }
     nextTokensByTokenNk.set(item.token_nk, { item, extras });
@@ -193,13 +217,12 @@ async function generateToken() {
     seenKeys.add(key);
   }
 
-
   // we find duplicate symbols and remove the one that matches blacklist patterns in the key, this is to skip bridged/old versions of tokens that have same symbol as the original token
   const symbolMap: Record<string, any> = {};
   for (const [key, item] of Object.entries(bySlug)) {
     const symbol = item.symbol.toLowerCase();
     if (!symbolMap[symbol]) {
-      symbolMap[symbol] = key
+      symbolMap[symbol] = key;
     } else {
       if (/old|bridged|wormhole|\(|\[/i.test(key)) {
         // console.log(`Skipping duplicate ${symbol} <- ${key}`);
@@ -210,9 +233,12 @@ async function generateToken() {
 
   await storeRouteData(OUTPUT_ROUTE, bySlug);
 
-  console.log(`Wrote ${Object.keys(bySlug).length} tokens to ${OUTPUT_ROUTE}. Used fallback key selection for ${nameFallbackCount} tokens, Included ${includedWithoutMetadataCount} tokens without protocol/chain metadata, Skipped ${skippedDuplicateTokenNkCount} duplicate token_nk rows, Preserved ${preservedMissingTokenCount} existing tokens missing from the current feed`);
+  console.log(
+    `Wrote ${
+      Object.keys(bySlug).length
+    } tokens to ${OUTPUT_ROUTE}. Used fallback key selection for ${nameFallbackCount} tokens, Included ${includedWithoutMetadataCount} tokens without protocol/chain metadata, Skipped ${skippedDuplicateTokenNkCount} duplicate token_nk rows, Preserved ${preservedMissingTokenCount} existing tokens missing from the current feed`
+  );
 }
-
 
 export async function genTokenConfig() {
   setTimeout(() => {
@@ -226,5 +252,4 @@ export async function genTokenConfig() {
   })
     .catch(console.error)
     .then(() => process.exit(0));
-
 }

--- a/defi/src/api2/cron-task/generateToken.ts
+++ b/defi/src/api2/cron-task/generateToken.ts
@@ -86,7 +86,11 @@ const getTokenMetadataExtrasByGeckoId = (
 
 export const getTokenExtras = (item: any, extrasByGeckoId: Map<string, any>, tokenRightsSymbols: Set<string>) => {
   const extras = extrasByGeckoId.get(getCoingeckoId(item.token_nk)!) ?? {};
-  if (!tokenRightsSymbols.has(item.symbol.trim().toLowerCase()) || extras.tokenRights) return extras;
+  if (!tokenRightsSymbols.size || extras.tokenRights) return extras;
+  const symbol = String(item?.symbol ?? "")
+    .trim()
+    .toLowerCase();
+  if (!tokenRightsSymbols.has(symbol)) return extras;
   return { ...extras, tokenRights: true };
 };
 


### PR DESCRIPTION
## Summary
- read cached /token-rights data while generating config/smol/token.json
- flag token records when their symbol appears in a token-rights Token list, even without protocol metadata
- add focused tests for BP-style standalone token rights and non-matching symbols

## Validation
- npx jest src/api2/cron-task/generateToken.test.ts --runInBand --watchman=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tokens are now enriched with token-rights data, properly identifying tokens with rights status based on available data sources

* **Tests**
  * Added comprehensive test coverage for token-rights flagging and metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->