### PR TITLE
fix: correct Sophon Farm category from "Chain" to "Farm"

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -2485,7 +2485,7 @@ const data4: Protocol[] = [
     audits: "2",
     gecko_id: null,
     cmcId: null,
-    category: "Chain",
+    category: "Farm",
     chains: ["Sophon"],
     module: "sophon-farm/index.js",
     twitter: "sophon",


### PR DESCRIPTION
Fixes #9656

## Root cause
Sophon Farm had `category: "Chain"` in data4.ts. This caused it to be 
filtered out by `hiddenCategoriesFromUISet` (which excludes "Chain" and 
"CEX") in storeGetProtocols.ts at lines 169 and 280, making it absent 
from /lite/protocols2 and consequently missing from 
appMetadata-protocols.json and the app UI.

## Fix
Single field correction in data4.ts:
- `category: "Chain"` → `category: "Farm"`

"Farm" is an established category in this codebase (26 existing 
protocols use it) and correctly describes Sophon Farm's purpose: 
depositing tokens to farm Sophon Points redeemable for $SOPH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated protocol classification to improve organization and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->