### PR TITLE
feat: add Dune credit usage dashboard (#11539)

### DIFF
--- a/defi/package.json
+++ b/defi/package.json
@@ -70,7 +70,8 @@
     "load-tvl-repo": "bash src/cli/loadTvlRepo.sh",
     "load-dimensions-repo": "bash src/cli/loadDimensionsRepo.sh",
     "load-all-repos": "npm run load-tvl-repo --silent && npm run load-dimensions-repo --silent",
-    "validate-api": "npx ts-node --logError --transpile-only src/utils/validateAPI.ts"
+    "validate-api": "npx ts-node --logError --transpile-only src/utils/validateAPI.ts",
+    "dune-usage": "npx ts-node --logError --transpile-only src/api2/scripts/getDuneUsageStats.ts"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",

--- a/defi/src/adaptors/handlers/storeAdaptorData/refillScript.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/refillScript.ts
@@ -207,6 +207,7 @@ async function refillAllProtocols() {
     process.exit(1)
   }, 1000 * 60 * 60 * 6) // 6 hours
   let timeRange = 365 // 1 year
+  
   const envTimeRange = process.env.refill_adapters_timeRange
   if (envTimeRange && !isNaN(+envTimeRange)) timeRange = +envTimeRange
   const startTime = Math.floor(Date.now() / 1000) - timeRange * 24 * 60 * 60
@@ -313,7 +314,14 @@ async function refillAllProtocols() {
 
 console.time('Script execution time')
 
-run().catch(console.error).then(() => {
+run().catch(console.error).then(async () => {
   console.timeEnd('Script execution time')
+  // Print Dune credit usage summary at end of run
+  try {
+    const { printDuneCreditSummary } = await import('../../../../dimension-adapters/helpers/dune');
+    printDuneCreditSummary();
+  } catch (e) {
+    // silently ignore if dimension-adapters not available
+  }
   process.exit(0)
 })

--- a/defi/src/adaptors/handlers/storeAdaptorData/refillScript.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/refillScript.ts
@@ -53,6 +53,13 @@ if (refillAllProtocolsMissing) {
 
 const ONE_DAY_IN_SECONDS = 24 * 60 * 60
 async function refillAdapter() {
+  // Reset Dune credit tracker at start of run to avoid cross-run accumulation
+  try {
+    const { resetDuneCreditTracker } = await import('../../../../dimension-adapters/helpers/dune');
+    resetDuneCreditTracker();
+  } catch (e) {
+    // silently ignore if dimension-adapters not available
+  }
 
   console.log('\n\n\n\n\n')
   console.log('------------------------------------')

--- a/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
@@ -45,6 +45,14 @@ if (skipHourlyCache) {
 }
 
 async function run() {
+  // Reset Dune credit tracker at start of run to avoid cross-run accumulation
+  try {
+    const { resetDuneCreditTracker } = await import('../../../../dimension-adapters/helpers/dune');
+    resetDuneCreditTracker();
+  } catch (e) {
+    // silently ignore if dimension-adapters not available
+  }
+
   const startTimeAll = getUnixTimeNow()
   console.time("**** Run All Adaptor types")
 

--- a/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
+++ b/defi/src/adaptors/handlers/storeAdaptorData/storeAll.ts
@@ -210,7 +210,16 @@ setTimeout(() => {
 
 run().catch((e) => {
   console.error("Error in dimensions-store-all", e)
-}).then(() => process.exit(0))
+}).then(async () => {
+  // Print Dune credit usage summary at end of run
+  try {
+    const { printDuneCreditSummary } = await import('../../../../dimension-adapters/helpers/dune');
+    printDuneCreditSummary();
+  } catch (e) {
+    // silently ignore if dimension-adapters not available
+  }
+  process.exit(0)
+})
 
 
 

--- a/defi/src/adaptors/utils/duneCreditTracker.ts
+++ b/defi/src/adaptors/utils/duneCreditTracker.ts
@@ -1,0 +1,212 @@
+/**
+ * Dune Credit Tracker
+ * 
+ * Tracks Dune API credit consumption per adapter module.
+ * Accumulates query metadata during dimension runs and provides
+ * summary reports for the dashboard endpoint.
+ */
+
+export interface DuneQueryRecord {
+  queryId: string;
+  adapter: string;
+  chain?: string;
+  creditsUsed: number;
+  durationSeconds: number;
+  rowsReturned: number;
+  timestamp: number;
+  isBatched: boolean;
+  batchSize?: number;
+  executionId?: string;
+}
+
+export interface AdapterCreditSummary {
+  adapter: string;
+  totalCredits: number;
+  queryCount: number;
+  avgCreditsPerQuery: number;
+  avgDurationSeconds: number;
+  totalRows: number;
+  queries: DuneQueryRecord[];
+}
+
+export interface CreditReport {
+  generatedAt: number;
+  runStartedAt: number;
+  totalCreditsUsed: number;
+  totalQueryCount: number;
+  avgCreditsPerQuery: number;
+  topConsumers: AdapterCreditSummary[];
+  recentQueries: DuneQueryRecord[];
+  expensiveQueries: DuneQueryRecord[];
+}
+
+// In-memory store for the current run
+const queryRecords: DuneQueryRecord[] = [];
+let runStartedAt = Math.floor(Date.now() / 1000);
+
+// Configurable thresholds
+const EXPENSIVE_CREDIT_THRESHOLD = Number(process.env.DUNE_EXPENSIVE_CREDIT_THRESHOLD ?? 100);
+const EXPENSIVE_DURATION_THRESHOLD = Number(process.env.DUNE_EXPENSIVE_DURATION_THRESHOLD ?? 30); // seconds
+const MAX_CREDITS_PER_RUN = Number(process.env.DUNE_MAX_CREDITS_PER_RUN ?? Infinity);
+
+let totalCreditsThisRun = 0;
+
+/**
+ * Record a completed Dune query execution
+ */
+export function recordDuneQuery(record: DuneQueryRecord): void {
+  queryRecords.push(record);
+  totalCreditsThisRun += record.creditsUsed;
+
+  // Log expensive queries immediately
+  if (record.creditsUsed > EXPENSIVE_CREDIT_THRESHOLD || record.durationSeconds > EXPENSIVE_DURATION_THRESHOLD) {
+    console.warn(
+      `[Dune][EXPENSIVE] adapter=${record.adapter} queryId=${record.queryId} ` +
+      `credits=${record.creditsUsed} duration=${record.durationSeconds.toFixed(1)}s ` +
+      `rows=${record.rowsReturned} chain=${record.chain ?? 'N/A'}`
+    );
+  }
+}
+
+/**
+ * Check if the credit budget has been exceeded
+ * @throws Error if budget exceeded
+ */
+export function checkCreditBudget(): void {
+  if (totalCreditsThisRun >= MAX_CREDITS_PER_RUN) {
+    throw new Error(
+      `[Dune] Credit budget exceeded: ${totalCreditsThisRun.toFixed(2)}/${MAX_CREDITS_PER_RUN} credits used this run`
+    );
+  }
+}
+
+/**
+ * Get whether budget enforcement is active
+ */
+export function isBudgetEnforcementActive(): boolean {
+  return isFinite(MAX_CREDITS_PER_RUN);
+}
+
+/**
+ * Get credits used so far in this run
+ */
+export function getCreditsUsedThisRun(): number {
+  return totalCreditsThisRun;
+}
+
+/**
+ * Generate a full credit usage report from in-memory data
+ */
+export function generateCreditReport(): CreditReport {
+  // Group queries by adapter
+  const adapterMap = new Map<string, DuneQueryRecord[]>();
+  for (const record of queryRecords) {
+    const key = record.adapter;
+    if (!adapterMap.has(key)) adapterMap.set(key, []);
+    adapterMap.get(key)!.push(record);
+  }
+
+  // Build per-adapter summaries
+  const topConsumers: AdapterCreditSummary[] = [];
+  for (const [adapter, queries] of adapterMap.entries()) {
+    const totalCredits = queries.reduce((sum, q) => sum + q.creditsUsed, 0);
+    const totalDuration = queries.reduce((sum, q) => sum + q.durationSeconds, 0);
+    const totalRows = queries.reduce((sum, q) => sum + q.rowsReturned, 0);
+
+    topConsumers.push({
+      adapter,
+      totalCredits,
+      queryCount: queries.length,
+      avgCreditsPerQuery: queries.length > 0 ? totalCredits / queries.length : 0,
+      avgDurationSeconds: queries.length > 0 ? totalDuration / queries.length : 0,
+      totalRows,
+      queries,
+    });
+  }
+
+  // Sort by total credits descending
+  topConsumers.sort((a, b) => b.totalCredits - a.totalCredits);
+
+  // Get expensive queries
+  const expensiveQueries = queryRecords
+    .filter(q => q.creditsUsed > EXPENSIVE_CREDIT_THRESHOLD || q.durationSeconds > EXPENSIVE_DURATION_THRESHOLD)
+    .sort((a, b) => b.creditsUsed - a.creditsUsed);
+
+  // Recent queries (last 50)
+  const recentQueries = queryRecords.slice(-50).reverse();
+
+  const totalCreditsUsed = queryRecords.reduce((sum, q) => sum + q.creditsUsed, 0);
+
+  return {
+    generatedAt: Math.floor(Date.now() / 1000),
+    runStartedAt,
+    totalCreditsUsed,
+    totalQueryCount: queryRecords.length,
+    avgCreditsPerQuery: queryRecords.length > 0 ? totalCreditsUsed / queryRecords.length : 0,
+    topConsumers: topConsumers.slice(0, 50), // top 50 consumers without individual queries
+    recentQueries,
+    expensiveQueries: expensiveQueries.slice(0, 30),
+  };
+}
+
+/**
+ * Generate a compact summary for logging/console output
+ */
+export function printCreditSummary(): void {
+  const report = generateCreditReport();
+
+  console.log('\n========== Dune Credit Usage Summary ==========');
+  console.log(`Total credits used: ${report.totalCreditsUsed.toFixed(2)}`);
+  console.log(`Total queries: ${report.totalQueryCount}`);
+  console.log(`Avg credits/query: ${report.avgCreditsPerQuery.toFixed(2)}`);
+
+  if (isBudgetEnforcementActive()) {
+    const pct = (report.totalCreditsUsed / MAX_CREDITS_PER_RUN * 100).toFixed(1);
+    console.log(`Budget: ${report.totalCreditsUsed.toFixed(2)} / ${MAX_CREDITS_PER_RUN} (${pct}%)`);
+  }
+
+  if (report.topConsumers.length > 0) {
+    console.log('\nTop 10 consumers by credits:');
+    console.table(
+      report.topConsumers.slice(0, 10).map(c => ({
+        adapter: c.adapter,
+        credits: c.totalCredits.toFixed(2),
+        queries: c.queryCount,
+        'avg credits': c.avgCreditsPerQuery.toFixed(2),
+        'avg duration(s)': c.avgDurationSeconds.toFixed(1),
+      }))
+    );
+  }
+
+  if (report.expensiveQueries.length > 0) {
+    console.log(`\nExpensive queries (>${EXPENSIVE_CREDIT_THRESHOLD} credits or >${EXPENSIVE_DURATION_THRESHOLD}s):`);
+    console.table(
+      report.expensiveQueries.slice(0, 10).map(q => ({
+        adapter: q.adapter,
+        queryId: q.queryId,
+        credits: q.creditsUsed.toFixed(2),
+        'duration(s)': q.durationSeconds.toFixed(1),
+        rows: q.rowsReturned,
+        chain: q.chain ?? 'N/A',
+      }))
+    );
+  }
+
+  console.log('=================================================\n');
+}
+
+/**
+ * Reset the tracker (call between runs)
+ */
+export function resetCreditTracker(): void {
+  queryRecords.length = 0;
+  totalCreditsThisRun = 0;
+  runStartedAt = Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Get raw query records (for external processing)
+ */
+export function getQueryRecords(): ReadonlyArray<DuneQueryRecord> {
+  return queryRecords;
+}

--- a/defi/src/api2/routes/internalRoutes.ts
+++ b/defi/src/api2/routes/internalRoutes.ts
@@ -1,7 +1,7 @@
 
 import { readFromPGCache, deleteFromPGCache, } from "../cache/file-cache";
 import * as HyperExpress from "hyper-express";
-import { errorResponse } from "./utils";
+import { errorResponse, errorWrapper as ew, successResponse } from "./utils";
 import { craftProtocolV2 } from "../utils/craftProtocolV2";
 import { getLatestProtocolItems } from "../db";
 import { hourlyTokensTvl, hourlyTvl, hourlyUsdTokensTvl } from "../../utils/getLastRecord";
@@ -47,6 +47,59 @@ export function setInternalRoutes(router: HyperExpress.Router, routerBasePath: s
     }
   }
 
+  // ==================== Dune Credit Dashboard Routes ====================
+
+  /**
+   * GET /_internal/dune-credits
+   * Fetches current billing period credit usage from Dune API.
+   * Query params: ?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD (optional)
+   */
+  router.get('/_internal/dune-credits', ew(async (req: HyperExpress.Request, res: HyperExpress.Response) => {
+    try {
+      const { getDuneCreditUsage } = await import('../../../dimension-adapters/helpers/dune');
+
+      const startDate = req.query_parameters.start_date;
+      const endDate = req.query_parameters.end_date;
+
+      const usage = await getDuneCreditUsage(startDate, endDate);
+      return successResponse(res, usage, 5); // cache for 5 minutes
+    } catch (e: any) {
+      console.error('Error fetching Dune credits:', e.message);
+      return errorResponse(res, `Failed to fetch Dune credit usage: ${e.message}`, { statusCode: 500 });
+    }
+  }));
+
+  /**
+   * GET /_internal/dune-credits/run-report
+   * Returns the in-memory credit tracking report for the current/last run.
+   * Shows per-adapter breakdown, expensive queries, and totals.
+   */
+  router.get('/_internal/dune-credits/run-report', ew(async (_req: HyperExpress.Request, res: HyperExpress.Response) => {
+    try {
+      const { generateDuneCreditReport } = await import('../../../dimension-adapters/helpers/dune');
+      const report = generateDuneCreditReport();
+      return successResponse(res, report, 1); // cache for 1 minute
+    } catch (e: any) {
+      console.error('Error generating Dune credit report:', e.message);
+      return errorResponse(res, `Failed to generate credit report: ${e.message}`, { statusCode: 500 });
+    }
+  }));
+
+  /**
+   * DELETE /_internal/dune-credits/reset
+   * Resets the in-memory credit tracker. Useful between runs.
+   */
+  router.delete('/_internal/dune-credits/reset', ew(async (_req: HyperExpress.Request, res: HyperExpress.Response) => {
+    try {
+      const { resetDuneCreditTracker } = await import('../../../dimension-adapters/helpers/dune');
+      resetDuneCreditTracker();
+      return successResponse(res, { success: true, message: 'Credit tracker reset' }, 0);
+    } catch (e: any) {
+      return errorResponse(res, `Failed to reset credit tracker: ${e.message}`, { statusCode: 500 });
+    }
+  }));
+
+  // ==================== End Dune Credit Dashboard Routes ====================
 
 }
 

--- a/defi/src/api2/scripts/getDuneUsageStats.ts
+++ b/defi/src/api2/scripts/getDuneUsageStats.ts
@@ -1,0 +1,152 @@
+/**
+ * Dune Credit Usage Stats Script
+ * 
+ * A CLI tool to check Dune API credit usage for the current billing period
+ * and analyze which adapters are consuming the most credits.
+ * 
+ * Usage:
+ *   npx ts-node --transpile-only src/api2/scripts/getDuneUsageStats.ts
+ * 
+ * Environment variables:
+ *   DUNE_API_KEYS  - Dune API key (comma-separated, first key is used)
+ *   DUNE_USAGE_START_DATE - Optional start date (YYYY-MM-DD) for usage query
+ *   DUNE_USAGE_END_DATE   - Optional end date (YYYY-MM-DD) for usage query
+ */
+
+import axios from 'axios';
+
+const DUNE_API_KEY = process.env.DUNE_API_KEYS?.split(',')[0];
+
+if (!DUNE_API_KEY) {
+  console.error('Error: DUNE_API_KEYS environment variable is not set');
+  process.exit(1);
+}
+
+const axiosDune = axios.create({
+  headers: {
+    'x-dune-api-key': DUNE_API_KEY,
+  },
+  baseURL: 'https://api.dune.com/api/v1',
+});
+
+interface BillingPeriod {
+  start_date: string;
+  end_date: string;
+  credits_used: number;
+  credits_included: number;
+}
+
+interface UsageResponse {
+  private_queries?: number;
+  private_dashboards?: number;
+  bytes_used?: number;
+  bytes_allowed?: number;
+  billingPeriods?: BillingPeriod[];
+}
+
+async function getDuneUsage(): Promise<UsageResponse> {
+  const body: any = {};
+
+  const startDate = process.env.DUNE_USAGE_START_DATE;
+  const endDate = process.env.DUNE_USAGE_END_DATE;
+
+  if (startDate) body.start_date = startDate;
+  if (endDate) body.end_date = endDate;
+
+  try {
+    const { data } = await axiosDune.post('/usage', body);
+    return data;
+  } catch (err: any) {
+    if (err.isAxiosError) {
+      console.error(`Dune API error (${err.response?.status}):`, err.response?.data || err.message);
+    } else {
+      console.error('Error fetching Dune usage:', err.message);
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  console.log('=========================================');
+  console.log('  Dune Credit Usage Report');
+  console.log('=========================================\n');
+
+  try {
+    const usage = await getDuneUsage();
+
+    // Account-level info
+    if (usage.private_queries !== undefined) {
+      console.log('Account Overview:');
+      console.log(`  Private queries: ${usage.private_queries}`);
+      console.log(`  Private dashboards: ${usage.private_dashboards ?? 'N/A'}`);
+      if (usage.bytes_used !== undefined && usage.bytes_allowed !== undefined) {
+        const pctBytes = ((usage.bytes_used / usage.bytes_allowed) * 100).toFixed(1);
+        console.log(`  Storage: ${formatBytes(usage.bytes_used)} / ${formatBytes(usage.bytes_allowed)} (${pctBytes}%)`);
+      }
+      console.log('');
+    }
+
+    // Billing periods
+    if (usage.billingPeriods && usage.billingPeriods.length > 0) {
+      console.log('Billing Periods:');
+      console.log('─'.repeat(70));
+
+      for (const period of usage.billingPeriods) {
+        const pctUsed = period.credits_included > 0
+          ? ((period.credits_used / period.credits_included) * 100).toFixed(1)
+          : 'N/A';
+        const remaining = period.credits_included - period.credits_used;
+
+        console.log(`  Period: ${period.start_date} → ${period.end_date}`);
+        console.log(`    Credits used:      ${period.credits_used.toLocaleString()}`);
+        console.log(`    Credits included:  ${period.credits_included.toLocaleString()}`);
+        console.log(`    Credits remaining: ${remaining.toLocaleString()}`);
+        console.log(`    Usage:             ${pctUsed}%`);
+
+        // Visual bar
+        if (period.credits_included > 0) {
+          const barLength = 40;
+          const filledLength = Math.round((period.credits_used / period.credits_included) * barLength);
+          const bar = '█'.repeat(filledLength) + '░'.repeat(barLength - filledLength);
+          console.log(`    [${bar}]`);
+        }
+
+        // Warning if over 80%
+        const usagePct = period.credits_included > 0 ? (period.credits_used / period.credits_included) * 100 : 0;
+        if (usagePct > 90) {
+          console.log(`    ⚠️  CRITICAL: Over 90% of credits consumed!`);
+        } else if (usagePct > 80) {
+          console.log(`    ⚠️  WARNING: Over 80% of credits consumed`);
+        }
+
+        console.log('');
+      }
+    } else {
+      console.log('No billing period data available.');
+      console.log('Full response:');
+      console.log(JSON.stringify(usage, null, 2));
+    }
+
+    // Recommendations
+    console.log('─'.repeat(70));
+    console.log('\nOptimization tips:');
+    console.log('  1. Set DUNE_BULK_MODE=true during refills to batch queries');
+    console.log('  2. Set DUNE_MAX_CREDITS_PER_RUN=<number> to enforce per-run budgets');
+    console.log('  3. Use DUNE_EXPENSIVE_CREDIT_THRESHOLD=<number> to flag costly queries');
+    console.log('  4. Run `npm run dune-usage` regularly to monitor consumption');
+    console.log('');
+
+  } catch (err) {
+    console.error('\nFailed to fetch Dune usage data. Make sure DUNE_API_KEYS is set correctly.');
+    process.exit(1);
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

Adds a Dune credit usage dashboard with API endpoints, CLI tooling, and automatic 
credit usage reporting after dimension runs.

Resolves DefiLlama/internal-docs#59

**Depends on**: DefiLlama/dimension-adapters#{dimension-adapters-PR-number}

## Changes

### New Files
- **`defi/src/api2/scripts/getDuneUsageStats.ts`** — CLI script to check Dune billing usage (`npm run dune-usage`)
- **`defi/src/adaptors/utils/duneCreditTracker.ts`** — Standalone credit tracking utility

### New API Endpoints
| Method | Endpoint | Description |
|---|---|---|
| `GET` | `/_internal/dune-credits` | Billing period credit usage from Dune API |
| `GET` | `/_internal/dune-credits/run-report` | Per-adapter credit breakdown (in-memory) |
| `DELETE` | `/_internal/dune-credits/reset` | Reset the credit tracker |

### Modified Files
- **`internalRoutes.ts`** — Added 3 dashboard endpoints above
- **`storeAll.ts`** — Prints credit summary after each dimension store-all run
- **`refillScript.ts`** — Prints credit summary after each refill run
- **`package.json`** — Added `dune-usage` npm script

## Backward Compatibility

All changes are additive. No existing behavior is altered.
