### PR TITLE
Update Arbitrage Inc protocol metadata

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -15171,8 +15171,8 @@ const data5: Protocol[] = [
   {
     id: "7591",
     name: "Arbitrage Inc",
-    address: null,
-    symbol: "-",
+    address: "bsc:0x5EE54869Ecd5E752C31aF095187326D4A4D50e1c",
+    symbol: "ARBINC",
     url: "https://arbitrage-inc.exchange",
     description:
       "Arbitrage Inc is a DEX aggregator on BSC.",
@@ -15186,7 +15186,6 @@ const data5: Protocol[] = [
     module: "dummy.js",
     twitter: "Arbitrageincept",
     listedAt: 1774634365,
-    deadUrl: true,
     dimensions: {
       fees: "arbitrage-inc",
       aggregators: "arbitrage-inc",

--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -15186,6 +15186,7 @@ const data5: Protocol[] = [
     module: "dummy.js",
     twitter: "Arbitrageincept",
     listedAt: 1774634365,
+    deadUrl: true,
     dimensions: {
       fees: "arbitrage-inc",
       aggregators: "arbitrage-inc",


### PR DESCRIPTION

Updates the Arbitrage Inc protocol metadata with the token address, symbol, active website, and logo reference.

This addresses the metadata request from DefiLlama/DefiLlama-Adapters#18634.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a protocol listing to include the correct BSC contract address and token symbol; other public fields (including its existing URL/flags) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->