### PR TITLE
Fix RWA leading empty chart history

### DIFF
--- a/defi/src/rwa/chartBreakdown.test.ts
+++ b/defi/src/rwa/chartBreakdown.test.ts
@@ -1,0 +1,41 @@
+import { shouldEmitRwaBreakdownItem } from './chartBreakdown';
+
+describe('rwa chart breakdown', () => {
+  it('does not emit zero-only pre-launch rows', () => {
+    const startedItems = new Set<string>();
+
+    expect(
+      shouldEmitRwaBreakdownItem(startedItems, 'PreStocks', {
+        onChainMcap: 0,
+        activeMcap: 0,
+        defiActiveTvl: 0,
+      })
+    ).toBe(false);
+    expect(startedItems.has('PreStocks')).toBe(false);
+  });
+
+  it('emits rows once an item has non-zero data', () => {
+    const startedItems = new Set<string>();
+
+    expect(
+      shouldEmitRwaBreakdownItem(startedItems, 'PreStocks', {
+        onChainMcap: 0,
+        activeMcap: 11_780_000,
+        defiActiveTvl: 0,
+      })
+    ).toBe(true);
+    expect(startedItems.has('PreStocks')).toBe(true);
+  });
+
+  it('keeps zero rows after an item has started', () => {
+    const startedItems = new Set<string>(['PreStocks']);
+
+    expect(
+      shouldEmitRwaBreakdownItem(startedItems, 'PreStocks', {
+        onChainMcap: 0,
+        activeMcap: 0,
+        defiActiveTvl: 0,
+      })
+    ).toBe(true);
+  });
+});

--- a/defi/src/rwa/chartBreakdown.ts
+++ b/defi/src/rwa/chartBreakdown.ts
@@ -1,0 +1,20 @@
+import { toFiniteNumberOrZero } from './utils';
+
+export type RwaBreakdownMetricValues = {
+  onChainMcap?: unknown;
+  activeMcap?: unknown;
+  defiActiveTvl?: unknown;
+};
+
+export function hasRwaBreakdownMetricData(values: RwaBreakdownMetricValues): boolean {
+  return toFiniteNumberOrZero(values.onChainMcap) !== 0 || toFiniteNumberOrZero(values.activeMcap) !== 0 || toFiniteNumberOrZero(values.defiActiveTvl) !== 0;
+}
+
+export function shouldEmitRwaBreakdownItem(startedItems: Set<string>, itemKey: string, values: RwaBreakdownMetricValues): boolean {
+  if (hasRwaBreakdownMetricData(values)) {
+    startedItems.add(itemKey);
+    return true;
+  }
+
+  return startedItems.has(itemKey);
+}

--- a/defi/src/rwa/cron.ts
+++ b/defi/src/rwa/cron.ts
@@ -19,6 +19,7 @@ import {
 } from './file-cache';
 import { initPG, fetchCurrentPG, fetchMetadataPG, fetchAllDailyRecordsPG, fetchMaxUpdatedAtPG, fetchAllDailyIdsPG, fetchDailyRecordsForIdPG, fetchDailyRecordsWithChainsPG, fetchDailyRecordsWithChainsForIdPG } from './db';
 
+import { shouldEmitRwaBreakdownItem } from './chartBreakdown';
 import { rwaSlug, toFiniteNumberOrZero, smoothHistoricalData, normalizeRwaMetadataForApiInPlace } from './utils';
 import { parentProtocolsById } from '../protocols/parentProtocols';
 import { protocolsById } from '../protocols/data';
@@ -930,6 +931,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
   const platformBreakdownAndAssetTypes: { [timestamp: number]: HistoricalDataPointAssetTypes } = {};
   // timestamp => assetType => key => assetGroup
   const assetGroupBreakdownAndAssetTypes: { [timestamp: number]: HistoricalDataPointAssetTypes } = {};
+  const chainBreakdownStartedItems = new Set<string>();
+  const categoryBreakdownStartedItems = new Set<string>();
+  const platformBreakdownStartedItems = new Set<string>();
+  const assetGroupBreakdownStartedItems = new Set<string>();
 
   function ensureDataPoint(
     map: { [key: string]: { [timestamp: number]: HistoricalDataPoint } },
@@ -971,8 +976,9 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
     (map[timestamp] as any)[assetType][key][chain] += value;
   }
   
-  function updateBreakdownAndAssetTypes(map: { [timestamp: number]: HistoricalDataPointAssetTypes }, m: any, timestamp: number, data: any) {
+  function updateBreakdownAndAssetTypes(map: { [timestamp: number]: HistoricalDataPointAssetTypes }, m: any, timestamp: number, data: any, startedItems: Set<string>) {
     function _addToBreakdownItem(map: { [timestamp: number]: HistoricalDataPointAssetTypes }, timestamp: number, assetType: string, itemKey: string, itemValues: any) {
+      if (!shouldEmitRwaBreakdownItem(startedItems, `${assetType}:${itemKey}`, itemValues as any)) return;
       _updateBreakdownAndAssetTypes(map, timestamp, assetType, "onChainMcap", itemKey, toFiniteNumberOrZero((itemValues as any)?.onChainMcap));
       _updateBreakdownAndAssetTypes(map, timestamp, assetType, "activeMcap", itemKey, toFiniteNumberOrZero((itemValues as any)?.activeMcap));
       _updateBreakdownAndAssetTypes(map, timestamp, assetType, "defiActiveTvl", itemKey, toFiniteNumberOrZero((itemValues as any)?.defiActiveTvl));
@@ -1114,10 +1120,10 @@ async function generateAggregatedHistoricalCharts(metadata: RWAMetadata[]): Prom
       }
 
       // update chart breakdown
-      updateBreakdownAndAssetTypes(chainBreakdownAndAssetTypes, m, timestamp, chains);
-      updateBreakdownAndAssetTypes(categoryBreakdownAndAssetTypes, m, timestamp, categoryItems);
-      updateBreakdownAndAssetTypes(platformBreakdownAndAssetTypes, m, timestamp, platformItems);
-      updateBreakdownAndAssetTypes(assetGroupBreakdownAndAssetTypes, m, timestamp, assetGroupItems);
+      updateBreakdownAndAssetTypes(chainBreakdownAndAssetTypes, m, timestamp, chains, chainBreakdownStartedItems);
+      updateBreakdownAndAssetTypes(categoryBreakdownAndAssetTypes, m, timestamp, categoryItems, categoryBreakdownStartedItems);
+      updateBreakdownAndAssetTypes(platformBreakdownAndAssetTypes, m, timestamp, platformItems, platformBreakdownStartedItems);
+      updateBreakdownAndAssetTypes(assetGroupBreakdownAndAssetTypes, m, timestamp, assetGroupItems, assetGroupBreakdownStartedItems);
     }
     processedCount++;
   }

--- a/defi/src/rwa/perps/aggregate.ts
+++ b/defi/src/rwa/perps/aggregate.ts
@@ -148,7 +148,7 @@ function buildBreakdownChartRows(
     const seriesLabel = String(getSeriesLabel(row) || UNKNOWN_PERPS_ASSET_GROUP);
     const metricValue = getMetricValue(row, key);
     if (!Number.isFinite(metricValue)) continue;
-    if (hasPerpsBreakdownData(row)) {
+    if (key === "markets" || hasPerpsBreakdownData(row)) {
       startedSeries.add(seriesLabel);
     } else if (!startedSeries.has(seriesLabel)) {
       continue;

--- a/defi/src/rwa/perps/aggregate.ts
+++ b/defi/src/rwa/perps/aggregate.ts
@@ -114,6 +114,10 @@ function getMetricValue(row: AggregateHistoricalRow, key: PerpsChartMetricKey): 
   return toFiniteNumberOrZero(row[key]);
 }
 
+function hasPerpsBreakdownData(row: AggregateHistoricalRow): boolean {
+  return row.openInterest !== 0 || row.volume24h !== 0;
+}
+
 function toOverviewSeriesLabel(row: AggregateHistoricalRow, breakdown: PerpsOverviewBreakdown): string {
   switch (breakdown) {
     case "venue":
@@ -135,6 +139,7 @@ function buildBreakdownChartRows(
   getSeriesLabel: (row: AggregateHistoricalRow) => string
 ): PerpsBreakdownChartRow[] {
   const byTimestamp = new Map<number, PerpsBreakdownChartRow>();
+  const startedSeries = new Set<string>();
 
   for (const row of rows) {
     const timestamp = Number(row.timestamp);
@@ -143,6 +148,11 @@ function buildBreakdownChartRows(
     const seriesLabel = String(getSeriesLabel(row) || UNKNOWN_PERPS_ASSET_GROUP);
     const metricValue = getMetricValue(row, key);
     if (!Number.isFinite(metricValue)) continue;
+    if (hasPerpsBreakdownData(row)) {
+      startedSeries.add(seriesLabel);
+    } else if (!startedSeries.has(seriesLabel)) {
+      continue;
+    }
 
     const existing = byTimestamp.get(timestamp) ?? { timestamp };
     existing[seriesLabel] = (existing[seriesLabel] ?? 0) + metricValue;

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -724,6 +724,12 @@ describe("buildOverviewBreakdownCharts", () => {
       { timestamp: 200, Meta: 4 },
       { timestamp: 300, Meta: 0 },
     ]);
+    expect(result["overview-breakdown/all/markets/baseasset.json"]).toEqual([
+      { timestamp: 100, Meta: 1, Gold: 1 },
+      { timestamp: 150, Meta: 1 },
+      { timestamp: 200, Meta: 1 },
+      { timestamp: 300, Meta: 1 },
+    ]);
   });
 });
 
@@ -808,6 +814,12 @@ describe("buildContractBreakdownCharts", () => {
       { timestamp: 150, "xyz:META": 0 },
       { timestamp: 200, "xyz:META": 4 },
       { timestamp: 300, "xyz:META": 0 },
+    ]);
+    expect(result["contract-breakdown/all/markets.json"]).toEqual([
+      { timestamp: 100, "xyz:META": 1, "flx:GOLD": 1 },
+      { timestamp: 150, "xyz:META": 1 },
+      { timestamp: 200, "xyz:META": 1 },
+      { timestamp: 300, "xyz:META": 1 },
     ]);
   });
 });

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -680,6 +680,51 @@ describe("buildOverviewBreakdownCharts", () => {
       { timestamp: 200, Bond: 5 },
     ]);
   });
+
+  it("omits zero-only pre-launch breakdown keys and keeps post-start zeroes", () => {
+    const result = buildOverviewBreakdownCharts(
+      [
+        { id: "xyz:meta", timestamp: 100, open_interest: "0", volume_24h: "0" },
+        { id: "flx:gold", timestamp: 100, open_interest: "7", volume_24h: "2" },
+        { id: "xyz:meta", timestamp: 150, open_interest: "5", volume_24h: "0" },
+        { id: "xyz:meta", timestamp: 200, open_interest: "12", volume_24h: "4" },
+        { id: "xyz:meta", timestamp: 300, open_interest: "0", volume_24h: "0" },
+      ],
+      [
+        {
+          id: "xyz:meta",
+          data: {
+            contract: "xyz:META",
+            venue: "xyz",
+            referenceAsset: "Meta",
+            referenceAssetGroup: "US Equities",
+          },
+        },
+        {
+          id: "flx:gold",
+          data: {
+            contract: "flx:GOLD",
+            venue: "flx",
+            referenceAsset: "Gold",
+            referenceAssetGroup: "Commodities",
+          },
+        },
+      ]
+    );
+
+    expect(result["overview-breakdown/all/openinterest/baseasset.json"]).toEqual([
+      { timestamp: 100, Gold: 7 },
+      { timestamp: 150, Meta: 5 },
+      { timestamp: 200, Meta: 12 },
+      { timestamp: 300, Meta: 0 },
+    ]);
+    expect(result["overview-breakdown/all/volume24h/baseasset.json"]).toEqual([
+      { timestamp: 100, Gold: 2 },
+      { timestamp: 150, Meta: 0 },
+      { timestamp: 200, Meta: 4 },
+      { timestamp: 300, Meta: 0 },
+    ]);
+  });
 });
 
 describe("buildContractBreakdownCharts", () => {
@@ -720,6 +765,49 @@ describe("buildContractBreakdownCharts", () => {
     ]);
     expect(result["contract-breakdown/assetgroup/commodities/volume24h.json"]).toEqual([
       { timestamp: 200, "flx:GOLD": 2 },
+    ]);
+  });
+
+  it("omits zero-only pre-launch contract keys and keeps post-start zeroes", () => {
+    const result = buildContractBreakdownCharts(
+      [
+        { id: "xyz:meta", timestamp: 100, open_interest: "0", volume_24h: "0" },
+        { id: "flx:gold", timestamp: 100, open_interest: "7", volume_24h: "2" },
+        { id: "xyz:meta", timestamp: 150, open_interest: "5", volume_24h: "0" },
+        { id: "xyz:meta", timestamp: 200, open_interest: "12", volume_24h: "4" },
+        { id: "xyz:meta", timestamp: 300, open_interest: "0", volume_24h: "0" },
+      ],
+      [
+        {
+          id: "xyz:meta",
+          data: {
+            contract: "xyz:META",
+            venue: "xyz",
+            referenceAssetGroup: "US Equities",
+          },
+        },
+        {
+          id: "flx:gold",
+          data: {
+            contract: "flx:GOLD",
+            venue: "flx",
+            referenceAssetGroup: "Commodities",
+          },
+        },
+      ]
+    );
+
+    expect(result["contract-breakdown/all/openinterest.json"]).toEqual([
+      { timestamp: 100, "flx:GOLD": 7 },
+      { timestamp: 150, "xyz:META": 5 },
+      { timestamp: 200, "xyz:META": 12 },
+      { timestamp: 300, "xyz:META": 0 },
+    ]);
+    expect(result["contract-breakdown/all/volume24h.json"]).toEqual([
+      { timestamp: 100, "flx:GOLD": 2 },
+      { timestamp: 150, "xyz:META": 0 },
+      { timestamp: 200, "xyz:META": 4 },
+      { timestamp: 300, "xyz:META": 0 },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- stop RWA aggregate charts from emitting zero-only pre-launch breakdown keys
- keep legitimate post-start zero values in RWA spot and perps breakdown charts
- add focused coverage for spot and perps breakdown emission behavior

## Validation
- ./node_modules/.bin/jest src/rwa/chartBreakdown.test.ts --runInBand --no-coverage --watchman=false
- ./node_modules/.bin/jest src/rwa/perps/perps.test.ts --runInBand --no-coverage --watchman=false