### PR TITLE
Update Orbit Finance metadata

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -14315,9 +14315,9 @@ const data5: Protocol[] = [
     name: "Orbit Finance",
     address: null,
     symbol: "-",
-    url: "https://orbitdex.io/en",
+    url: "https://markets.cipherlabsx.com",
     description:
-      "Perpetual futures with up to 300x leverage. Non-custodial, fully on-chain.",
+      "Orbit Finance is a DLMM (Dynamic Liquidity Market Maker) on Solana. Concentrated liquidity pools with configurable fee tiers, built on the CipherDLMM program.",
     chain: "Solana",
     logo: `${baseIconsUrl}/orbit-finance.jpg`,
     audits: "0",


### PR DESCRIPTION
## Summary
- update Orbit Finance's website URL to the current CipherLabs markets URL
- replace the stale perpetuals description with the protocol-provided DLMM description

## Why
The existing Orbit Finance listing describes a perpetuals DEX at `orbitdex.io`, but the linked issue reports that the listed protocol is a Solana DLMM built on the CipherDLMM program. This updates the metadata fields that are stored in `defillama-server` and keeps the existing icon slug untouched.

Refs DefiLlama/defillama-server#11562.

## Validation
- `pnpm run prebuild`
- `pnpm exec jest --testPathPattern='protocols/data.test' --runInBand --no-coverage --forceExit`

Notes: the focused metadata test passes. It still logs the existing non-fatal `hermetica/index.js` missing-adapter warning. The issue also requests a logo replacement; I did not change the icon binary here because the current `DefiLlama/icons` v2 repo does not store protocol image assets directly.