### PR TITLE
Complete per-chain TVL fallback (closes #11354)

### DIFF
--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -19,7 +19,8 @@ export type ChainTvlFailure = {
   protocol_id: string;
   chain: string;
   error_class: string;
-  last_failure_at: number;        // unix seconds
+  first_failure_at: number;       // unix seconds — preserved across upserts so escalation measures continuous failure duration
+  last_failure_at: number;        // unix seconds — bumped on every failure
   fallback_used: boolean;
   fallback_reason: string | null; // 'too-old' | 'over-threshold' | 'malformed-cache' | 'no-cache' | 'not-cron-task' | 'low-total-tvl' | null
   cached_tvl: number;
@@ -30,6 +31,7 @@ export const columns = [
   "protocol_id",
   "chain",
   "error_class",
+  "first_failure_at",
   "last_failure_at",
   "fallback_used",
   "fallback_reason",
@@ -48,6 +50,7 @@ export async function recordChainFailure(f: ChainTvlFailure): Promise<void> {
         on conflict (protocol_id, chain) do update set
           error_class = excluded.error_class,
           last_failure_at = excluded.last_failure_at,
+          -- first_failure_at deliberately NOT updated on conflict so escalation reflects continuous failure duration
           fallback_used = excluded.fallback_used,
           fallback_reason = excluded.fallback_reason,
           consecutive_failures = chain_tvl_failures.consecutive_failures + 1,
@@ -82,7 +85,7 @@ export async function notifyChainTvlFailures(): Promise<void> {
     const sql = await getPgConnection();
     const allColumns = [...columns, "consecutive_failures"];
     const stored: (ChainTvlFailure & { consecutive_failures: number })[] = await queryPostgresWithRetry(
-      sql`select ${(sql as any)(allColumns)} from chain_tvl_failures order by last_failure_at asc`,
+      sql`select ${(sql as any)(allColumns)} from chain_tvl_failures order by first_failure_at asc`,
       sql,
     );
     if (!stored.length) return;
@@ -91,7 +94,10 @@ export async function notifyChainTvlFailures(): Promise<void> {
     let summary = "";
     let escalation = "";
     for (const f of stored) {
-      const ageHours = (now - f.last_failure_at) / 3600;
+      // Age is measured from first_failure_at so escalation tracks continuous failure duration,
+      // not just time since the latest poke. A chain that fails every cron run for 5 days reports
+      // 5d here even though last_failure_at is "minutes ago".
+      const ageHours = (now - f.first_failure_at) / 3600;
       const ageDays = ageHours / 24;
       const fallbackInfo = f.fallback_used
         ? `fallback used (${f.fallback_reason ?? "ok"})`

--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -103,7 +103,11 @@ export async function notifyChainTvlFailures(): Promise<void> {
     const promises: any[] = [];
     if (summary && process.env.STALE_COINS_ADAPTERS_WEBHOOK) {
       promises.push(
-        sendMessage(`Chain TVL failures (last 24h):${summary}`, process.env.STALE_COINS_ADAPTERS_WEBHOOK, true),
+        sendMessage(
+          `Open chain TVL failures (cleared automatically on next successful run):${summary}`,
+          process.env.STALE_COINS_ADAPTERS_WEBHOOK,
+          true,
+        ),
       );
     }
     if (escalation && process.env.TEAM_WEBHOOK) {
@@ -119,4 +123,15 @@ export async function notifyChainTvlFailures(): Promise<void> {
   } catch (e) {
     console.error(`notifyChainTvlFailures failed: ${e}`);
   }
+}
+
+// Allow this module to be invoked as a standalone script, mirroring staleCoins.ts.
+// Use: RUN_SCRIPT_MODE=true ts-node defi/src/storeTvlInterval/chainTvlFailures.ts
+if (process.env.RUN_SCRIPT_MODE) {
+  notifyChainTvlFailures()
+    .catch(console.error)
+    .then(() => {
+      console.log("Done");
+      process.exit(0);
+    });
 }

--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -128,7 +128,13 @@ export async function notifyChainTvlFailures(): Promise<void> {
     }
     await Promise.all(promises);
   } catch (e) {
-    console.error(`notifyChainTvlFailures failed: ${e}`);
+    // Re-throw so the RUN_SCRIPT_MODE caller below exits non-zero. Unlike
+    // recordChainFailure / clearChainFailure (called from the live TVL pipeline
+    // where a Postgres outage must NOT crash the run), notifyChainTvlFailures
+    // runs as its own scheduled-job entry point — silent failure here means
+    // the team's monitoring sees a clean run when it isn't.
+    console.error("notifyChainTvlFailures failed:", e);
+    throw e;
   }
 }
 

--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -81,9 +81,10 @@ export async function notifyChainTvlFailures(): Promise<void> {
   try {
     const sql = await getPgConnection();
     const allColumns = [...columns, "consecutive_failures"];
-    const stored: (ChainTvlFailure & { consecutive_failures: number })[] = await sql`
-      select ${(sql as any)(allColumns)} from chain_tvl_failures order by last_failure_at asc
-    `;
+    const stored: (ChainTvlFailure & { consecutive_failures: number })[] = await queryPostgresWithRetry(
+      sql`select ${(sql as any)(allColumns)} from chain_tvl_failures order by last_failure_at asc`,
+      sql,
+    );
     if (!stored.length) return;
 
     const now = Date.now() / 1000;

--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -1,0 +1,122 @@
+// Per-(protocol, chain) TVL failure tracker.
+//
+// When a single chain in a multi-chain protocol fails, getAndStoreTvl substitutes
+// the last cached value (subject to age + share thresholds in isCacheDataFresh).
+// This module persists each failure event so the team can identify chains that
+// keep breaking and either fix or remove them from the adapter (per issue #11354
+// second sentence: "track these failures and fix/remove the problematic chain").
+//
+// Storage: Postgres table `chain_tvl_failures` (PRIMARY KEY (protocol_id, chain)).
+// Reporting: daily summary to STALE_COINS_ADAPTERS_WEBHOOK; chains failing > 3 days
+// are escalated to TEAM_WEBHOOK.
+
+import { queryPostgresWithRetry } from "../../src/utils/shared/bridgedTvlPostgres";
+import { getPgConnection } from "../utils/shared/getDBConnection";
+import { sendMessage } from "../utils/discord";
+import { humanizeNumber } from "@defillama/sdk";
+
+export type ChainTvlFailure = {
+  protocol_id: string;
+  chain: string;
+  error_class: string;
+  last_failure_at: number;        // unix seconds
+  fallback_used: boolean;
+  fallback_reason: string | null; // 'too-old' | 'over-threshold' | 'malformed-cache' | 'no-cache' | 'not-cron-task' | 'low-total-tvl' | null
+  cached_tvl: number;
+  total_tvl: number;
+};
+
+export const columns = [
+  "protocol_id",
+  "chain",
+  "error_class",
+  "last_failure_at",
+  "fallback_used",
+  "fallback_reason",
+  "cached_tvl",
+  "total_tvl",
+];
+
+const ESCALATE_AFTER_HOURS = 72;
+
+export async function recordChainFailure(f: ChainTvlFailure): Promise<void> {
+  try {
+    const sql = await getPgConnection();
+    await queryPostgresWithRetry(
+      sql`
+        insert into chain_tvl_failures ${(sql as any)([f], ...columns)}
+        on conflict (protocol_id, chain) do update set
+          error_class = excluded.error_class,
+          last_failure_at = excluded.last_failure_at,
+          fallback_used = excluded.fallback_used,
+          fallback_reason = excluded.fallback_reason,
+          consecutive_failures = chain_tvl_failures.consecutive_failures + 1,
+          cached_tvl = excluded.cached_tvl,
+          total_tvl = excluded.total_tvl;
+      `,
+      sql,
+    );
+  } catch (e) {
+    // Never let failure-recording itself break the TVL pipeline.
+    console.error(`recordChainFailure failed: ${e}`);
+  }
+}
+
+export async function clearChainFailure(protocol_id: string, chain: string): Promise<void> {
+  try {
+    const sql = await getPgConnection();
+    await queryPostgresWithRetry(
+      sql`
+        delete from chain_tvl_failures
+        where protocol_id = ${protocol_id} and chain = ${chain}
+      `,
+      sql,
+    );
+  } catch (e) {
+    console.error(`clearChainFailure failed: ${e}`);
+  }
+}
+
+export async function notifyChainTvlFailures(): Promise<void> {
+  try {
+    const sql = await getPgConnection();
+    const allColumns = [...columns, "consecutive_failures"];
+    const stored: (ChainTvlFailure & { consecutive_failures: number })[] = await sql`
+      select ${(sql as any)(allColumns)} from chain_tvl_failures order by last_failure_at asc
+    `;
+    if (!stored.length) return;
+
+    const now = Date.now() / 1000;
+    let summary = "";
+    let escalation = "";
+    for (const f of stored) {
+      const ageHours = (now - f.last_failure_at) / 3600;
+      const ageDays = ageHours / 24;
+      const fallbackInfo = f.fallback_used
+        ? `fallback used (${f.fallback_reason ?? "ok"})`
+        : `fallback NOT used (${f.fallback_reason ?? "n/a"})`;
+      const line = `\n- ${f.protocol_id}/${f.chain}: ${f.consecutive_failures} consecutive failures over ${ageDays.toFixed(1)}d. Last error: ${f.error_class}. ${fallbackInfo}. Cached TVL ${humanizeNumber(f.cached_tvl)} / total ${humanizeNumber(f.total_tvl)}.`;
+      summary += line;
+      if (ageHours > ESCALATE_AFTER_HOURS) escalation += line;
+    }
+
+    const promises: any[] = [];
+    if (summary && process.env.STALE_COINS_ADAPTERS_WEBHOOK) {
+      promises.push(
+        sendMessage(`Chain TVL failures (last 24h):${summary}`, process.env.STALE_COINS_ADAPTERS_WEBHOOK, true),
+      );
+    }
+    if (escalation && process.env.TEAM_WEBHOOK) {
+      promises.push(
+        sendMessage(
+          `Chains failing > ${ESCALATE_AFTER_HOURS}h (consider removing from adapter):${escalation}`,
+          process.env.TEAM_WEBHOOK,
+          true,
+        ),
+      );
+    }
+    await Promise.all(promises);
+  } catch (e) {
+    console.error(`notifyChainTvlFailures failed: ${e}`);
+  }
+}

--- a/defi/src/storeTvlInterval/chainTvlFailures.ts
+++ b/defi/src/storeTvlInterval/chainTvlFailures.ts
@@ -134,11 +134,19 @@ export async function notifyChainTvlFailures(): Promise<void> {
 
 // Allow this module to be invoked as a standalone script, mirroring staleCoins.ts.
 // Use: RUN_SCRIPT_MODE=true ts-node defi/src/storeTvlInterval/chainTvlFailures.ts
+//
+// Note: failures must surface to the caller (e.g. cron scheduler) as a non-zero
+// exit code. The `.catch().then()` pattern in staleCoins.ts swallows the error
+// and always exits 0, which hides scheduled-job failures — we deliberately fix
+// that here.
 if (process.env.RUN_SCRIPT_MODE) {
   notifyChainTvlFailures()
-    .catch(console.error)
     .then(() => {
       console.log("Done");
       process.exit(0);
+    })
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
     });
 }

--- a/defi/src/storeTvlInterval/getAndStoreTvl.test.ts
+++ b/defi/src/storeTvlInterval/getAndStoreTvl.test.ts
@@ -1,0 +1,84 @@
+import { isCacheDataFresh } from "./getAndStoreTvl";
+
+const SEC_PER_DAY = 24 * 3600;
+
+const validCache = (overrides: Partial<{ usdTvls: number; timestamp: number }> = {}) => ({
+  usdTvls: 1_000,
+  tokensBalances: { foo: "1" },
+  usdTokenBalances: { foo: 1 },
+  rawTokenBalances: { foo: "1" },
+  timestamp: Math.floor(Date.now() / 1000),
+  ...overrides,
+});
+
+describe("isCacheDataFresh (per #11354)", () => {
+  const ENV_KEYS = ["TVL_FALLBACK_MAX_AGE_SEC", "TVL_FALLBACK_MAX_SHARE"];
+  const savedEnv: Record<string, string | undefined> = {};
+  beforeAll(() => ENV_KEYS.forEach((k) => (savedEnv[k] = process.env[k])));
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it("returns isFresh=true for a fresh cache well under the share threshold", () => {
+    const cache = validCache({ usdTvls: 1_000 }); // 1k of 100k = 1%
+    expect(isCacheDataFresh(cache, 100_000)).toEqual({ isFresh: true });
+  });
+
+  it("rejects a malformed cache (missing required fields)", () => {
+    expect(isCacheDataFresh({} as any, 100_000)).toEqual({ isFresh: false, reason: "malformed-cache" });
+    expect(isCacheDataFresh({ usdTvls: 1, timestamp: 0 } as any, 100_000)).toEqual({
+      isFresh: false,
+      reason: "malformed-cache",
+    });
+  });
+
+  it("rejects a cache older than the default 7-day max age", () => {
+    const cache = validCache({ timestamp: Math.floor(Date.now() / 1000) - 7 * SEC_PER_DAY - 1 });
+    const result = isCacheDataFresh(cache, 100_000);
+    expect(result.isFresh).toBe(false);
+    expect(result.reason).toBe("too-old");
+    expect(result.invalidCacheTime).toBeGreaterThan(7 * SEC_PER_DAY);
+  });
+
+  it("accepts a cache just under the 7-day threshold", () => {
+    const cache = validCache({ timestamp: Math.floor(Date.now() / 1000) - 7 * SEC_PER_DAY + 60 });
+    expect(isCacheDataFresh(cache, 100_000)).toEqual({ isFresh: true });
+  });
+
+  it("rejects a cache at or above the 5% share threshold", () => {
+    const cache = validCache({ usdTvls: 6_000 }); // 6k of 100k = 6%
+    expect(isCacheDataFresh(cache, 100_000)).toEqual({ isFresh: false, reason: "over-threshold" });
+
+    const exactly5pct = validCache({ usdTvls: 5_000 }); // 5k of 100k = exactly 5%
+    expect(isCacheDataFresh(exactly5pct, 100_000)).toEqual({ isFresh: false, reason: "over-threshold" });
+  });
+
+  it("honors TVL_FALLBACK_MAX_AGE_SEC override (tighter)", () => {
+    process.env.TVL_FALLBACK_MAX_AGE_SEC = "600"; // 10 minutes
+    const cache = validCache({ timestamp: Math.floor(Date.now() / 1000) - 700 });
+    expect(isCacheDataFresh(cache, 100_000)).toMatchObject({ isFresh: false, reason: "too-old" });
+  });
+
+  it("honors TVL_FALLBACK_MAX_AGE_SEC override (looser)", () => {
+    process.env.TVL_FALLBACK_MAX_AGE_SEC = String(30 * SEC_PER_DAY);
+    const cache = validCache({ timestamp: Math.floor(Date.now() / 1000) - 14 * SEC_PER_DAY });
+    expect(isCacheDataFresh(cache, 100_000)).toEqual({ isFresh: true });
+  });
+
+  it("honors TVL_FALLBACK_MAX_SHARE override", () => {
+    process.env.TVL_FALLBACK_MAX_SHARE = "0.10"; // raise threshold to 10%
+    const cache = validCache({ usdTvls: 8_000 }); // 8% — would be rejected at default 5%
+    expect(isCacheDataFresh(cache, 100_000)).toEqual({ isFresh: true });
+  });
+
+  it("checks staleness before share threshold (too-old wins over over-threshold)", () => {
+    const cache = validCache({
+      usdTvls: 50_000, // 50% share — over threshold
+      timestamp: Math.floor(Date.now() / 1000) - 30 * SEC_PER_DAY, // also too old
+    });
+    expect(isCacheDataFresh(cache, 100_000)).toMatchObject({ isFresh: false, reason: "too-old" });
+  });
+});

--- a/defi/src/storeTvlInterval/getAndStoreTvl.ts
+++ b/defi/src/storeTvlInterval/getAndStoreTvl.ts
@@ -23,8 +23,36 @@ import { getBlocksRetry, getCurrentBlock } from "./blocks";
 import { importAdapterDynamic } from "../utils/imports/importAdapter";
 import { deadChainsSet } from "../config/deadChains";
 import { getJSON, setJSON } from "./redis";
+import { recordChainFailure, clearChainFailure } from "./chainTvlFailures";
 import axios from "axios";
 import sluggify from "../utils/sluggify";
+
+const FALLBACK_DEFAULT_MAX_AGE_SEC = 7 * 24 * 3600;
+const FALLBACK_DEFAULT_MAX_SHARE = 0.05;
+
+export type CacheFreshness = { isFresh: boolean; invalidCacheTime?: number; reason?: string };
+
+// Decides whether a per-chain cached TVL value is fresh enough to substitute for
+// a failed live fetch. Two checks (per issue #11354):
+//   1. Time bound — never use a value older than TVL_FALLBACK_MAX_AGE_SEC (default 7d).
+//      Without this, a months-old cached value could pass the share check below and
+//      silently mask broken adapters indefinitely.
+//   2. Share threshold — only substitute when the failing chain's last-known share is
+//      small enough that masking it can't materially mislead total TVL. Default 5%.
+// Both thresholds are env-tunable.
+export function isCacheDataFresh(cacheData: any, totalTvl: number): CacheFreshness {
+  if (!cacheData?.usdTvls || !cacheData?.tokensBalances || !cacheData?.usdTokenBalances || !cacheData?.rawTokenBalances || !cacheData?.timestamp)
+    return { isFresh: false, reason: 'malformed-cache' }
+
+  const maxAgeSec = +(process.env.TVL_FALLBACK_MAX_AGE_SEC ?? FALLBACK_DEFAULT_MAX_AGE_SEC)
+  const ageSec = (Date.now() / 1000) - cacheData.timestamp
+  if (ageSec > maxAgeSec) return { isFresh: false, invalidCacheTime: ageSec, reason: 'too-old' }
+
+  const maxShare = +(process.env.TVL_FALLBACK_MAX_SHARE ?? FALLBACK_DEFAULT_MAX_SHARE)
+  if ((cacheData.usdTvls / totalTvl) >= maxShare) return { isFresh: false, reason: 'over-threshold' }
+
+  return { isFresh: true }
+}
 
 async function insertOnDb(useCurrentPrices: boolean, table: any, data: any, probabilitySampling: number = 1) {
   if (process.env.LOCAL === 'true' || !useCurrentPrices || Math.random() > probabilitySampling) return;
@@ -417,7 +445,35 @@ export async function storeTvl(
       for (const key of storedKeys) {
 
         if (tvlErrorsObject[key]) {
-          const tempStoreKeyCache = await getCachedTvlData({ protocol, storeKey: key, options, tvlErrorsObject })
+          const errMsg = (tvlErrorsObject[key]?.message ?? 'unknown').slice(0, 200)
+          let tempStoreKeyCache: any
+          try {
+            tempStoreKeyCache = await getCachedTvlData({ protocol, storeKey: key, options, tvlErrorsObject })
+          } catch (e: any) {
+            // Fallback exhausted — record the failure for the team's tracker, then re-throw to preserve existing behavior.
+            await recordChainFailure({
+              protocol_id: String(protocol.id),
+              chain: key,
+              error_class: errMsg,
+              last_failure_at: Math.floor(Date.now() / 1000),
+              fallback_used: false,
+              fallback_reason: e?.fallbackReason ?? 'unknown',
+              cached_tvl: 0,
+              total_tvl: 0,
+            })
+            throw e
+          }
+          // Fallback succeeded — record that this chain ran on cached data so the team can act on chronic offenders.
+          await recordChainFailure({
+            protocol_id: String(protocol.id),
+            chain: key,
+            error_class: errMsg,
+            last_failure_at: Math.floor(Date.now() / 1000),
+            fallback_used: true,
+            fallback_reason: 'ok',
+            cached_tvl: tempStoreKeyCache.usdTvls ?? 0,
+            total_tvl: 0,
+          })
 
           usdTvls[key] = tempStoreKeyCache.usdTvls;
           tokensBalances[key] = tempStoreKeyCache.tokensBalances;
@@ -426,6 +482,9 @@ export async function storeTvl(
 
           // if all the data is present, store temp cache for key to use in future if needed
         } else if (runType === 'cron-task' && usdTvls[key] !== undefined && tokensBalances[key] !== undefined && usdTokenBalances[key] !== undefined && rawTokenBalances[key] !== undefined) {
+          // Successful per-chain run — clear any prior failure record (fire-and-forget; never blocks the pipeline).
+          void clearChainFailure(String(protocol.id), key)
+
           const tempStoreKeyResultCaheKey = getCachedTvlDataKey(protocol, key)
 
           // store temp result cache for key
@@ -599,26 +658,31 @@ function getCachedTvlDataKey(protocol: Protocol, key: string) {
   return `storeTvlInterval-cache-${protocol.id}-${key}`
 }
 
+function throwWithReason(err: any, reason: string): never {
+  if (err && typeof err === 'object') (err as any).fallbackReason = reason
+  throw err ?? new Error('cache-not-fresh')
+}
+
 async function getCachedTvlData({ options, storeKey, protocol, tvlErrorsObject }: { options: StoreTvlOptions, storeKey: string, protocol: Protocol, tvlErrorsObject: tvlsObject<Error> }) {
 
   // cron-task and allow to use temp cache
   if (options.runType !== 'cron-task' || options.tempCacheInfo === undefined) {
-    throw tvlErrorsObject[storeKey];
+    throwWithReason(tvlErrorsObject[storeKey], 'not-cron-task')
   }
 
   const totalTvl = await pullTvlNumber(protocol);
 
   if (totalTvl === null || (totalTvl as number) < 10e3)  // if total tvl is very low, it's better to fail than return cached data
-    throw tvlErrorsObject[storeKey];
+    throwWithReason(tvlErrorsObject[storeKey], 'low-total-tvl')
 
   const tempStoreKeyCache = await getJSON(getCachedTvlDataKey(protocol, storeKey), { throwErrorWhenFailed: false });
 
   // query redis but cache was not found, throw Error
   if (tempStoreKeyCache === null)
-    throw tvlErrorsObject[storeKey];
+    throwWithReason(tvlErrorsObject[storeKey], 'no-cache')
 
   const cacheCheck = isCacheDataFresh(tempStoreKeyCache, totalTvl!);
-  if (!cacheCheck.isFresh) throw tvlErrorsObject[storeKey];
+  if (!cacheCheck.isFresh) throwWithReason(tvlErrorsObject[storeKey], cacheCheck.reason ?? 'unknown')
 
 
   options.tempCacheInfo.push({
@@ -631,14 +695,6 @@ async function getCachedTvlData({ options, storeKey, protocol, tvlErrorsObject }
   })
 
   return tempStoreKeyCache
-
-  function isCacheDataFresh(cacheData: any, totalTvl: number): { isFresh: boolean, invalidCacheTime?: number } {
-    if (!cacheData?.usdTvls || !cacheData?.tokensBalances || !cacheData?.usdTokenBalances || !cacheData?.rawTokenBalances || !cacheData?.timestamp)
-      return { isFresh: false }
-
-    // if the cached tvl is less than 5% of total tvl, consider it fresh regardless of cache age, because it's not significant enough to cause big errors. This is to avoid unnecessary cache invalidation for low tvl protocols.
-    return { isFresh: (cacheData.usdTvls / totalTvl) < (5 / 100) }
-  }
 
   async function pullTvlNumber(protocol: Protocol): Promise<number | null> {
     try {

--- a/defi/src/storeTvlInterval/getAndStoreTvl.ts
+++ b/defi/src/storeTvlInterval/getAndStoreTvl.ts
@@ -446,16 +446,20 @@ export async function storeTvl(
 
         if (tvlErrorsObject[key]) {
           const errMsg = (tvlErrorsObject[key]?.message ?? 'unknown').slice(0, 200)
+          const failureAt = Math.floor(Date.now() / 1000)
           let tempStoreKeyCache: any
           try {
             tempStoreKeyCache = await getCachedTvlData({ protocol, storeKey: key, options, tvlErrorsObject })
           } catch (e: any) {
             // Fallback exhausted — record the failure for the team's tracker, then re-throw to preserve existing behavior.
+            // first_failure_at is set to the same timestamp as last_failure_at on insert; the upsert keeps the
+            // original first_failure_at on subsequent failures so escalation tracks continuous duration.
             await recordChainFailure({
               protocol_id: String(protocol.id),
               chain: key,
               error_class: errMsg,
-              last_failure_at: Math.floor(Date.now() / 1000),
+              first_failure_at: failureAt,
+              last_failure_at: failureAt,
               fallback_used: false,
               fallback_reason: e?.fallbackReason ?? 'unknown',
               cached_tvl: 0,
@@ -468,7 +472,8 @@ export async function storeTvl(
             protocol_id: String(protocol.id),
             chain: key,
             error_class: errMsg,
-            last_failure_at: Math.floor(Date.now() / 1000),
+            first_failure_at: failureAt,
+            last_failure_at: failureAt,
             fallback_used: true,
             fallback_reason: 'ok',
             cached_tvl: tempStoreKeyCache.usdTvls ?? 0,

--- a/defi/src/storeTvlInterval/getAndStoreTvl.ts
+++ b/defi/src/storeTvlInterval/getAndStoreTvl.ts
@@ -472,7 +472,7 @@ export async function storeTvl(
             fallback_used: true,
             fallback_reason: 'ok',
             cached_tvl: tempStoreKeyCache.usdTvls ?? 0,
-            total_tvl: 0,
+            total_tvl: tempStoreKeyCache._totalTvl ?? 0,
           })
 
           usdTvls[key] = tempStoreKeyCache.usdTvls;
@@ -694,7 +694,10 @@ async function getCachedTvlData({ options, storeKey, protocol, tvlErrorsObject }
     invalidCacheTime: cacheCheck.invalidCacheTime! ?? 0,
   })
 
-  return tempStoreKeyCache
+  // Surface totalTvl on the returned cache object so the caller can record it on the failure row.
+  // Prefixed with `_` to make it clear this is metadata for failure tracking, not part of the
+  // cache snapshot itself.
+  return { ...tempStoreKeyCache, _totalTvl: totalTvl! }
 
   async function pullTvlNumber(protocol: Protocol): Promise<number | null> {
     try {


### PR DESCRIPTION
Closes #11354.

## What this PR does

Completes the per-chain TVL fallback that's already 80% wired in `getAndStoreTvl.ts` but missing the **time bound** the issue specifically asks for ("max up to a week old"), and adds the **per-(protocol, chain) failure tracking** the issue's second sentence calls for ("track these failures and fix/remove the problematic chain").

## What's already in `master` (for context)

`defi/src/storeTvlInterval/getAndStoreTvl.ts` already:

- Captures per-chain failures via `tvlErrorsObject` (try/catch in `getTvl`).
- On cron-task success, writes a per-chain TVL snapshot to Redis (`storeTvlInterval-cache-${protocol.id}-${storedKey}`).
- On per-chain failure, calls `getCachedTvlData` to substitute the cached value if available.
- Has a 5%-of-total-TVL share threshold in `isCacheDataFresh`.

## What was missing

`isCacheDataFresh` (previously at lines 635–641) had an explicit comment: *"if the cached tvl is less than 5% of total tvl, consider it fresh **regardless of cache age**."* So a cached value from 6 months ago would still be substituted as long as it stayed below 5% — silently masking long-broken adapters. The issue text — *"max up to a week old"* — is exactly this missing constraint.

There was also no persistent record of which (protocol, chain) pairs were failing, no signal to the team that a chain has been broken for days, and the team's "fix/remove the problematic chain" workflow was unsupported.

## What this PR adds

1. **Time-bound check** in `isCacheDataFresh` (env-tunable, default 7 days via `TVL_FALLBACK_MAX_AGE_SEC`).
2. **Existing share threshold made env-tunable** (`TVL_FALLBACK_MAX_SHARE`, default `0.05`). Defaults are unchanged.
3. **`isCacheDataFresh` extracted to module-level + exported** so it's directly unit-testable. It also now returns a `reason` field (`'too-old' | 'over-threshold' | 'malformed-cache'`) that flows into the failure-tracking record.
4. **`throwWithReason` helper** so `getCachedTvlData` annotates re-thrown errors with the precise reason fallback was rejected.
5. **New module `defi/src/storeTvlInterval/chainTvlFailures.ts`** with three functions:
   - `recordChainFailure` — upserts into `chain_tvl_failures` (PRIMARY KEY `(protocol_id, chain)`, increments `consecutive_failures` on conflict). Wired into the failure block of `storeTvl`. Fail-soft: a Postgres outage never breaks the TVL pipeline.
   - `clearChainFailure` — deletes the row when the chain runs cleanly again. Wired into the success path of `storeTvl`.
   - `notifyChainTvlFailures` — daily summary to `STALE_COINS_ADAPTERS_WEBHOOK`; chains failing more than 72h are escalated to `TEAM_WEBHOOK`. Mirrors the structure of `notifyStaleCoins` so the operational pattern is familiar.
6. **Unit tests** (`getAndStoreTvl.test.ts`, 9 cases) covering: malformed cache, fresh cache, age-boundary, share-boundary, both env overrides (tighter + looser), and ordering when both checks fail.

## Behavior change

- Default behavior changes only at the limit: caches older than 7 days that *previously* would have been substituted (because they passed the 5% share check) will now be rejected with `reason: 'too-old'` and the adapter will fail loudly. This matches the issue's explicit ask.
- All other paths preserve current behavior.
- Both thresholds are env-tunable so the team can dial them per-environment without redeploying.

## New table required

```sql
CREATE TABLE IF NOT EXISTS chain_tvl_failures (
  protocol_id TEXT NOT NULL,
  chain TEXT NOT NULL,
  error_class TEXT,
  last_failure_at BIGINT NOT NULL,
  fallback_used BOOLEAN NOT NULL DEFAULT FALSE,
  fallback_reason TEXT,
  consecutive_failures INTEGER NOT NULL DEFAULT 1,
  cached_tvl NUMERIC NOT NULL DEFAULT 0,
  total_tvl NUMERIC NOT NULL DEFAULT 0,
  PRIMARY KEY (protocol_id, chain)
);
CREATE INDEX IF NOT EXISTS chain_tvl_failures_age ON chain_tvl_failures (last_failure_at);
```

I haven't included this as a migration file because the repo doesn't appear to have a schema-migration system for the existing `stalecoins` table — happy to follow whatever process you use for schema changes there.

## Files touched

- `defi/src/storeTvlInterval/getAndStoreTvl.ts` — extract + extend `isCacheDataFresh`, add `throwWithReason`, wire failure recording
- `defi/src/storeTvlInterval/chainTvlFailures.ts` — new module
- `defi/src/storeTvlInterval/getAndStoreTvl.test.ts` — new unit tests

## Verification

```bash
cd defi
npx jest src/storeTvlInterval/getAndStoreTvl.test.ts
# 9 passed
```

TypeScript: `npx tsc --noEmit` shows no new errors introduced by this PR (the pre-existing errors in `craftCsvDataset.ts` and elsewhere are unchanged).

## Notes / open questions

- I left the existing Elastic logging via `tempCacheInfo` (line 456-481) untouched — that's still useful for the "every-cache-use" stream. The new Postgres tracking complements it with a *persistent + queryable* record specifically for chains that need maintainer action.
- If you'd prefer the failure tracker behind a feature flag (e.g., `TVL_FAILURE_TRACKING_ENABLED`), happy to gate it. The current implementation is fail-soft so a missing table or DB outage can't break the pipeline, but I understand if you want to roll it out gradually.
- Defaults (7d age, 5% share) are conservative and align with the issue text. Easy to tune if production data suggests otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chain TVL failure tracking with automated notifications and escalation for persistent failures (escalates after configured hours).
  * Cache-freshness checks for TVL fallbacks with configurable age and share thresholds; fallback usage and failure reasons are recorded and influence behavior.

* **Tests**
  * Added tests validating cache freshness logic, threshold behavior, env-configurable settings, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->