### PR TITLE
Fix Sablier fees metadata mapping

### DIFF
--- a/defi/src/protocols/data1.ts
+++ b/defi/src/protocols/data1.ts
@@ -2073,9 +2073,6 @@ const data: Protocol[] = [
     twitter: "Sablier",
     audit_links: ["https://certificate.quantstamp.com/full/sablier"],
     parentProtocol: "parent#sablier-finance",
-    dimensions: {
-      fees: "sablier"
-    }
   },
   {
     id: "200",

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -13481,6 +13481,9 @@ const data3_0: Protocol[] = [
     audit_links: ["https://github.com/sablier-labs/audits"],
     parentProtocol: "parent#sablier-finance",
     listedAt: 1690655852,
+    dimensions: {
+      fees: "sablier",
+    },
   },
   {
     id: "3309",


### PR DESCRIPTION
## Summary
- move the `sablier` fees dimension mapping from Sablier Legacy to Sablier Lockup
- keep the Sablier parent fees summary linked to a current, fee-enabled Sablier product instead of the legacy protocol

## Why
Sablier Legacy does not collect fees or revenue, but the metadata currently links it to the shared `sablier` fees adapter. The adapter methodology and implementation track fee-enabled Sablier Lockup/Flow/Airdrop contracts and explicitly exclude legacy contracts, so attributing those fees to the Legacy child is misleading. This addresses DefiLlama/DefiLlama-Adapters#13716.

## Validation
- `pnpm run prebuild`
- `pnpm exec jest --testPathPattern='protocols/data.test' --runInBand --no-coverage --forceExit`

Notes: `npm ci` could not run locally because `defi/package-lock.json` is out of sync with `package.json`, and plain `npm ci` also hits the repo's existing redis/typeorm peer conflict. `pnpm install --frozen-lockfile` succeeded against the checked-in `pnpm-lock.yaml`. The metadata test still logs the existing non-fatal `hermetica/index.js` missing-adapter warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized protocol metadata structure for improved organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->