### PR TITLE
Optimize emissions breakdown aggregation

### DIFF
--- a/defi/src/api2/utils/emissionsUtils.test.ts
+++ b/defi/src/api2/utils/emissionsUtils.test.ts
@@ -1,0 +1,117 @@
+jest.mock('../../utils/r2', () => ({
+  getR2JSONString: jest.fn(),
+}));
+
+jest.mock('../cache/file-cache', () => ({
+  storeRouteData: jest.fn(),
+}));
+
+import { getR2JSONString } from '../../utils/r2';
+import { storeRouteData } from '../cache/file-cache';
+import { storeEmissionsCache } from './emissionsUtils';
+
+const mockedGetR2JSONString = getR2JSONString as jest.MockedFunction<typeof getR2JSONString>;
+const mockedStoreRouteData = storeRouteData as jest.MockedFunction<typeof storeRouteData>;
+
+const timestamp = (date: string) => Math.floor(Date.parse(`${date}T00:00:00Z`) / 1000);
+
+describe('storeEmissionsCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('pre-indexed breakdown aggregation matches previous timestamp lookup semantics', async () => {
+    const janTimestamp = timestamp('2024-01-15');
+    const febTimestamp = timestamp('2024-02-15');
+    const unusedTimestamp = timestamp('2024-03-15');
+
+    mockedGetR2JSONString.mockImplementation(async (key: string) => {
+      if (key === 'emissionsProtocolsList') return ['test-protocol'] as any;
+      if (key === 'emissions/test-protocol') {
+        return {
+          unlockUsdChart: [
+            [janTimestamp, 100],
+            [febTimestamp, 200],
+          ],
+          componentData: {
+            sections: {
+              sectionA: {
+                components: {
+                  incentiveA: {
+                    name: 'Incentive A',
+                    methodology: 'A methodology',
+                    isIncentive: true,
+                    unlockUsdChart: [
+                      [janTimestamp, 10],
+                      [janTimestamp, 999], // previous .find() implementation used the first match
+                      [febTimestamp, 20],
+                      [unusedTimestamp, 30],
+                    ],
+                  },
+                  incentiveB: {
+                    name: 'Incentive B',
+                    methodology: 'B methodology',
+                    isIncentive: true,
+                    unlockUsdChart: [[janTimestamp, 1]],
+                  },
+                  nonIncentive: {
+                    name: 'Non Incentive',
+                    methodology: 'Non incentive methodology',
+                    isIncentive: false,
+                    unlockUsdChart: [[janTimestamp, 500]],
+                  },
+                },
+              },
+            },
+          },
+        } as any;
+      }
+      return null as any;
+    });
+
+    await expect(storeEmissionsCache()).resolves.toEqual({ error: null });
+
+    expect(mockedStoreRouteData).toHaveBeenCalledTimes(1);
+    expect(mockedStoreRouteData).toHaveBeenCalledWith('emissions/test-protocol', {
+      id: 'test-protocol',
+      breakdownMethodology: {
+        'Incentive A': 'A methodology',
+        'Incentive B': 'B methodology',
+        'Non Incentive': 'Non incentive methodology',
+      },
+      monthly: {
+        '2024-01': {
+          value: 100,
+          'by-label': {
+            'Incentive A': 10,
+            'Incentive B': 1,
+          },
+        },
+        '2024-02': {
+          value: 200,
+          'by-label': {
+            'Incentive A': 20,
+          },
+        },
+      },
+      quarterly: {
+        '2024-Q1': {
+          value: 300,
+          'by-label': {
+            'Incentive A': 30,
+            'Incentive B': 1,
+          },
+        },
+      },
+      yearly: {
+        '2024': {
+          value: 300,
+          'by-label': {
+            'Incentive A': 30,
+            'Incentive B': 1,
+          },
+        },
+      },
+    });
+  });
+});

--- a/defi/src/api2/utils/emissionsUtils.ts
+++ b/defi/src/api2/utils/emissionsUtils.ts
@@ -21,15 +21,10 @@ export async function storeEmissionsCache(): Promise<{error: string | null}> {
     if (_emissionsData && _emissionsData.unlockUsdChart) {
       const hasBreakdownData = !!_emissionsData.componentData && !!_emissionsData.componentData.sections;
 
+      let breakdownLabelsByTimestamp: Record<number, Record<string, number>> = {};
       if (hasBreakdownData) {
         const breakdownMethodology: Record<string, string> = {};
-        for (const section of Object.values(_emissionsData.componentData.sections)) {
-          const s = section as any;
-          for (const component of Object.values(s.components || {})) {
-            const c = component as any;
-            if (c.methodology && c.name) breakdownMethodology[c.name] = c.methodology;
-          }
-        }
+        breakdownLabelsByTimestamp = buildBreakdownLabelsByTimestamp(_emissionsData.componentData.sections, breakdownMethodology);
         if (Object.keys(breakdownMethodology).length) emissionsProtocolData.breakdownMethodology = breakdownMethodology;
       }
 
@@ -49,7 +44,7 @@ export async function storeEmissionsCache(): Promise<{error: string | null}> {
           
           if (hasBreakdownData) {
             (emissionsProtocolData as any)[timeframe][timeframeKey]['by-label'] = (emissionsProtocolData as any)[timeframe][timeframeKey]['by-label'] || {};
-            const breakdownLabels: any = findBreakdownLabelsAtTimestamp(_emissionsData.componentData.sections, timestamp);
+            const breakdownLabels = breakdownLabelsByTimestamp[timestamp] ?? {};
             for (const [label, value] of Object.entries(breakdownLabels)) {
               (emissionsProtocolData as any)[timeframe][timeframeKey]['by-label'][label] = (emissionsProtocolData as any)[timeframe][timeframeKey]['by-label'][label] || 0;
               (emissionsProtocolData as any)[timeframe][timeframeKey]['by-label'][label] += Number(value);
@@ -63,21 +58,26 @@ export async function storeEmissionsCache(): Promise<{error: string | null}> {
   }
   
   // helper function
-  function findBreakdownLabelsAtTimestamp(sections: any, timestamp: number): any {
-    const labels: Record<string, number> = {};
+  function buildBreakdownLabelsByTimestamp(sections: any, breakdownMethodology: Record<string, string>): Record<number, Record<string, number>> {
+    const labelsByTimestamp: Record<number, Record<string, number>> = {};
     for (const section of Object.values(sections)) {
-      for (const component of Object.values((section as any).components)) {
-        const compomentItem = component as any;
-        if (compomentItem.name && compomentItem.unlockUsdChart && compomentItem.isIncentive) {
-          const label = compomentItem.name;
-          const item = compomentItem.unlockUsdChart.find((item: any) => item[0] === timestamp)
-          if (item) {
-            labels[label] = Number(item[1]);
+      for (const component of Object.values((section as any).components || {})) {
+        const componentItem = component as any;
+        if (componentItem.methodology && componentItem.name) breakdownMethodology[componentItem.name] = componentItem.methodology;
+        if (componentItem.name && componentItem.unlockUsdChart && componentItem.isIncentive) {
+          const label = componentItem.name;
+          const seenTimestamps = new Set<number>();
+          for (const item of componentItem.unlockUsdChart) {
+            const timestamp = item[0];
+            if (seenTimestamps.has(timestamp)) continue;
+            seenTimestamps.add(timestamp);
+            labelsByTimestamp[timestamp] = labelsByTimestamp[timestamp] || {};
+            labelsByTimestamp[timestamp][label] = Number(item[1]);
           }
         }
       }
     }
-    return labels;
+    return labelsByTimestamp;
   }
 
   try {


### PR DESCRIPTION
### Summary
* Pre-index emissions component breakdowns by timestamp before aggregating cache data
* Avoid repeated .find() scans across component unlock charts for every main chart timestamp
* Reuse the same component traversal to collect breakdown methodology
* Preserve previous behavior for duplicate component timestamps by keeping the first value
* Unit test for compatibility testing (you can cherry-pick commit with the test into main and make sure it works as well)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for emissions cache storage and validation of aggregated data structures.

* **Refactor**
  * Optimized emissions data aggregation logic to improve performance through streamlined breakdown label processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->