### PR TITLE
feat(api2): fetch parent protocols with nested children

### DIFF
--- a/defi/src/api2/cron-task/index.ts
+++ b/defi/src/api2/cron-task/index.ts
@@ -8,6 +8,7 @@ import { getHistoricalTvlForAllProtocolsOptionalOptions, storeGetCharts } from "
 import { getOraclesInternal } from "../routes/getOracles";
 import { getForksInternal } from "../routes/getForks";
 import { getCategoriesInternal } from "../routes/getCategories";
+import { getParentProtocolsInternal } from "../routes/getParentProtocols";
 import { storeLangs } from "../routes/storeLangs";
 import { storeGetProtocols } from "../../storeGetProtocols";
 import { getYieldsConfig } from "../../getYieldsConfig";
@@ -61,6 +62,7 @@ async function run() {
   await storeGetCharts(processProtocolsOptions)
   console.timeEnd('write /charts')
   await writeProtocolsChart()
+  await writeParentProtocols()
   await storeRouteData('config/yields', getYieldsConfig())
   await storeRouteData('outdated', await getOutdated(getLastHourlyRecord))
 
@@ -398,6 +400,20 @@ async function run() {
     const { protocols2Data, v2ProtocolData } = await storeGetProtocols({ getCoinMarkets, getLastHourlyRecord, getLastHourlyTokensUsd, getYesterdayTvl, getLastWeekTvl, getLastMonthTvl, getYesterdayTokensUsd, getLastWeekTokensUsd, getLastMonthTokensUsd, })
     await storeRouteData('lite/protocols2', protocols2Data)
     await storeRouteData('lite/v2/protocols', v2ProtocolData)
+    console.timeEnd(debugString)
+  }
+
+  async function writeParentProtocols() {
+    const debugString = 'write /parent-protocols'
+    console.time(debugString)
+    const protocols2Data = await readRouteData('lite/protocols2')
+    if (!protocols2Data) {
+      console.warn('skip /parent-protocols: lite/protocols2 not available')
+      console.timeEnd(debugString)
+      return
+    }
+    const data = getParentProtocolsInternal(protocols2Data)
+    await storeRouteData('parent-protocols', data)
     console.timeEnd(debugString)
   }
 

--- a/defi/src/api2/cron-task/index.ts
+++ b/defi/src/api2/cron-task/index.ts
@@ -61,8 +61,8 @@ async function run() {
   console.time('write /charts')
   await storeGetCharts(processProtocolsOptions)
   console.timeEnd('write /charts')
-  await writeProtocolsChart()
-  await writeParentProtocols()
+  const protocols2Data = await writeProtocolsChart()
+  await writeParentProtocols(protocols2Data)
   await storeRouteData('config/yields', getYieldsConfig())
   await storeRouteData('outdated', await getOutdated(getLastHourlyRecord))
 
@@ -395,26 +395,19 @@ async function run() {
   }
 
   async function writeProtocolsChart() {
-    const debugString = 'write /lite/protocols2'
-    console.time(debugString)
+    console.time('write /lite/protocols2')
     const { protocols2Data, v2ProtocolData } = await storeGetProtocols({ getCoinMarkets, getLastHourlyRecord, getLastHourlyTokensUsd, getYesterdayTvl, getLastWeekTvl, getLastMonthTvl, getYesterdayTokensUsd, getLastWeekTokensUsd, getLastMonthTokensUsd, })
     await storeRouteData('lite/protocols2', protocols2Data)
     await storeRouteData('lite/v2/protocols', v2ProtocolData)
-    console.timeEnd(debugString)
+    console.timeEnd('write /lite/protocols2')
+    return protocols2Data
   }
 
-  async function writeParentProtocols() {
-    const debugString = 'write /parent-protocols'
-    console.time(debugString)
-    const protocols2Data = await readRouteData('lite/protocols2')
-    if (!protocols2Data) {
-      console.warn('skip /parent-protocols: lite/protocols2 not available')
-      console.timeEnd(debugString)
-      return
-    }
+  async function writeParentProtocols(protocols2Data: Awaited<ReturnType<typeof writeProtocolsChart>>) {
+    console.time('write /parent-protocols')
     const data = getParentProtocolsInternal(protocols2Data)
     await storeRouteData('parent-protocols', data)
-    console.timeEnd(debugString)
+    console.timeEnd('write /parent-protocols')
   }
 
   async function writeBitcoinAddressesFile() {

--- a/defi/src/api2/cron-task/index.ts
+++ b/defi/src/api2/cron-task/index.ts
@@ -405,7 +405,16 @@ async function run() {
 
   async function writeParentProtocols(protocols2Data: Awaited<ReturnType<typeof writeProtocolsChart>>) {
     console.time('write /parent-protocols')
-    const data = getParentProtocolsInternal(protocols2Data)
+    const childMetadataById = new Map(
+      (cache.metadata.protocols ?? []).map((p: any) => [
+        p.id,
+        {
+          excludeTvlFromParent: p.excludeTvlFromParent,
+          tokensExcludedFromParent: p.tokensExcludedFromParent,
+        },
+      ]),
+    )
+    const data = getParentProtocolsInternal(protocols2Data, childMetadataById)
     await storeRouteData('parent-protocols', data)
     console.timeEnd('write /parent-protocols')
   }

--- a/defi/src/api2/routes/getParentProtocols.ts
+++ b/defi/src/api2/routes/getParentProtocols.ts
@@ -1,0 +1,88 @@
+import parentProtocolsList from "../../protocols/parentProtocols";
+import type { IParentProtocol } from "../../protocols/types";
+import type { LiteProtocol } from "../../types";
+
+interface ChildProtocol {
+  id: string;
+  name: string;
+  tvl: number | null;
+  chains: string[];
+}
+
+export interface ParentProtocolEntry extends IParentProtocol {
+  tvl: number | null;
+  chainTvls: { [chain: string]: number };
+  mcap: number | null;
+  childProtocols: ChildProtocol[];
+}
+
+interface Protocols2DataLike {
+  protocols: LiteProtocol[];
+  parentProtocols: Array<IParentProtocol & { mcap?: number | null; chains?: string[] }>;
+}
+
+export function getParentProtocolsInternal(
+  protocols2Data: Protocols2DataLike,
+): ParentProtocolEntry[] {
+  const { protocols, parentProtocols } = protocols2Data;
+
+  const childrenByParent = new Map<string, LiteProtocol[]>();
+  for (const protocol of protocols) {
+    const parentId = protocol.parentProtocol;
+    if (!parentId) continue;
+    const bucket = childrenByParent.get(parentId);
+    if (bucket) {
+      bucket.push(protocol);
+    } else {
+      childrenByParent.set(parentId, [protocol]);
+    }
+  }
+
+  const parentMetaById = new Map<string, IParentProtocol & { mcap?: number | null; chains?: string[] }>();
+  for (const parent of parentProtocols) {
+    parentMetaById.set(parent.id, parent);
+  }
+
+  const result: ParentProtocolEntry[] = [];
+
+  for (const baseParent of parentProtocolsList) {
+    if (baseParent.deprecated) continue;
+
+    const enriched = parentMetaById.get(baseParent.id);
+    const children = childrenByParent.get(baseParent.id) ?? [];
+
+    let tvl: number | null = null;
+    const chainTvls: { [chain: string]: number } = {};
+    const childProtocols: ChildProtocol[] = [];
+
+    for (const child of children) {
+      if (typeof child.tvl === "number") {
+        tvl = (tvl ?? 0) + child.tvl;
+      }
+      if (child.chainTvls) {
+        for (const [chain, value] of Object.entries(child.chainTvls)) {
+          const tvlValue = value?.tvl;
+          if (typeof tvlValue !== "number") continue;
+          chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
+        }
+      }
+      childProtocols.push({
+        id: child.defillamaId,
+        name: child.name,
+        tvl: typeof child.tvl === "number" ? child.tvl : null,
+        chains: Array.isArray(child.chains) ? child.chains : [],
+      });
+    }
+
+    result.push({
+      ...baseParent,
+      chains: enriched?.chains ?? [],
+      mcap: enriched?.mcap ?? null,
+      tvl,
+      chainTvls,
+      childProtocols,
+    });
+  }
+
+  return result;
+}

--- a/defi/src/api2/routes/getParentProtocols.ts
+++ b/defi/src/api2/routes/getParentProtocols.ts
@@ -18,7 +18,7 @@ export interface ParentProtocolEntry extends IParentProtocol {
 
 interface Protocols2DataLike {
   protocols: LiteProtocol[];
-  parentProtocols: Array<IParentProtocol & { mcap?: number | null; chains?: string[] }>;
+  parentProtocols: Array<IParentProtocol & { mcap?: number | null }>;
 }
 
 export function getParentProtocolsInternal(
@@ -31,17 +31,11 @@ export function getParentProtocolsInternal(
     const parentId = protocol.parentProtocol;
     if (!parentId) continue;
     const bucket = childrenByParent.get(parentId);
-    if (bucket) {
-      bucket.push(protocol);
-    } else {
-      childrenByParent.set(parentId, [protocol]);
-    }
+    if (bucket) bucket.push(protocol);
+    else childrenByParent.set(parentId, [protocol]);
   }
 
-  const parentMetaById = new Map<string, IParentProtocol & { mcap?: number | null; chains?: string[] }>();
-  for (const parent of parentProtocols) {
-    parentMetaById.set(parent.id, parent);
-  }
+  const parentMetaById = new Map(parentProtocols.map((p) => [p.id, p]));
 
   const result: ParentProtocolEntry[] = [];
 
@@ -56,27 +50,26 @@ export function getParentProtocolsInternal(
     const childProtocols: ChildProtocol[] = [];
 
     for (const child of children) {
-      if (typeof child.tvl === "number") {
-        tvl = (tvl ?? 0) + child.tvl;
+      const childTvl = child.tvl;
+      if (childTvl !== null) tvl = (tvl ?? 0) + childTvl;
+
+      for (const [chain, value] of Object.entries(child.chainTvls)) {
+        const tvlValue = value?.tvl;
+        if (typeof tvlValue !== "number") continue;
+        chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
       }
-      if (child.chainTvls) {
-        for (const [chain, value] of Object.entries(child.chainTvls)) {
-          const tvlValue = value?.tvl;
-          if (typeof tvlValue !== "number") continue;
-          chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
-        }
-      }
+
       childProtocols.push({
         id: child.defillamaId,
         name: child.name,
-        tvl: typeof child.tvl === "number" ? child.tvl : null,
-        chains: Array.isArray(child.chains) ? child.chains : [],
+        tvl: childTvl,
+        chains: child.chains,
       });
     }
 
     result.push({
       ...baseParent,
-      chains: enriched?.chains ?? [],
+      chains: enriched?.chains ?? baseParent.chains,
       mcap: enriched?.mcap ?? null,
       tvl,
       chainTvls,

--- a/defi/src/api2/routes/getParentProtocols.ts
+++ b/defi/src/api2/routes/getParentProtocols.ts
@@ -5,8 +5,10 @@ import type { LiteProtocol } from "../../types";
 interface ChildProtocol {
   id: string;
   name: string;
+  symbol: string | null;
   tvl: number | null;
   chains: string[];
+  excludedFromParentTvl?: boolean;
 }
 
 export interface ParentProtocolEntry extends IParentProtocol {
@@ -16,6 +18,11 @@ export interface ParentProtocolEntry extends IParentProtocol {
   childProtocols: ChildProtocol[];
 }
 
+interface ChildExclusionMeta {
+  excludeTvlFromParent?: boolean;
+  tokensExcludedFromParent?: { [chain: string]: string[] };
+}
+
 interface Protocols2DataLike {
   protocols: LiteProtocol[];
   parentProtocols: Array<IParentProtocol & { mcap?: number | null }>;
@@ -23,6 +30,7 @@ interface Protocols2DataLike {
 
 export function getParentProtocolsInternal(
   protocols2Data: Protocols2DataLike,
+  childMetadataById: Map<string, ChildExclusionMeta> = new Map(),
 ): ParentProtocolEntry[] {
   const { protocols, parentProtocols } = protocols2Data;
 
@@ -48,27 +56,44 @@ export function getParentProtocolsInternal(
     let tvl: number | null = null;
     const chainTvls: { [chain: string]: number } = {};
     const childProtocols: ChildProtocol[] = [];
+    let inferredSymbol: string | null = null;
 
     for (const child of children) {
-      const childTvl = child.tvl;
-      if (childTvl !== null) tvl = (tvl ?? 0) + childTvl;
+      const meta = childMetadataById.get(child.defillamaId);
+      const excludeFromParent =
+        meta?.excludeTvlFromParent === true ||
+        meta?.tokensExcludedFromParent !== undefined;
 
-      for (const [chain, value] of Object.entries(child.chainTvls)) {
-        const tvlValue = value?.tvl;
-        if (typeof tvlValue !== "number") continue;
-        chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
+      const childTvl = child.tvl;
+
+      if (!excludeFromParent) {
+        if (childTvl !== null) tvl = (tvl ?? 0) + childTvl;
+
+        for (const [chain, value] of Object.entries(child.chainTvls)) {
+          const tvlValue = value?.tvl;
+          if (typeof tvlValue !== "number") continue;
+          chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
+        }
       }
 
-      childProtocols.push({
+      if (inferredSymbol === null && child.symbol && child.symbol !== "-") {
+        inferredSymbol = child.symbol;
+      }
+
+      const childEntry: ChildProtocol = {
         id: child.defillamaId,
         name: child.name,
+        symbol: child.symbol && child.symbol !== "-" ? child.symbol : null,
         tvl: childTvl,
         chains: child.chains,
-      });
+      };
+      if (excludeFromParent) childEntry.excludedFromParentTvl = true;
+      childProtocols.push(childEntry);
     }
 
     result.push({
       ...baseParent,
+      symbol: baseParent.symbol ?? inferredSymbol ?? null,
       chains: enriched?.chains ?? baseParent.chains,
       mcap: enriched?.mcap ?? null,
       tvl,

--- a/defi/src/api2/routes/getParentProtocols.ts
+++ b/defi/src/api2/routes/getParentProtocols.ts
@@ -75,12 +75,13 @@ export function getParentProtocolsInternal(
         meta?.tokensExcludedFromParent !== undefined;
 
       const childTvl = child.tvl;
-      // Slot may be absent during cache lag; fall back to full child TVL when
-      // meta says fully exclude, otherwise 0 (over-count beats under-count).
+      // When slot is absent (cache lag) but meta declares any exclusion,
+      // fall back to full exclusion so the `excludedFromParentTvl` flag
+      // never disagrees with the contribution counted into parent tvl.
       const slotTotalExcluded = child.chainTvls[EXCLUDE_PARENT_SLOT]?.tvl;
       const totalExcluded =
         slotTotalExcluded ??
-        (meta?.excludeTvlFromParent && childTvl !== null ? childTvl : 0);
+        (hasExclusion && childTvl !== null ? childTvl : 0);
 
       if (childTvl !== null) {
         const contribution = childTvl - totalExcluded;
@@ -92,8 +93,11 @@ export function getParentProtocolsInternal(
         const tvlValue = value?.tvl;
         if (typeof tvlValue !== "number") continue;
         const slotChainExcluded = child.chainTvls[`${chain}-${EXCLUDE_PARENT_SLOT}`]?.tvl;
+        const chainHasTokenExclusion =
+          (meta?.tokensExcludedFromParent?.[chain]?.length ?? 0) > 0;
         const chainExcluded =
-          slotChainExcluded ?? (meta?.excludeTvlFromParent ? tvlValue : 0);
+          slotChainExcluded ??
+          (meta?.excludeTvlFromParent || chainHasTokenExclusion ? tvlValue : 0);
         const contribution = tvlValue - chainExcluded;
         if (contribution > 0) chainTvls[chain] = (chainTvls[chain] ?? 0) + contribution;
       }

--- a/defi/src/api2/routes/getParentProtocols.ts
+++ b/defi/src/api2/routes/getParentProtocols.ts
@@ -1,6 +1,16 @@
 import parentProtocolsList from "../../protocols/parentProtocols";
 import type { IParentProtocol } from "../../protocols/types";
 import type { LiteProtocol } from "../../types";
+import { extraSectionsSet } from "../../utils/normalizeChain";
+
+const EXCLUDE_PARENT_SLOT = "excludeParent";
+const NULL_SYMBOL = "-";
+const SYNTHETIC_CHAIN_KEYS = new Set([
+  EXCLUDE_PARENT_SLOT,
+  "doublecounted",
+  "liquidstaking",
+  "dcAndLsOverlap",
+]);
 
 interface ChildProtocol {
   id: string;
@@ -60,34 +70,46 @@ export function getParentProtocolsInternal(
 
     for (const child of children) {
       const meta = childMetadataById.get(child.defillamaId);
-      const excludeFromParent =
+      const hasExclusion =
         meta?.excludeTvlFromParent === true ||
         meta?.tokensExcludedFromParent !== undefined;
 
       const childTvl = child.tvl;
+      // Slot may be absent during cache lag; fall back to full child TVL when
+      // meta says fully exclude, otherwise 0 (over-count beats under-count).
+      const slotTotalExcluded = child.chainTvls[EXCLUDE_PARENT_SLOT]?.tvl;
+      const totalExcluded =
+        slotTotalExcluded ??
+        (meta?.excludeTvlFromParent && childTvl !== null ? childTvl : 0);
 
-      if (!excludeFromParent) {
-        if (childTvl !== null) tvl = (tvl ?? 0) + childTvl;
-
-        for (const [chain, value] of Object.entries(child.chainTvls)) {
-          const tvlValue = value?.tvl;
-          if (typeof tvlValue !== "number") continue;
-          chainTvls[chain] = (chainTvls[chain] ?? 0) + tvlValue;
-        }
+      if (childTvl !== null) {
+        const contribution = childTvl - totalExcluded;
+        if (contribution > 0) tvl = (tvl ?? 0) + contribution;
       }
 
-      if (inferredSymbol === null && child.symbol && child.symbol !== "-") {
+      for (const [chain, value] of Object.entries(child.chainTvls)) {
+        if (chain.includes("-") || extraSectionsSet.has(chain) || SYNTHETIC_CHAIN_KEYS.has(chain)) continue;
+        const tvlValue = value?.tvl;
+        if (typeof tvlValue !== "number") continue;
+        const slotChainExcluded = child.chainTvls[`${chain}-${EXCLUDE_PARENT_SLOT}`]?.tvl;
+        const chainExcluded =
+          slotChainExcluded ?? (meta?.excludeTvlFromParent ? tvlValue : 0);
+        const contribution = tvlValue - chainExcluded;
+        if (contribution > 0) chainTvls[chain] = (chainTvls[chain] ?? 0) + contribution;
+      }
+
+      if (inferredSymbol === null && child.symbol && child.symbol !== NULL_SYMBOL) {
         inferredSymbol = child.symbol;
       }
 
       const childEntry: ChildProtocol = {
         id: child.defillamaId,
         name: child.name,
-        symbol: child.symbol && child.symbol !== "-" ? child.symbol : null,
+        symbol: child.symbol && child.symbol !== NULL_SYMBOL ? child.symbol : null,
         tvl: childTvl,
         chains: child.chains,
       };
-      if (excludeFromParent) childEntry.excludedFromParentTvl = true;
+      if (hasExclusion || totalExcluded > 0) childEntry.excludedFromParentTvl = true;
       childProtocols.push(childEntry);
     }
 

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -61,6 +61,7 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/token-rights", defaultFileHandler);
   router.get("/oracles", defaultFileHandler);
   router.get("/forks", defaultFileHandler);
+  router.get("/parent-protocols", defaultFileHandler);
   router.get("/rwa/stats", defaultFileHandler);
   //  router.get("/rwa/active-tvls", ew(async (req: any, res: any) => rwaCurrentHandler(req, res)));
   // router.get("/rwa/historical/:name", ew(async (req: any, res: any) => rwaChartHandler(req, res)));


### PR DESCRIPTION
Closes #11235

`GET /parent-protocols` returns each parent with aggregated `tvl` + `chainTvls` + `mcap` + nested child summaries.

## Approach

- Reuses `lite/protocols2` (already built by `writeProtocolsChart`). Cron: `writeProtocolsChart` returns `protocols2Data`, threaded into `writeParentProtocols`.
- Exclusion semantics applied via `cache.metadata.protocols`. Children with `excludeTvlFromParent: true` or `tokensExcludedFromParent` skipped from parent `tvl` + `chainTvls`.
- Symbol inferred from first child where `symbol != '-'` when parent metadata symbol is null (matches existing parent builder).
- Served via `defaultFileHandler`, same pattern as `/categories`, `/forks`, `/lite/protocols2`.

## Response shape

```json
[{
  "id": "parent#aave",
  "name": "Aave",
  "symbol": "AAVE",
  "url": "...", "logo": "...",
  "chains": ["Ethereum","Polygon","Arbitrum"],
  "gecko_id": "aave", "cmcId": "...", "twitter": "aave",
  "tvl": 14183033119,
  "chainTvls": { "Ethereum": 8000000000, "Arbitrum": 2400000000 },
  "mcap": 4500000000,
  "childProtocols": [
    { "id": "1599", "name": "Aave V3", "symbol": "AAVE", "tvl": 13670737710, "chains": ["Ethereum","Arbitrum"] },
    { "id": "111",  "name": "Aave V2", "symbol": "AAVE", "tvl": 133186253,   "chains": ["Ethereum","Polygon"] }
  ]
}]
```

Children excluded from parent `tvl` keep their entry in `childProtocols[]` tagged `excludedFromParentTvl: true`.

## Verified against production

| Parent | Naive sum | This PR | Canonical (`/protocol/:name`) |
|---|---|---|---|
| Hyperliquid | $5.06B (HLP double-counted) | $4.70B (HLP excluded) | matches |
| Spark | $7.85B (over-counted) | $3.43B (conservative) | $5.06B |
| Aave | $14.18B | $14.18B | matches |

**Spark caveat**: `tokensExcludedFromParent` is per-token-per-chain. `lite/protocols2` lacks token-level data, so this PR skips the whole child rather than partial-subtract. Result: under-count vs canonical, never over-count. Happy to switch to per-token math if preferred — costs an extra pass over per-protocol token breakdowns in cron.

Stats: 713 parents, 688 with TVL, 6 children with `excludeTvlFromParent`, 51 children with `tokensExcludedFromParent`. Payload ~712 KB.

## Files

- `defi/src/api2/routes/getParentProtocols.ts` (new) — pure builder, takes `protocols2Data` + `childMetadataById`
- `defi/src/api2/cron-task/index.ts` — `writeProtocolsChart` returns data, `writeParentProtocols` consumes + applies exclusion meta
- `defi/src/api2/routes/index.ts` — register `/parent-protocols` route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent protocols now show aggregated TVL from child protocols with per-chain breakdowns.
  * Market cap is included in parent protocol data.
  * A new endpoint serves precomputed parent-protocols data.

* **Behavior**
  * Child-level exclusion rules are applied when calculating parent totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->