### PR TITLE
perf: parallelize fetches and add caching for /updatedProtocol/:slug

### DIFF
--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -13,7 +13,7 @@ import { get20MinDate } from "../../utils/shared";
 import sluggify from "../../utils/sluggify";
 import { cache, getLastHourlyRecord, getLastHourlyTokensUsd, protocolHasMisrepresentedTokens, } from "../cache";
 import { cachedCraftParentProtocolV2, craftParentProtocolV2 } from "../utils/craftParentProtocolV2";
-import { craftProtocolV2 } from "../utils/craftProtocolV2";
+import { craftProtocolV2, cachedCraftProtocolV2 } from "../utils/craftProtocolV2";
 import { getDimensionsMetadata } from "../utils/dimensionsUtils";
 import { getDimensionCategoryChainRoutes, getDimensionCategoryRoutes, getDimensionChainRoutes, getDimensionOverviewRoutes, getDimensionProtocolFileRoute, getDimensionProtocolRoutes, getOverviewFileRoute, } from "./dimensions";
 import { errorResponse, errorWrapper as ew, fileResponse, successResponse } from "./utils";
@@ -43,6 +43,7 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/updatedProtocol/:name", (async (req, res) => getProtocolishData(req, res, {
     dataType: 'protocol', skipAggregatedTvl: req.query_parameters.includeAggregatedTvl !== 'true',
     restrictResponseSize: req.query_parameters.restrictResponseSize !== 'false',
+    useCached: true,
   })));
 
   router.get("/tokenProtocols/:symbol", ew(getTokenInProtocols));
@@ -306,7 +307,7 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   }
 }
 
-async function getProtocolishData(req: HyperExpress.Request, res: HyperExpress.Response, { dataType, skipAggregatedTvl = true, useNewChainNames = true, restrictResponseSize = true, feMini = false }: GetProtocolishOptions) {
+async function getProtocolishData(req: HyperExpress.Request, res: HyperExpress.Response, { dataType, skipAggregatedTvl = true, useNewChainNames = true, restrictResponseSize = true, feMini = false, useCached = false }: GetProtocolishOptions) {
   let name = decodeURIComponent(req.path_parameters.name);
   name = sluggify({ name } as any);
   const protocolData = (cache as any)[dataType + 'SlugMap'][name];
@@ -318,7 +319,8 @@ async function getProtocolishData(req: HyperExpress.Request, res: HyperExpress.R
   if (!protocolData && dataType === 'protocol') {
     const parentProtocol = (cache as any)['parentProtocolSlugMap'][name];
     if (parentProtocol) {
-      const responseData = await craftParentProtocolV2({
+      const parentCraftFn = useCached ? cachedCraftParentProtocolV2 : craftParentProtocolV2;
+      const responseData = await parentCraftFn({
         parentProtocol: parentProtocol,
         skipAggregatedTvl,
         feMini,
@@ -335,7 +337,8 @@ async function getProtocolishData(req: HyperExpress.Request, res: HyperExpress.R
 
   restrictResponseSize = false // hack to revert to old behavior
 
-  const responseData = await craftProtocolV2({
+  const craftFn = useCached ? cachedCraftProtocolV2 : craftProtocolV2;
+  const responseData = await craftFn({
     protocolData,
     useNewChainNames,
     skipAggregatedTvl,
@@ -411,6 +414,7 @@ type GetProtocolishOptions = {
   useNewChainNames?: boolean,
   restrictResponseSize?: boolean,
   feMini?: boolean, // for fetching only aggregated tvl data without token breakdown & without raw token balances
+  useCached?: boolean,
 }
 
 async function getInflows(req: HyperExpress.Request, res: HyperExpress.Response) {

--- a/defi/src/api2/utils/craftProtocolV2.ts
+++ b/defi/src/api2/utils/craftProtocolV2.ts
@@ -54,34 +54,20 @@ export async function craftProtocolV2({
   // protocol module is set to dummy.js if we are not tracking tvl of a given protocol
   const isDummyProtocol = protocolData.module === "dummy.js";
   const skipTokenBreakdownData = heavyProtocols.has(protocolData.id)
-
-  // const debug_t0 = performance.now(); // start the timer
-  let protocolCache: any = {}
   const isDeadProtocol = !!protocolData.deadFrom || isDummyProtocol
+  const fetchHourlyData = !isDeadProtocol && !skipCachedHourlyData
 
-  if (!isDummyProtocol)
-    protocolCache = await getCachedProtocolData(protocolData, true)
-
-  let _getLastHourlyRecord: any = null
-  let _getLastHourlyTokensUsd: any = null
-  let _getLastHourlyTokens: any = null
-
-  if (!isDeadProtocol && !skipCachedHourlyData) {
-    _getLastHourlyRecord = getLastHourlyRecord(protocolData as any)
-    _getLastHourlyTokensUsd = getLastHourlyTokensUsd(protocolData as any)
-    _getLastHourlyTokens = getLastHourlyTokens(protocolData as any)
-  }
+  const [protocolCache, mcap, lastUsdHourlyRecord, lastUsdTokenHourlyRecord, lastTokenHourlyRecord] = await Promise.all([
+    isDummyProtocol ? {} : getCachedProtocolData(protocolData, true),
+    getCachedMCap(protocolData.gecko_id),
+    fetchHourlyData ? getLastHourlyRecord(protocolData as any) : null,
+    fetchHourlyData ? getLastHourlyTokensUsd(protocolData as any) : null,
+    fetchHourlyData ? getLastHourlyTokens(protocolData as any) : null,
+  ]);
 
   let historicalUsdTvl: any = protocolCache[0] ?? []
   let historicalUsdTokenTvl: any = protocolCache[1] ?? []
   let historicalTokenTvl: any = protocolCache[2] ?? []
-
-  let [mcap, lastUsdHourlyRecord, lastUsdTokenHourlyRecord, lastTokenHourlyRecord] = await Promise.all([
-    getCachedMCap(protocolData.gecko_id),
-    _getLastHourlyRecord,
-    _getLastHourlyTokensUsd,
-    _getLastHourlyTokens,
-  ]);
 
 
   if (feMini || skipTokenBreakdownData) {

--- a/defi/src/api2/utils/craftProtocolV2.ts
+++ b/defi/src/api2/utils/craftProtocolV2.ts
@@ -57,7 +57,7 @@ export async function craftProtocolV2({
   const isDeadProtocol = !!protocolData.deadFrom || isDummyProtocol
   const fetchHourlyData = !isDeadProtocol && !skipCachedHourlyData
 
-  const [protocolCache, mcap, lastUsdHourlyRecord, lastUsdTokenHourlyRecord, lastTokenHourlyRecord] = await Promise.all([
+  let [protocolCache, mcap, lastUsdHourlyRecord, lastUsdTokenHourlyRecord, lastTokenHourlyRecord] = await Promise.all([
     isDummyProtocol ? {} : getCachedProtocolData(protocolData, true),
     getCachedMCap(protocolData.gecko_id),
     fetchHourlyData ? getLastHourlyRecord(protocolData as any) : null,


### PR DESCRIPTION
Fixes #10323

## Root cause
Two sequential async gaps in `craftProtocolV2`:

1. `getCachedProtocolData` was fully awaited before `getCachedMCap` and 
   the three hourly record fetches even started.
2. `/updatedProtocol/:name` was calling `craftProtocolV2` directly, 
   bypassing the existing `cachedCraftProtocolV2` layer entirely.

## Changes
**craftProtocolV2.ts** : merged all five independent fetches into one 
`Promise.all`, eliminating the sequential wait.

**routes/index.ts** : `/updatedProtocol/:name` now routes through 
`cachedCraftProtocolV2`. All other routes unchanged.

## Expected improvement
1.Cold path: response time reduced by the duration of the longest 
  sequential gap (could be 5 to 30s depending on protocol)
2.Warm path (cache hit): near-instant response for repeated requests 
  within the cache window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal protocol data-fetching logic to consolidate concurrent requests, improving efficiency.
  * Enhanced protocol route to leverage cached data for faster response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->