### PR TITLE
fix(security): harden internal debug cache routes

### DIFF
--- a/defi/src/api2/cache/file-cache.ts
+++ b/defi/src/api2/cache/file-cache.ts
@@ -126,7 +126,31 @@ function getCacheFile(key: string) {
   return `pg-cache/${key}`
 }
 
+const INVALID_CACHE_KEY_ERROR = 'Invalid cache key'
+
+function normalizePGCacheKey(key: string) {
+  if (typeof key !== 'string' || !key.length)
+    throw new Error(INVALID_CACHE_KEY_ERROR)
+
+  if (key.includes('\\'))
+    throw new Error(INVALID_CACHE_KEY_ERROR)
+
+  const normalizedKey = path.posix.normalize(key)
+
+  if (
+    normalizedKey === '.' ||
+    normalizedKey.startsWith('..') ||
+    normalizedKey.includes('/../') ||
+    normalizedKey.startsWith('/')
+  ) {
+    throw new Error(INVALID_CACHE_KEY_ERROR)
+  }
+
+  return normalizedKey
+}
+
 export async function readFromPGCache(key: string, { withTimestamp = false } = {}) {
+  key = normalizePGCacheKey(key)
   const item: any = await readFileData(getCacheFile(key))
   if (!item) return null
   if (withTimestamp) return item
@@ -134,6 +158,7 @@ export async function readFromPGCache(key: string, { withTimestamp = false } = {
 }
 
 export async function writeToPGCache(key: string, data: any) {
+  key = normalizePGCacheKey(key)
   const id = getCacheFile(key)
   return storeData(id, { id, timestamp: Math.floor(Date.now() / 1e3), data })
 }
@@ -172,6 +197,7 @@ export function getDailyTvlCacheId(id: string) {
 
 export async function deleteFromPGCache(key: string) {
   log('Deleting from db cache:', key)
+  key = normalizePGCacheKey(key)
   let keySplit = key.split('/')
   if (typeof keySplit[1] === 'string' && keySplit[1].startsWith('tvl-cache-daily')) {
     keySplit[1] = TVL_CACHE_FOLDER

--- a/defi/src/api2/routes/internalRoutes.ts
+++ b/defi/src/api2/routes/internalRoutes.ts
@@ -10,13 +10,11 @@ import { protocolsById } from "../../protocols/data";
 import * as sdk from '@defillama/sdk';
 import { clearDimensionsCacheV2 } from "../utils/dimensionsUtils";
 
+const INTERNAL_SECRET_KEY = process.env.LLAMA_INTERNAL_ROUTE_KEY;
+const INTERNAL_SECRET_HEADER = 'x-internal-secret';
 
-const INTERNAL_SECRET_KEY = process.env.LLAMA_INTERNAL_ROUTE_KEY ?? process.env.LLAMA_PRO_API2_SECRET_KEY ?? process.env.API2_SUBPATH
-
-export function setInternalRoutes(router: HyperExpress.Router, routerBasePath: string) {
-
+export function setInternalRoutes(router: HyperExpress.Router, _routerBasePath: string) {
   // router.get('/_internal/all-protocol-data', getAllProtocolLatestData)
-
 
   router.get('/debug-pg/*', debugHandler)
   router.delete('/debug-pg/*', debugHandler)
@@ -24,19 +22,20 @@ export function setInternalRoutes(router: HyperExpress.Router, routerBasePath: s
   async function debugHandler(req: any, res: any) {
     const fullPath = req.path;
     const routerPath = fullPath.split('debug-pg')[1];
+    const cachePath = routerPath.replace(/^\/+/, '');
+    const internalSecret = req.headers[INTERNAL_SECRET_HEADER];
     try {
-
-      if (process.env.API2_SKIP_SUBPATH === 'true')
-        if (!req.headers['x-internal-secret'] || req.headers['x-internal-secret'] !== INTERNAL_SECRET_KEY) throw new Error('Unauthorized')
+      if (!INTERNAL_SECRET_KEY || !internalSecret || internalSecret !== INTERNAL_SECRET_KEY)
+        return errorResponse(res, 'Unauthorized', { statusCode: 401 })
 
       switch (req.method) {
         case 'GET':
-          return res.json(await readFromPGCache(routerPath))
+          return res.json(await readFromPGCache(cachePath))
         case 'DELETE':
-          if (routerPath === '/clear-dimensions-cache') {
+          if (cachePath === 'clear-dimensions-cache') {
             await clearDimensionsCacheV2()
           } else
-            await deleteFromPGCache(routerPath)
+            await deleteFromPGCache(cachePath)
           return res.json({ success: true })
         default:
           throw new Error('Unsupported method')
@@ -46,8 +45,6 @@ export function setInternalRoutes(router: HyperExpress.Router, routerBasePath: s
       return errorResponse(res, 'Internal server error', { statusCode: 500 })
     }
   }
-
-
 }
 
 async function getAllProtocolLatestData(_req: HyperExpress.Request, res: HyperExpress.Response) {

--- a/defi/src/api2/tests/internalRoutes.test.ts
+++ b/defi/src/api2/tests/internalRoutes.test.ts
@@ -1,0 +1,187 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const originalEnv = process.env;
+
+function resetEnv() {
+  process.env = { ...originalEnv };
+}
+
+function mockInternalRouteDependencies() {
+  const readFromPGCache = jest.fn(async (key: string) => {
+    if (key.startsWith('/')) throw new Error('Invalid cache key');
+    return { key };
+  });
+  const deleteFromPGCache = jest.fn(async (key: string) => {
+    if (key.startsWith('/')) throw new Error('Invalid cache key');
+  });
+  const clearDimensionsCacheV2 = jest.fn(async () => undefined);
+
+  jest.doMock('../cache/file-cache', () => ({
+    readFromPGCache,
+    deleteFromPGCache,
+  }));
+  jest.doMock('../utils/craftProtocolV2', () => ({
+    craftProtocolV2: jest.fn(),
+  }));
+  jest.doMock('../db', () => ({
+    getLatestProtocolItems: jest.fn(),
+  }));
+  jest.doMock('../../utils/getLastRecord', () => ({
+    hourlyTokensTvl: {},
+    hourlyTvl: {},
+    hourlyUsdTokensTvl: {},
+  }));
+  jest.doMock('../../protocols/data', () => ({
+    protocolsById: {},
+  }));
+  jest.doMock('../utils/dimensionsUtils', () => ({
+    clearDimensionsCacheV2,
+  }));
+  jest.doMock('@defillama/sdk', () => ({
+    log: jest.fn(),
+  }))
+
+  return { readFromPGCache, deleteFromPGCache, clearDimensionsCacheV2 };
+}
+
+function loadDebugHandler() {
+  const mocks = mockInternalRouteDependencies();
+  const { setInternalRoutes } = require('../routes/internalRoutes');
+  const router = {
+    get: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  setInternalRoutes(router as any, '');
+
+  return {
+    debugHandler: router.get.mock.calls[0][1],
+    ...mocks,
+  };
+}
+
+function createResponse() {
+  const res: any = {
+    json: jest.fn(),
+    send: jest.fn(),
+    status: jest.fn(),
+  };
+
+  res.status.mockImplementation(() => res);
+  return res;
+}
+
+describe('internal debug routes', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    resetEnv();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('rejects unauthenticated debug cache reads when API2_SKIP_SUBPATH is not true', async () => {
+    process.env.API2_SKIP_SUBPATH = 'false';
+    process.env.LLAMA_INTERNAL_ROUTE_KEY = 'super-secret';
+
+    const { debugHandler, readFromPGCache } = loadDebugHandler();
+    const res = createResponse();
+
+    await debugHandler(
+      {
+        path: '/debug-pg/protocols',
+        method: 'GET',
+        headers: {},
+      },
+      res
+    );
+
+    expect(readFromPGCache).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith('Unauthorized', true);
+  });
+
+  test('accepts authenticated debug cache reads', async () => {
+    process.env.API2_SKIP_SUBPATH = 'true';
+    process.env.LLAMA_INTERNAL_ROUTE_KEY = 'super-secret';
+
+    const { debugHandler, readFromPGCache } = loadDebugHandler();
+    const res = createResponse();
+
+    await debugHandler(
+      {
+        path: '/debug-pg/protocols',
+        method: 'GET',
+        headers: {
+          'x-internal-secret': 'super-secret',
+        },
+      },
+      res
+    );
+
+    expect(readFromPGCache).toHaveBeenCalledWith('protocols');
+    expect(res.json).toHaveBeenCalledWith({ key: 'protocols' });
+  });
+
+  test('clears dimensions cache through the authenticated debug route', async () => {
+    process.env.LLAMA_INTERNAL_ROUTE_KEY = 'super-secret';
+
+    const { debugHandler, clearDimensionsCacheV2, deleteFromPGCache } = loadDebugHandler();
+    const res = createResponse();
+
+    await debugHandler(
+      {
+        path: '/debug-pg/clear-dimensions-cache',
+        method: 'DELETE',
+        headers: {
+          'x-internal-secret': 'super-secret',
+        },
+      },
+      res
+    );
+
+    expect(clearDimensionsCacheV2).toHaveBeenCalled();
+    expect(deleteFromPGCache).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+});
+
+describe('pg cache file handling', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    resetEnv();
+    jest.unmock('../cache/file-cache');
+    jest.doMock('@defillama/sdk', () => ({
+      log: jest.fn(),
+      util: {
+        sliceIntoChunks: jest.fn(),
+      },
+    }));
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('rejects traversal outside the pg-cache directory', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'defillama-cache-'));
+    process.env.API2_CACHE_DIR = tempDir;
+    const secretPath = path.join(tempDir, 'secret.json');
+
+    fs.writeFileSync(secretPath, JSON.stringify({ data: 'stolen' }));
+
+    const { readFromPGCache, deleteFromPGCache } = require('../cache/file-cache');
+
+    await expect(readFromPGCache('../secret.json')).rejects.toThrow('Invalid cache key');
+    await expect(deleteFromPGCache('../secret.json')).rejects.toThrow('Invalid cache key');
+    await expect(readFromPGCache('a/..')).rejects.toThrow('Invalid cache key');
+    await expect(deleteFromPGCache('a/..')).rejects.toThrow('Invalid cache key');
+    expect(fs.existsSync(secretPath)).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Currently, the internal debug cache routes only enforced authentication in the local-testing `API2_SKIP_SUBPATH === 'true'` path, which left the normal `API2_SUBPATH` deployment path without the intended secret check...the same handler also passed unsanitized cache keys into the file-backed PG cache helpers, which allowed traversal-style keys to escape the `pg-cache` directory. 
Now, dedicated internal secret for all debug cache operations is required, rejects invalid cache keys before any cache read/write/delete, and adds regression tests covering unauthenticated access, authenticated access, and traversal attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened cache key validation with normalization to prevent unauthorized directory traversal attacks.

* **Tests**
  * Added comprehensive test coverage for internal debug route authentication and cache key validation security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->