### PR TITLE
feat(data-quality): external metric comparison CLI (#11830)

### DIFF
--- a/defi/package.json
+++ b/defi/package.json
@@ -61,6 +61,7 @@
     "fillOld-dimensions-all": "refill_all_missing_protocols=true NODE_OPTIONS=\"--max-old-space-size=16144\"  npx ts-node --logError --transpile-only src/adaptors/handlers/storeAdaptorData/refillScript.ts",
     "notify-outdated": "npx ts-node --logError --transpile-only src/server-scripts/notifyOutdated.ts",
     "notify-stablecoin-spike": "npx ts-node --logError --transpile-only src/server-scripts/notifyStablecoinSpikes.ts",
+    "compare-external-metrics": "npx ts-node --logError --transpile-only src/cli/compareExternalMetrics.ts",
     "store-block-explorers": "npx ts-node --logError --transpile-only src/server-scripts/storeBlockExplorers.ts",
     "dead-protocols-check": "npx ts-node --logError --transpile-only src/api2/scripts/checkForDeadProtocols.ts",
     "local-test-por": "npx ts-node --logError --transpile-only proof-of-reserves/cli/test.ts",

--- a/defi/src/cli/compareExternalMetrics.ts
+++ b/defi/src/cli/compareExternalMetrics.ts
@@ -1,0 +1,110 @@
+/**
+ * Compare numeric metrics from DefiLlama JSON endpoints against external providers (same metric path shape).
+ *
+ * Config JSON shape:
+ * { "comparisons": [{ entity, metric, llamaUrl, llamaPath, externalProvider, externalUrl, externalPath,
+ *    warningThreshold?, criticalThreshold?, minAbsDiff?, maxTimestampDriftSeconds? }] }
+ *
+ * Env:
+ * - EXTERNAL_METRIC_COMPARISON_CONFIG — path to JSON when no CLI arg is passed
+ * - EXTERNAL_METRIC_COMPARISON_WEBHOOK — Discord webhook (omit or use --dry-run to skip posting)
+ *
+ * Related: DefiLlama/defillama-server#11830 (deterministic comparison layer before AI triage).
+ */
+import fs from "fs"
+import fetch from "node-fetch"
+import { sendMessage } from "../utils/discord"
+import {
+  compareMetricSample,
+  formatMetricComparisonReport,
+  MetricComparisonOptions,
+  numberAtPath,
+} from "../dataQuality/externalMetricComparison"
+
+type MetricComparisonConfig = MetricComparisonOptions & {
+  entity: string
+  metric: string
+  llamaUrl: string
+  llamaPath: string
+  externalProvider: string
+  externalUrl: string
+  externalPath: string
+}
+
+type ConfigFile = {
+  comparisons: MetricComparisonConfig[]
+}
+
+function parseArgs(argv: string[]) {
+  let dryRun = false
+  const rest: string[] = []
+  for (const a of argv) {
+    if (a === "--dry-run") dryRun = true
+    else rest.push(a)
+  }
+  return { dryRun, positional: rest }
+}
+
+async function main() {
+  const { dryRun, positional } = parseArgs(process.argv.slice(2))
+  const configPath = positional[0] ?? process.env.EXTERNAL_METRIC_COMPARISON_CONFIG
+  if (!configPath) {
+    throw new Error(
+      "Usage: npx ts-node src/cli/compareExternalMetrics.ts [--dry-run] <config.json>\n" +
+        "Or set EXTERNAL_METRIC_COMPARISON_CONFIG to the JSON path.",
+    )
+  }
+
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as ConfigFile
+  const results = []
+
+  for (const comparison of config.comparisons) {
+    const [llamaPayload, externalPayload] = await Promise.all([
+      fetchJson(comparison.llamaUrl),
+      fetchJson(comparison.externalUrl),
+    ])
+
+    results.push(
+      compareMetricSample(
+        {
+          provider: "llama",
+          entity: comparison.entity,
+          metric: comparison.metric,
+          value: numberAtPath(llamaPayload, comparison.llamaPath),
+          url: comparison.llamaUrl,
+        },
+        {
+          provider: comparison.externalProvider,
+          entity: comparison.entity,
+          metric: comparison.metric,
+          value: numberAtPath(externalPayload, comparison.externalPath),
+          url: comparison.externalUrl,
+        },
+        comparison,
+      ),
+    )
+  }
+
+  const report = formatMetricComparisonReport(results)
+  console.log(report)
+
+  const webhook = process.env.EXTERNAL_METRIC_COMPARISON_WEBHOOK
+  if (webhook && !dryRun) {
+    await sendMessage(report, webhook, true)
+  } else if (dryRun && webhook) {
+    console.log("(dry-run: skipped Discord webhook)")
+  }
+
+  if (results.some((item) => item.status === "critical")) process.exitCode = 1
+}
+
+async function fetchJson(url: string) {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  return response.json()
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/defi/src/dataQuality/externalMetricComparison.test.ts
+++ b/defi/src/dataQuality/externalMetricComparison.test.ts
@@ -1,0 +1,60 @@
+import {
+  compareMetricSample,
+  formatMetricComparisonReport,
+  numberAtPath,
+} from "./externalMetricComparison"
+
+describe("external metric comparison", () => {
+  test("extracts nested numeric values", () => {
+    expect(numberAtPath({ data: [{ metrics: { fees: "123.45" } }] }, "data.0.metrics.fees")).toBe(123.45)
+    expect(numberAtPath({ data: { fees: "" } }, "data.fees")).toBeNull()
+    expect(numberAtPath({ data: { fees: "bad" } }, "data.fees")).toBeNull()
+  })
+
+  test("marks small deviations as ok", () => {
+    const result = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 94 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+
+    expect(result.status).toBe("ok")
+    expect(result.relativeDiff).toBeCloseTo(0.06)
+  })
+
+  test("marks larger deviations by threshold", () => {
+    const warning = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 80 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+    const critical = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 60 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+
+    expect(warning.status).toBe("warning")
+    expect(critical.status).toBe("critical")
+  })
+
+  test("uses absolute threshold to suppress dust", () => {
+    const result = compareMetricSample(
+      { provider: "llama", entity: "small-protocol", metric: "fees_24h", value: 2 },
+      { provider: "external", entity: "small-protocol", metric: "fees_24h", value: 1 },
+      { minAbsDiff: 10 },
+    )
+
+    expect(result.status).toBe("ok")
+  })
+
+  test("formats a compact report", () => {
+    const result = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 50 },
+      { criticalThreshold: 0.25 },
+    )
+
+    expect(formatMetricComparisonReport([result])).toContain("CRITICAL | aave | fees_24h")
+  })
+})

--- a/defi/src/dataQuality/externalMetricComparison.ts
+++ b/defi/src/dataQuality/externalMetricComparison.ts
@@ -1,0 +1,161 @@
+export type MetricComparisonStatus = "ok" | "warning" | "critical" | "missing"
+
+export interface MetricSample {
+  provider: string
+  entity: string
+  metric: string
+  value: number | null | undefined
+  timestamp?: number
+  url?: string
+}
+
+export interface MetricComparisonOptions {
+  warningThreshold?: number
+  criticalThreshold?: number
+  minAbsDiff?: number
+  maxTimestampDriftSeconds?: number
+}
+
+export interface MetricComparisonResult {
+  entity: string
+  metric: string
+  status: MetricComparisonStatus
+  llamaProvider: string
+  externalProvider: string
+  llamaValue: number | null
+  externalValue: number | null
+  absoluteDiff: number | null
+  relativeDiff: number | null
+  timestampDriftSeconds: number | null
+  message: string
+  llamaUrl?: string
+  externalUrl?: string
+}
+
+export function valueAtPath(input: any, path: string): any {
+  if (!path) return input
+
+  return path.split(".").reduce((current, segment) => {
+    if (current === null || current === undefined) return undefined
+    if (Array.isArray(current) && /^\d+$/.test(segment)) return current[Number(segment)]
+    return current[segment]
+  }, input)
+}
+
+export function numberAtPath(input: any, path: string): number | null {
+  const value = valueAtPath(input, path)
+  if (value === null || value === undefined || value === "") return null
+
+  const parsed = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function compareMetricSample(
+  llama: MetricSample,
+  external: MetricSample,
+  options: MetricComparisonOptions = {},
+): MetricComparisonResult {
+  const warningThreshold = options.warningThreshold ?? 0.1
+  const criticalThreshold = options.criticalThreshold ?? 0.25
+  const minAbsDiff = options.minAbsDiff ?? 0
+
+  const timestampDriftSeconds = getTimestampDrift(llama, external)
+  if (
+    timestampDriftSeconds !== null &&
+    options.maxTimestampDriftSeconds !== undefined &&
+    timestampDriftSeconds > options.maxTimestampDriftSeconds
+  ) {
+    return result(llama, external, "warning", null, null, timestampDriftSeconds, "timestamps are outside allowed drift")
+  }
+
+  if (!isUsableNumber(llama.value) || !isUsableNumber(external.value)) {
+    return result(llama, external, "missing", null, null, timestampDriftSeconds, "missing metric value")
+  }
+
+  const llamaValue = Number(llama.value)
+  const externalValue = Number(external.value)
+  const absoluteDiff = Math.abs(llamaValue - externalValue)
+  const denominator = Math.max(Math.abs(llamaValue), Math.abs(externalValue), 1)
+  const relativeDiff = absoluteDiff / denominator
+
+  if (absoluteDiff < minAbsDiff) {
+    return result(llama, external, "ok", absoluteDiff, relativeDiff, timestampDriftSeconds, "within absolute threshold")
+  }
+
+  if (relativeDiff >= criticalThreshold) {
+    return result(llama, external, "critical", absoluteDiff, relativeDiff, timestampDriftSeconds, "outside critical threshold")
+  }
+
+  if (relativeDiff >= warningThreshold) {
+    return result(llama, external, "warning", absoluteDiff, relativeDiff, timestampDriftSeconds, "outside warning threshold")
+  }
+
+  return result(llama, external, "ok", absoluteDiff, relativeDiff, timestampDriftSeconds, "within threshold")
+}
+
+export function formatMetricComparisonReport(results: MetricComparisonResult[]): string {
+  if (!results.length) return "No metric comparisons were run."
+
+  const flagged = results.filter((item) => item.status !== "ok")
+  const header = `External metric comparison: ${flagged.length}/${results.length} flagged`
+  const rows = flagged.length ? flagged : results
+
+  return [
+    header,
+    ...rows.map((item) => {
+      const diff = item.relativeDiff === null ? "n/a" : `${(item.relativeDiff * 100).toFixed(2)}%`
+      return [
+        item.status.toUpperCase(),
+        item.entity,
+        item.metric,
+        `${item.llamaProvider}=${formatValue(item.llamaValue)}`,
+        `${item.externalProvider}=${formatValue(item.externalValue)}`,
+        `diff=${diff}`,
+        item.message,
+      ].join(" | ")
+    }),
+  ].join("\n")
+}
+
+function result(
+  llama: MetricSample,
+  external: MetricSample,
+  status: MetricComparisonStatus,
+  absoluteDiff: number | null,
+  relativeDiff: number | null,
+  timestampDriftSeconds: number | null,
+  message: string,
+): MetricComparisonResult {
+  return {
+    entity: llama.entity,
+    metric: llama.metric,
+    status,
+    llamaProvider: llama.provider,
+    externalProvider: external.provider,
+    llamaValue: isUsableNumber(llama.value) ? Number(llama.value) : null,
+    externalValue: isUsableNumber(external.value) ? Number(external.value) : null,
+    absoluteDiff,
+    relativeDiff,
+    timestampDriftSeconds,
+    message,
+    llamaUrl: llama.url,
+    externalUrl: external.url,
+  }
+}
+
+function getTimestampDrift(llama: MetricSample, external: MetricSample): number | null {
+  if (llama.timestamp === undefined || external.timestamp === undefined) return null
+  return Math.abs(llama.timestamp - external.timestamp)
+}
+
+function isUsableNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function formatValue(value: number | null): string {
+  if (value === null) return "n/a"
+  if (Math.abs(value) >= 1e9) return `${(value / 1e9).toFixed(2)}b`
+  if (Math.abs(value) >= 1e6) return `${(value / 1e6).toFixed(2)}m`
+  if (Math.abs(value) >= 1e3) return `${(value / 1e3).toFixed(2)}k`
+  return `${Math.round(value * 100) / 100}`
+}


### PR DESCRIPTION
## Summary

Adds a deterministic comparison layer for DefiLlama JSON metrics vs external providers: path-based numeric extraction, relative/absolute thresholds, compact report, optional Discord webhook.

## Refs

Fixes https://github.com/DefiLlama/defillama-server/issues/11830

## How to run

```bash
cd defi
npm run compare-external-metrics -- --dry-run path/to/config.json
```

```bash
npx jest --testPathPattern=externalMetricComparison.test --runInBand --no-coverage --forceExit
```

Note: Relates to the same scope as https://github.com/DefiLlama/defillama-server/pull/11847 — happy to consolidate with maintainers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI utility to compare internal metrics against external data sources
  * Configurable thresholds to classify results as acceptable, warning, or critical
  * Automated report generation with optional Discord webhook notifications for metric alerts
  * Supports dry-run mode for testing without sending notifications

* **Tests**
  * Added test coverage for metric comparison and reporting utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->