### PR TITLE
fix: preserve range hallmarks

### DIFF
--- a/defi/src/protocols/data.test.ts
+++ b/defi/src/protocols/data.test.ts
@@ -1,6 +1,6 @@
 import { importAdapter, } from "../utils/imports/importAdapter";
 import { chainCoingeckoIds, getChainDisplayName, normalizeChain, transformNewChainName } from "../utils/normalizeChain";
-import protocols from "./data";
+import protocols, { convertHallmarkStrings } from "./data";
 import parentProtocols, { parentProtocolsById } from "./parentProtocols";
 import treasuries from "./treasury";
 import operationalCosts from "../operationalCosts/daos";
@@ -8,6 +8,17 @@ import { sluggifyString } from "../utils/sluggify";
 import { ADAPTER_TYPES, AdaptorRecordType } from "../adaptors/data/types";
 const fs = require("fs");
 import loadAdaptorsData from "../adaptors/data";
+
+test("normalizes range hallmarks", () => {
+  expect(convertHallmarkStrings([
+    [["2024-01-01", "2024-01-03"], "Range hallmark"],
+    ["2024-01-04", "Single-day hallmark"],
+    [["bad-date", "2024-01-05"], "Bad range hallmark"],
+  ])).toEqual([
+    [[1704067200, 1704240000], "Range hallmark"],
+    [1704326400, "Single-day hallmark"],
+  ])
+});
 
 test("operational expenses: script has been run", async () => {
   const outputData = JSON.parse(fs.readFileSync(`${__dirname}/../operationalCosts/output/expenses.json`, 'utf8'));

--- a/defi/src/protocols/data/index.ts
+++ b/defi/src/protocols/data/index.ts
@@ -220,11 +220,7 @@ export function convertHallmarkStrings(hallmarks: any) {
     return item
   }).filter((item) => {
     if (typeof item?.[0] === 'number') return true
-    // if it is a range hallmark
-    if (Array.isArray(item?.[0]) && typeof item[0][0] === 'number' && typeof item[0][1] === 'number') {
-      return true
-    }
-    return false
+    return Array.isArray(item?.[0]) && typeof item[0][0] === 'number' && typeof item[0][1] === 'number'
   })
 }
 

--- a/defi/src/protocols/data/index.ts
+++ b/defi/src/protocols/data/index.ts
@@ -204,7 +204,7 @@ export function sortHallmarks(hallmarks: Hallmark[] | any) {
   });
 }
 
-function convertHallmarkStrings(hallmarks: any) {
+export function convertHallmarkStrings(hallmarks: any) {
   if (!Array.isArray(hallmarks)) return hallmarks
   return hallmarks.map((item) => {
     if (typeof item?.[0] === 'string') {
@@ -221,7 +221,7 @@ function convertHallmarkStrings(hallmarks: any) {
   }).filter((item) => {
     if (typeof item?.[0] === 'number') return true
     // if it is a range hallmark
-    if (Array.isArray(item?.[0] && typeof item[0][0] === 'number' && typeof item[0][1] === 'number')) {
+    if (Array.isArray(item?.[0]) && typeof item[0][0] === 'number' && typeof item[0][1] === 'number') {
       return true
     }
     return false


### PR DESCRIPTION
## Summary
- Fix range hallmark normalization so valid `[start, end]` hallmarks are preserved
- Add a regression test for date-string range hallmarks and invalid ranges

## Details
`convertHallmarkStrings()` already converts range hallmark date strings into timestamps, but the filter checked `Array.isArray()` on the result of a boolean expression. That caused valid range hallmarks to be filtered out after conversion.

## Test plan
- `npm test -- --runTestsByPath src/protocols/data.test.ts -t "normalizes range hallmarks" --runInBand --no-coverage`

Note: running the full `src/protocols/data.test.ts` suite currently hits an unrelated existing failure: `Protocol "SakuraSwap AMM" doesn't have chain "shape" on their module`.