### PR TITLE
Add RektRadar (Security Extension) — Ethereum scam detector

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1064,5 +1064,24 @@ const data6: Protocol[] = [
     audit_links: ["https://docs.wedefin.com/technical-overview/audits"],
     listedAt: 1777310614,
   },
+  {
+    id: "7758",
+    name: "RektRadar",
+    address: null,
+    symbol: "-",
+    url: "https://rektradar.io",
+    description:
+      "Real-time Ethereum scam detector and rug pull analyzer. Combines on-chain forensics, mempool monitoring, and graph-based deployer clustering to score smart contracts 0-100 across 80+ risk flags (honeypot, hidden owner, dynamic taxes, brand-jacking).",
+    chain: "Ethereum",
+    logo: `${baseIconsUrl}/rektradar.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Security Extension",
+    chains: ["Ethereum"],
+    module: "dummy.js",
+    twitter: "mik3fly__",
+    listedAt: 1777334400,
+  },
 ];
 export default data6;


### PR DESCRIPTION
Adds [RektRadar](https://rektradar.io) to the **Security Extension** category alongside Pocket Universe, Carbon Browser, and Kerberus.

## What it does

RektRadar is a real-time Ethereum scam detector + rug pull analyzer that combines:

- **On-chain forensics** — deployer history, prior-rugs clustering, brand-jacking detection
- **Mempool monitoring** — catches token launches before liquidity-add confirms
- **Bytecode + source pattern matching** — 80+ risk flags (honeypot, hidden owner, dynamic taxes, blacklist, unrestricted_mint, etc.)
- **Live honeypot simulation** against three DEX pools

## Stats

- 66K+ Ethereum contracts analyzed
- ~450 scams flagged per 24h (current avg)
- Free tier (3 scans / day for anonymous, more with account)

## Reference doc

- Site: https://rektradar.io
- App: https://app.rektradar.io
- Guide: https://rektradar.io/blog/posts/how-to-detect-ethereum-scam-token/
- Twitter: https://x.com/mik3fly__

## Notes

- `module: dummy.js` — same pattern as other Security Extension entries (no on-chain TVL/fees to track)
- Logo at `${baseIconsUrl}/rektradar.jpg` — happy to provide via icons repo PR if needed
- `listedAt: 1777334400` (2026-04-28)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RektRadar protocol support to the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->