### PR TITLE
 Move misrepresented token lookup down in token search as importAdapter is sync

### DIFF
--- a/defi/src/getTokenInProtocols.ts
+++ b/defi/src/getTokenInProtocols.ts
@@ -3,8 +3,8 @@ import protocols, { Protocol} from "./protocols/data";
 import { getLastRecord, hourlyUsdTokensTvl } from "./utils/getLastRecord";
 import { importAdapter } from "./utils/imports/importAdapter";
 
-async function _protocolHasMisrepresentedTokens(protocol: Protocol){
-  const module = await importAdapter(protocol);
+function _protocolHasMisrepresentedTokens(protocol: Protocol){
+  const module = importAdapter(protocol);
   return module.misrepresentedTokens
 }
 
@@ -19,10 +19,7 @@ export async function getTokensInProtocolsInternal(symbol: string, {
 } = {}){
   return (await Promise.all(
     protocolList.map(async (protocol) => {
-      const [lastTvl, misrepresentedTokens] = await Promise.all([
-        getLastHourlyTokensUsd(protocol),
-        protocolHasMisrepresentedTokens(protocol),
-      ]);
+      const lastTvl = await getLastHourlyTokensUsd(protocol);
       if(typeof lastTvl?.tvl !== "object"){
         return null
       }
@@ -37,6 +34,7 @@ export async function getTokensInProtocolsInternal(symbol: string, {
       if(matches === 0){
         return null
       }
+      const misrepresentedTokens = protocolHasMisrepresentedTokens(protocol);
       return {
           name: protocol.name,
           category: protocol.category,

--- a/defi/src/getTokenInProtocols.ts
+++ b/defi/src/getTokenInProtocols.ts
@@ -3,7 +3,7 @@ import protocols, { Protocol} from "./protocols/data";
 import { getLastRecord, hourlyUsdTokensTvl } from "./utils/getLastRecord";
 import { importAdapter } from "./utils/imports/importAdapter";
 
-function _protocolHasMisrepresentedTokens(protocol: Protocol){
+function _protocolHasMisrepresentedTokens(protocol: Protocol): boolean{
   const module = importAdapter(protocol);
   return module.misrepresentedTokens
 }


### PR DESCRIPTION
### Summary
* change _protocolHasMisrepresentedTokens to sync as importAdapter is sync as well
*  Move misrepresented token lookup down in token search as importAdapter is sync and there is possible early exit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Protocol validation now checks TVL shape and match count first; token misrepresentation checks run only for protocols that pass these validations. Misrepresentation checks were changed from asynchronous/concurrent evaluation to synchronous/sequential evaluation and now return an explicit boolean result, yielding more predictable and consistent validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->