### PR TITLE
add usdnr and M prices on fluent

### DIFF
--- a/coins/src/adapters/other/others2.ts
+++ b/coins/src/adapters/other/others2.ts
@@ -253,4 +253,19 @@ export const adapters = {
       }, projectName: "other2",
     });
   },
+
+  USDnr: async (timestamp: number = 0) => {
+    const usdNr = "0xD48e565561416dE59DA1050ED70b8d75e8eF28f9";
+    const m = "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b";
+    const chain = "fluent";
+    const api = await getApi(chain, timestamp, true)
+    const bal = await api.call({ abi: "erc20:balanceOf", target: m, params: [usdNr] });
+    const supply = await api.call({ abi: "erc20:totalSupply", target: usdNr });
+
+    return getWrites({
+      chain, timestamp, pricesObject: {
+        [usdNr]: { price: bal / supply, underlying: m, }
+      }, projectName: "other2",
+    });
+  },
 };

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -16715,7 +16715,7 @@
     "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b": {
       "decimals": 6,
       "symbol": "M",
-      "to": "coingecko#usd-coin"
+      "to": "coingecko#wrappedm-by-m0"
     },
     "0x0000000000000000000000000000000000000000": {
       "to": "coingecko#bitcoin",
@@ -17038,6 +17038,13 @@
       "to": "coingecko#rocket-pool-eth",
       "decimals": 18,
       "symbol": "rETH"
+    }
+  },
+  "fluent": {
+     "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b": {
+      "to": "coingecko#wrappedm-by-m0",
+      "decimals": 6,
+      "symbol": "M"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USDnr token support on the Fluent chain with per-token price calculations.
  * Updated token mappings for the citrea network and introduced new Fluent network mapping with M token configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->