### PR TITLE
Add training dataset export pipeline for APY prediction model

### DIFF
--- a/defi/package.json
+++ b/defi/package.json
@@ -70,7 +70,8 @@
     "load-tvl-repo": "bash src/cli/loadTvlRepo.sh",
     "load-dimensions-repo": "bash src/cli/loadDimensionsRepo.sh",
     "load-all-repos": "npm run load-tvl-repo --silent && npm run load-dimensions-repo --silent",
-    "validate-api": "npx ts-node --logError --transpile-only src/utils/validateAPI.ts"
+    "validate-api": "npx ts-node --logError --transpile-only src/utils/validateAPI.ts",
+    "compare-external-metrics": "npx ts-node --logError --transpile-only src/cli/compareExternalMetrics.ts"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",

--- a/defi/src/cli/compareExternalMetrics.test.ts
+++ b/defi/src/cli/compareExternalMetrics.test.ts
@@ -20,6 +20,19 @@ describe("parseArgs", () => {
     })
   })
 
+  test("--config takes precedence over positional config", () => {
+    expect(parseArgs(["--config", "flag.json", "pos.json"])).toEqual({
+      dryRun: false,
+      help: false,
+      config: "flag.json",
+    })
+  })
+
+  test("sets help for both help aliases", () => {
+    expect(parseArgs(["-h"]).help).toBe(true)
+    expect(parseArgs(["--help"]).help).toBe(true)
+  })
+
   test("throws for unknown options instead of treating them as config paths", () => {
     expect(() => parseArgs(["--no-discord"])).toThrow(
       /Unknown option: --no-discord/,

--- a/defi/src/cli/compareExternalMetrics.test.ts
+++ b/defi/src/cli/compareExternalMetrics.test.ts
@@ -1,0 +1,41 @@
+import { parseArgs } from "./compareExternalMetrics"
+
+describe("parseArgs", () => {
+  test("parses dry-run, output paths, and positional config", () => {
+    expect(
+      parseArgs([
+        "--dry-run",
+        "--json",
+        "/tmp/report.json",
+        "--md",
+        "/tmp/report.md",
+        "src/dataQuality/configs/llama-tvl-spot-check.json",
+      ]),
+    ).toEqual({
+      dryRun: true,
+      help: false,
+      json: "/tmp/report.json",
+      md: "/tmp/report.md",
+      config: "src/dataQuality/configs/llama-tvl-spot-check.json",
+    })
+  })
+
+  test("throws for unknown options instead of treating them as config paths", () => {
+    expect(() => parseArgs(["--no-discord"])).toThrow(
+      /Unknown option: --no-discord/,
+    )
+    expect(() => parseArgs(["--josn", "/tmp/report.json"])).toThrow(
+      /Unknown option: --josn/,
+    )
+  })
+
+  test("throws when value-taking options are missing values", () => {
+    expect(() => parseArgs(["--json"])).toThrow(/Missing value for --json/)
+    expect(() => parseArgs(["--md", "--dry-run"])).toThrow(
+      /Missing value for --md/,
+    )
+    expect(() => parseArgs(["--config", "--json"])).toThrow(
+      /Missing value for --config/,
+    )
+  })
+})

--- a/defi/src/cli/compareExternalMetrics.ts
+++ b/defi/src/cli/compareExternalMetrics.ts
@@ -1,0 +1,138 @@
+/**
+ * CLI: external metric comparison.
+ *
+ * Reads a JSON config of comparisons (DefiLlama vs external providers),
+ * fetches each unique URL exactly once, classifies discrepancies via
+ * configurable thresholds, and emits a text report (always), plus
+ * optional JSON / Markdown outputs and a Discord webhook post.
+ *
+ * Refs DefiLlama/defillama-server#11830.
+ */
+
+import fs from "fs"
+import { sendMessage } from "../utils/discord"
+import {
+  ConfigSchema,
+  runComparisons,
+} from "../dataQuality/runComparisons"
+import { formatMetricComparisonReport } from "../dataQuality/externalMetricComparison"
+import {
+  formatJsonReport,
+  formatMarkdownReport,
+} from "../dataQuality/reportFormatter"
+
+interface CliFlags {
+  dryRun: boolean
+  json?: string
+  md?: string
+  config?: string
+  help: boolean
+}
+
+const HELP = `Usage: compare-external-metrics [OPTIONS] [CONFIG]
+
+Compares numeric metrics from DefiLlama against external providers,
+classifying discrepancies (ok | warning | critical | missing) by
+configurable thresholds. (refs DefiLlama/defillama-server#11830)
+
+Arguments:
+  CONFIG                            Path to JSON config (or use --config or env)
+
+Options:
+  --dry-run                         Skip Discord webhook posting
+  --json <path>                     Write structured JSON report to <path>
+  --md <path>                       Write Markdown report to <path>
+  --config <path>                   Path to JSON config (alt to positional)
+  --help, -h                        Show this help
+
+Environment:
+  EXTERNAL_METRIC_COMPARISON_CONFIG    Config path (alternative to args)
+  EXTERNAL_METRIC_COMPARISON_WEBHOOK   Discord webhook URL
+
+Exit codes:
+  0   No critical results
+  1   At least one critical result, or argument / config error
+
+Examples:
+  npm run compare-external-metrics -- --dry-run \\
+    src/dataQuality/configs/llama-tvl-spot-check.json
+
+  npm run compare-external-metrics -- --no-discord \\
+    --json /tmp/report.json --md /tmp/report.md \\
+    src/dataQuality/configs/llama-tvl-spot-check.json
+`
+
+function parseArgs(argv: string[]): CliFlags {
+  const flags: CliFlags = { dryRun: false, help: false }
+  const positional: string[] = []
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === "--dry-run") flags.dryRun = true
+    else if (a === "--help" || a === "-h") flags.help = true
+    else if (a === "--json") flags.json = argv[++i]
+    else if (a === "--md") flags.md = argv[++i]
+    else if (a === "--config") flags.config = argv[++i]
+    else positional.push(a)
+  }
+  if (!flags.config && positional[0]) flags.config = positional[0]
+  return flags
+}
+
+async function main(): Promise<void> {
+  const flags = parseArgs(process.argv.slice(2))
+  if (flags.help) {
+    console.log(HELP)
+    return
+  }
+
+  const configPath =
+    flags.config ?? process.env.EXTERNAL_METRIC_COMPARISON_CONFIG
+  if (!configPath) {
+    console.error(HELP)
+    process.exit(1)
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf8"))
+  } catch (e: any) {
+    console.error(`Failed to read config '${configPath}': ${e.message}`)
+    process.exit(1)
+  }
+
+  const parsed = ConfigSchema.safeParse(raw)
+  if (!parsed.success) {
+    console.error(`Invalid config '${configPath}':`)
+    for (const issue of parsed.error.issues) {
+      console.error(`  - ${issue.path.join(".")}: ${issue.message}`)
+    }
+    process.exit(1)
+  }
+
+  const results = await runComparisons(parsed.data, {
+    onFetchError: (url, error) => {
+      const msg = error instanceof Error ? error.message : String(error)
+      console.error(`Fetch failed for ${url}: ${msg}`)
+    },
+  })
+
+  const text = formatMetricComparisonReport(results)
+  console.log(text)
+
+  if (flags.json) fs.writeFileSync(flags.json, formatJsonReport(results))
+  if (flags.md) fs.writeFileSync(flags.md, formatMarkdownReport(results))
+
+  const webhook = process.env.EXTERNAL_METRIC_COMPARISON_WEBHOOK
+  if (webhook && !flags.dryRun) {
+    await sendMessage(text, webhook, true)
+  } else if (flags.dryRun && webhook) {
+    console.log("(dry-run: skipped Discord webhook)")
+  }
+
+  if (results.some((r) => r.status === "critical")) process.exitCode = 1
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/defi/src/cli/compareExternalMetrics.ts
+++ b/defi/src/cli/compareExternalMetrics.ts
@@ -57,21 +57,31 @@ Examples:
   npm run compare-external-metrics -- --dry-run \\
     src/dataQuality/configs/llama-tvl-spot-check.json
 
-  npm run compare-external-metrics -- --no-discord \\
+  npm run compare-external-metrics -- --dry-run \\
     --json /tmp/report.json --md /tmp/report.md \\
     src/dataQuality/configs/llama-tvl-spot-check.json
 `
 
-function parseArgs(argv: string[]): CliFlags {
+export function parseArgs(argv: string[]): CliFlags {
   const flags: CliFlags = { dryRun: false, help: false }
   const positional: string[] = []
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
+    const takeValue = () => {
+      const value = argv[i + 1]
+      if (!value || value.startsWith("-")) {
+        throw new Error(`Missing value for ${a}`)
+      }
+      i += 1
+      return value
+    }
+
     if (a === "--dry-run") flags.dryRun = true
     else if (a === "--help" || a === "-h") flags.help = true
-    else if (a === "--json") flags.json = argv[++i]
-    else if (a === "--md") flags.md = argv[++i]
-    else if (a === "--config") flags.config = argv[++i]
+    else if (a === "--json") flags.json = takeValue()
+    else if (a === "--md") flags.md = takeValue()
+    else if (a === "--config") flags.config = takeValue()
+    else if (a.startsWith("-")) throw new Error(`Unknown option: ${a}`)
     else positional.push(a)
   }
   if (!flags.config && positional[0]) flags.config = positional[0]
@@ -132,7 +142,9 @@ async function main(): Promise<void> {
   if (results.some((r) => r.status === "critical")) process.exitCode = 1
 }
 
-main().catch((e) => {
-  console.error(e)
-  process.exit(1)
-})
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+}

--- a/defi/src/dataQuality/configs/README.md
+++ b/defi/src/dataQuality/configs/README.md
@@ -1,0 +1,84 @@
+# DefiLlama Data Quality — Sample Configs
+
+Each `*.json` file in this directory is a config for the
+`compare-external-metrics` CLI (refs DefiLlama/defillama-server#11830).
+
+## Config schema
+
+```jsonc
+{
+  "comparisons": [
+    {
+      "entity": "<readable-id>",          // e.g. "aave-v3-ethereum"
+      "metric": "<metric-name>",          // e.g. "tvl_usd"
+      "llamaUrl": "<url>",                // a DefiLlama JSON endpoint
+      "llamaPath": "<dot.path>",          // e.g. "currentChainTvls.Ethereum"
+      "llamaTimestampPath": "<dot.path>", // optional — wires drift gating
+      "externalProvider": "<name>",       // e.g. "rekt-news"
+      "externalUrl": "<url>",             // any external JSON endpoint
+      "externalPath": "<dot.path>",
+      "externalTimestampPath": "<dot.path>",
+      "warningThreshold": 0.10,           // optional, default 0.10 (10% relative)
+      "criticalThreshold": 0.25,          // optional, default 0.25 (25% relative)
+      "minAbsDiff": 0,                    // optional — suppress dust below this
+      "maxTimestampDriftSeconds": 3600    // optional — flag drift exceeding this
+    }
+  ]
+}
+```
+
+## Running
+
+```bash
+# Deterministic comparison; print text to stdout, optionally write
+# JSON / Markdown reports, optionally post a Discord webhook.
+npm run compare-external-metrics -- --dry-run \
+  --json /tmp/report.json --md /tmp/report.md \
+  src/dataQuality/configs/llama-tvl-spot-check.json
+```
+
+Environment:
+
+- `EXTERNAL_METRIC_COMPARISON_CONFIG` — config path (alternative to argv).
+- `EXTERNAL_METRIC_COMPARISON_WEBHOOK` — Discord webhook URL.
+
+## Provided configs
+
+### `llama-tvl-spot-check.json` — smoke test
+
+Compares Aave V3's Ethereum TVL on `/protocol/aave-v3` against itself
+from the same endpoint. Always returns `ok` — its job is to prove the
+CLI runs end to end against live DefiLlama data: fetch + URL cache + path
+extraction + threshold logic + report formatting all wired up.
+
+**To do real cross-source validation**, replace `externalUrl` and
+`externalPath` with a non-DefiLlama provider's endpoint that publishes
+the same metric (for example, a protocol's own public dashboard JSON if
+they expose one). Numeric-string values are supported; deep nested paths
+are supported; arrays can be indexed by numeric segment.
+
+## Path syntax
+
+`<dot.path>` supports nested object access and array indexing by numeric
+segment:
+
+- `data.tvl` → `obj["data"]["tvl"]`
+- `data.0.tvl` → `obj["data"][0]["tvl"]`
+
+**Limitation:** keys containing literal dots (e.g. `"uniswap.v3"`) cannot
+be addressed — by design, to keep the parser tiny. Pick endpoints whose
+JSON keys don't use dots.
+
+## Adding a new config
+
+1. Create `<name>.json` next to this README.
+2. Verify the JSON path syntax against the live endpoint:
+   ```bash
+   curl -s "<URL>" | python3 -c 'import json,sys; \
+     d=json.load(sys.stdin); \
+     # walk d["foo"]["bar"]... by hand to confirm the value
+   '
+   ```
+3. Add an entry above describing what the config compares and why.
+4. Run with `--dry-run` first to confirm the report makes sense before
+   wiring up a webhook.

--- a/defi/src/dataQuality/configs/llama-tvl-spot-check.json
+++ b/defi/src/dataQuality/configs/llama-tvl-spot-check.json
@@ -1,0 +1,16 @@
+{
+  "comparisons": [
+    {
+      "entity": "aave-v3-ethereum-tvl",
+      "metric": "tvl_usd",
+      "llamaUrl": "https://api.llama.fi/protocol/aave-v3",
+      "llamaPath": "currentChainTvls.Ethereum",
+      "externalProvider": "defillama-protocol-detail",
+      "externalUrl": "https://api.llama.fi/protocol/aave-v3",
+      "externalPath": "currentChainTvls.Ethereum",
+      "warningThreshold": 0.001,
+      "criticalThreshold": 0.005,
+      "minAbsDiff": 1000
+    }
+  ]
+}

--- a/defi/src/dataQuality/externalMetricComparison.test.ts
+++ b/defi/src/dataQuality/externalMetricComparison.test.ts
@@ -14,8 +14,17 @@ describe("numberAtPath / valueAtPath", () => {
 
   test("returns null for empty / non-numeric / missing", () => {
     expect(numberAtPath({ data: { fees: "" } }, "data.fees")).toBeNull()
+    expect(numberAtPath({ data: { fees: "   " } }, "data.fees")).toBeNull()
     expect(numberAtPath({ data: { fees: "bad" } }, "data.fees")).toBeNull()
     expect(numberAtPath({}, "missing.path")).toBeNull()
+  })
+
+  test("rejects JS-coercible non-numeric payload values", () => {
+    expect(numberAtPath({ x: false }, "x")).toBeNull()
+    expect(numberAtPath({ x: true }, "x")).toBeNull()
+    expect(numberAtPath({ x: [] }, "x")).toBeNull()
+    expect(numberAtPath({ x: [1] }, "x")).toBeNull()
+    expect(numberAtPath({ x: {} }, "x")).toBeNull()
   })
 
   test("supports array index segments", () => {
@@ -30,6 +39,10 @@ describe("numberAtPath / valueAtPath", () => {
 
   test("handles numeric strings with exponent notation", () => {
     expect(numberAtPath({ x: "1e3" }, "x")).toBe(1000)
+    expect(numberAtPath({ x: "-1.25e-3" }, "x")).toBe(-0.00125)
+    expect(numberAtPath({ x: ".5" }, "x")).toBe(0.5)
+    expect(numberAtPath({ x: "1." }, "x")).toBe(1)
+    expect(numberAtPath({ x: "1,000" }, "x")).toBeNull()
   })
 
   test("dotted-key limitation is documented (returns null for `uniswap.v3` key)", () => {
@@ -130,6 +143,24 @@ describe("compareMetricSample — thresholds and dust suppression", () => {
     )
     expect(nanResult.status).toBe("missing")
     expect(undefResult.status).toBe("missing")
+  })
+
+  test("missing metric values take precedence over stale timestamps", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: null, timestamp: 1 },
+      {
+        provider: "external",
+        entity: "x",
+        metric: "y",
+        value: 100,
+        timestamp: 10_000,
+      },
+      { maxTimestampDriftSeconds: 600 },
+    )
+
+    expect(r.status).toBe("missing")
+    expect(r.message).toMatch(/missing metric value/i)
+    expect(r.timestampDriftSeconds).toBe(9_999)
   })
 })
 

--- a/defi/src/dataQuality/externalMetricComparison.test.ts
+++ b/defi/src/dataQuality/externalMetricComparison.test.ts
@@ -1,0 +1,191 @@
+import {
+  compareMetricSample,
+  formatMetricComparisonReport,
+  numberAtPath,
+  valueAtPath,
+} from "./externalMetricComparison"
+
+describe("numberAtPath / valueAtPath", () => {
+  test("extracts nested numeric values", () => {
+    expect(
+      numberAtPath({ data: [{ metrics: { fees: "123.45" } }] }, "data.0.metrics.fees"),
+    ).toBe(123.45)
+  })
+
+  test("returns null for empty / non-numeric / missing", () => {
+    expect(numberAtPath({ data: { fees: "" } }, "data.fees")).toBeNull()
+    expect(numberAtPath({ data: { fees: "bad" } }, "data.fees")).toBeNull()
+    expect(numberAtPath({}, "missing.path")).toBeNull()
+  })
+
+  test("supports array index segments", () => {
+    expect(numberAtPath({ data: [{ tvl: 100 }] }, "data.0.tvl")).toBe(100)
+  })
+
+  test("treats NaN and Infinity as null (regression: usable-number guard)", () => {
+    expect(numberAtPath({ x: NaN }, "x")).toBeNull()
+    expect(numberAtPath({ x: Infinity }, "x")).toBeNull()
+    expect(numberAtPath({ x: -Infinity }, "x")).toBeNull()
+  })
+
+  test("handles numeric strings with exponent notation", () => {
+    expect(numberAtPath({ x: "1e3" }, "x")).toBe(1000)
+  })
+
+  test("dotted-key limitation is documented (returns null for `uniswap.v3` key)", () => {
+    expect(numberAtPath({ "uniswap.v3": 5 }, "uniswap.v3")).toBeNull()
+  })
+
+  test("valueAtPath with empty path returns input", () => {
+    expect(valueAtPath({ a: 1 }, "")).toEqual({ a: 1 })
+  })
+})
+
+describe("compareMetricSample — bug fixes (regression tests)", () => {
+  // Bug #1: denominator floor of `1` made sub-1 metrics misreport relative drift.
+  test("0.5 vs 0.6 reports ~16.7% relative diff (regression: bug #1)", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 0.5 },
+      { provider: "external", entity: "x", metric: "y", value: 0.6 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+    expect(r.relativeDiff).toBeCloseTo(0.1667, 3)
+    expect(r.status).toBe("warning")
+  })
+
+  test("0 vs 0 returns relativeDiff null with status ok", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 0 },
+      { provider: "external", entity: "x", metric: "y", value: 0 },
+    )
+    expect(r.relativeDiff).toBeNull()
+    expect(r.status).toBe("ok")
+  })
+
+  test("0 vs 1 returns relativeDiff 1.0 critical", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 0 },
+      { provider: "external", entity: "x", metric: "y", value: 1 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+    expect(r.relativeDiff).toBeCloseTo(1.0)
+    expect(r.status).toBe("critical")
+  })
+})
+
+describe("compareMetricSample — thresholds and dust suppression", () => {
+  test("marks small deviations (<warning) as ok", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 94 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+    expect(r.status).toBe("ok")
+    expect(r.relativeDiff).toBeCloseTo(0.06)
+  })
+
+  test("warning at 20% drift, critical at 40% drift", () => {
+    const warning = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 80 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+    const critical = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 60 },
+      { warningThreshold: 0.1, criticalThreshold: 0.25 },
+    )
+
+    expect(warning.status).toBe("warning")
+    expect(critical.status).toBe("critical")
+  })
+
+  test("uses absolute threshold to suppress dust", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "small", metric: "fees_24h", value: 2 },
+      { provider: "external", entity: "small", metric: "fees_24h", value: 1 },
+      { minAbsDiff: 10 },
+    )
+    expect(r.status).toBe("ok")
+  })
+
+  test("mixed signs: -50 vs 50 is a 200% relative drift (critical)", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: -50 },
+      { provider: "external", entity: "x", metric: "y", value: 50 },
+      { criticalThreshold: 0.25 },
+    )
+    expect(r.relativeDiff).toBeCloseTo(2.0)
+    expect(r.status).toBe("critical")
+  })
+
+  test("non-finite values produce missing status", () => {
+    const nanResult = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: NaN },
+      { provider: "external", entity: "x", metric: "y", value: 100 },
+    )
+    const undefResult = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: undefined },
+      { provider: "external", entity: "x", metric: "y", value: 100 },
+    )
+    expect(nanResult.status).toBe("missing")
+    expect(undefResult.status).toBe("missing")
+  })
+})
+
+describe("compareMetricSample — timestamp drift (regression: bug #2 prep)", () => {
+  test("drift gating fires when timestamps are populated and exceed limit", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 100, timestamp: 1000 },
+      {
+        provider: "external",
+        entity: "x",
+        metric: "y",
+        value: 100,
+        timestamp: 99_999,
+      },
+      { maxTimestampDriftSeconds: 600 },
+    )
+    expect(r.status).toBe("warning")
+    expect(r.message).toMatch(/drift/i)
+    expect(r.timestampDriftSeconds).toBe(98_999)
+  })
+
+  test("drift gating is silent when timestamps are absent", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 100 },
+      { provider: "external", entity: "x", metric: "y", value: 100 },
+      { maxTimestampDriftSeconds: 600 },
+    )
+    expect(r.status).toBe("ok")
+    expect(r.timestampDriftSeconds).toBeNull()
+  })
+})
+
+describe("formatMetricComparisonReport", () => {
+  test("renders a compact one-line-per-row report", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "aave", metric: "fees_24h", value: 100 },
+      { provider: "external", entity: "aave", metric: "fees_24h", value: 50 },
+      { criticalThreshold: 0.25 },
+    )
+    expect(formatMetricComparisonReport([r])).toContain(
+      "CRITICAL | aave | fees_24h",
+    )
+  })
+
+  test("'no comparisons' message when empty", () => {
+    expect(formatMetricComparisonReport([])).toMatch(/no metric comparisons/i)
+  })
+
+  test("renders n/a for null relativeDiff", () => {
+    const r = compareMetricSample(
+      { provider: "llama", entity: "x", metric: "y", value: 0 },
+      { provider: "external", entity: "x", metric: "y", value: 0 },
+    )
+    // 0 vs 0 is `ok`, so flagged is empty; report falls back to all rows.
+    const out = formatMetricComparisonReport([r])
+    expect(out).toContain("OK | x | y")
+    expect(out).toContain("diff=n/a")
+  })
+})

--- a/defi/src/dataQuality/externalMetricComparison.ts
+++ b/defi/src/dataQuality/externalMetricComparison.ts
@@ -1,0 +1,294 @@
+/**
+ * Deterministic external-metric comparator.
+ *
+ * Compares numeric metrics extracted from two JSON sources (DefiLlama vs.
+ * an external provider) and classifies the discrepancy as `ok | warning |
+ * critical | missing` against configurable relative and absolute thresholds.
+ *
+ * Refs: DefiLlama/defillama-server#11830.
+ */
+
+/** Status of a single metric comparison. */
+export type MetricComparisonStatus = "ok" | "warning" | "critical" | "missing"
+
+/** A single metric value drawn from one provider. */
+export interface MetricSample {
+  provider: string
+  entity: string
+  metric: string
+  value: number | null | undefined
+  /** Unix epoch seconds, used for {@link MetricComparisonOptions.maxTimestampDriftSeconds}. */
+  timestamp?: number
+  url?: string
+}
+
+/** Tunable thresholds for {@link compareMetricSample}. */
+export interface MetricComparisonOptions {
+  /** Relative-diff threshold above which status becomes `warning`. Default: 0.10 (10%). */
+  warningThreshold?: number
+  /** Relative-diff threshold above which status becomes `critical`. Default: 0.25 (25%). */
+  criticalThreshold?: number
+  /** Absolute-diff threshold below which the comparison is suppressed as dust. Default: 0. */
+  minAbsDiff?: number
+  /** If both samples carry timestamps and they drift further than this, status becomes `warning`. */
+  maxTimestampDriftSeconds?: number
+}
+
+/** Result of comparing one Llama sample with one external sample. */
+export interface MetricComparisonResult {
+  entity: string
+  metric: string
+  status: MetricComparisonStatus
+  llamaProvider: string
+  externalProvider: string
+  llamaValue: number | null
+  externalValue: number | null
+  absoluteDiff: number | null
+  /** `null` when both samples are exactly 0, or when either side is missing. */
+  relativeDiff: number | null
+  timestampDriftSeconds: number | null
+  message: string
+  llamaUrl?: string
+  externalUrl?: string
+}
+
+/**
+ * Extracts a value from a nested object using dot-separated path notation.
+ *
+ * Supports array indexing via numeric segments (e.g., `"data.0.tvl"`).
+ *
+ * **Limitation**: keys containing literal dots (e.g., `"uniswap.v3"`)
+ * cannot be addressed and will return `undefined`. By design, to keep
+ * parsing simple. Configs should target dot-free key shapes.
+ *
+ * @param input - Object to extract from.
+ * @param path - Dot-separated key path. Empty string returns the input.
+ * @returns The value at the path, or `undefined` if not found.
+ */
+export function valueAtPath(input: any, path: string): any {
+  if (!path) return input
+
+  return path.split(".").reduce((current, segment) => {
+    if (current === null || current === undefined) return undefined
+    if (Array.isArray(current) && /^\d+$/.test(segment))
+      return current[Number(segment)]
+    return current[segment]
+  }, input)
+}
+
+/**
+ * Like {@link valueAtPath} but coerces the result to a finite number.
+ *
+ * Returns `null` for `null`, `undefined`, empty string, NaN, Infinity,
+ * or any non-numeric content.
+ *
+ * @param input - Object to extract from.
+ * @param path - Dot-separated key path.
+ * @returns A finite number, or `null` if the value is missing or non-numeric.
+ */
+export function numberAtPath(input: any, path: string): number | null {
+  const value = valueAtPath(input, path)
+  if (value === null || value === undefined || value === "") return null
+
+  const parsed = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Compares two metric samples and classifies the discrepancy.
+ *
+ * Status precedence:
+ * 1. `missing` — either sample's value is non-finite or absent.
+ * 2. `warning` — timestamps drift further than `maxTimestampDriftSeconds`.
+ * 3. `ok` — absolute diff is below `minAbsDiff` (dust suppression).
+ * 4. `critical` — relative diff is at or above `criticalThreshold`.
+ * 5. `warning` — relative diff is at or above `warningThreshold`.
+ * 6. `ok` — otherwise.
+ *
+ * Bug-fix note: the relative-diff denominator no longer has a `1` floor
+ * (refs #11830 Bug #1) — sub-1 metrics now compare proportionally.
+ * When both samples are exactly 0, `relativeDiff` is `null` and the
+ * comparison is `ok`.
+ *
+ * @param llama - Sample from DefiLlama.
+ * @param external - Sample from the external provider.
+ * @param options - Tunable thresholds.
+ * @returns Structured comparison result.
+ */
+export function compareMetricSample(
+  llama: MetricSample,
+  external: MetricSample,
+  options: MetricComparisonOptions = {},
+): MetricComparisonResult {
+  const warningThreshold = options.warningThreshold ?? 0.1
+  const criticalThreshold = options.criticalThreshold ?? 0.25
+  const minAbsDiff = options.minAbsDiff ?? 0
+
+  const timestampDriftSeconds = getTimestampDrift(llama, external)
+  if (
+    timestampDriftSeconds !== null &&
+    options.maxTimestampDriftSeconds !== undefined &&
+    timestampDriftSeconds > options.maxTimestampDriftSeconds
+  ) {
+    return result(
+      llama,
+      external,
+      "warning",
+      null,
+      null,
+      timestampDriftSeconds,
+      "timestamps are outside allowed drift",
+    )
+  }
+
+  if (!isUsableNumber(llama.value) || !isUsableNumber(external.value)) {
+    return result(
+      llama,
+      external,
+      "missing",
+      null,
+      null,
+      timestampDriftSeconds,
+      "missing metric value",
+    )
+  }
+
+  const llamaValue = Number(llama.value)
+  const externalValue = Number(external.value)
+  const absoluteDiff = Math.abs(llamaValue - externalValue)
+  const denominator = Math.max(Math.abs(llamaValue), Math.abs(externalValue))
+  const relativeDiff = denominator === 0 ? null : absoluteDiff / denominator
+
+  if (absoluteDiff < minAbsDiff) {
+    return result(
+      llama,
+      external,
+      "ok",
+      absoluteDiff,
+      relativeDiff,
+      timestampDriftSeconds,
+      "within absolute threshold",
+    )
+  }
+
+  if (relativeDiff !== null) {
+    if (relativeDiff >= criticalThreshold) {
+      return result(
+        llama,
+        external,
+        "critical",
+        absoluteDiff,
+        relativeDiff,
+        timestampDriftSeconds,
+        "outside critical threshold",
+      )
+    }
+
+    if (relativeDiff >= warningThreshold) {
+      return result(
+        llama,
+        external,
+        "warning",
+        absoluteDiff,
+        relativeDiff,
+        timestampDriftSeconds,
+        "outside warning threshold",
+      )
+    }
+  }
+
+  return result(
+    llama,
+    external,
+    "ok",
+    absoluteDiff,
+    relativeDiff,
+    timestampDriftSeconds,
+    relativeDiff === null
+      ? "both values are zero"
+      : "within threshold",
+  )
+}
+
+/**
+ * Formats an array of comparison results as a compact one-line-per-row
+ * text report (backwards-compatible with PR #11850's output shape).
+ *
+ * @param results - Comparison results to render.
+ * @returns Plain-text report (line-delimited).
+ */
+export function formatMetricComparisonReport(
+  results: MetricComparisonResult[],
+): string {
+  if (!results.length) return "No metric comparisons were run."
+
+  const flagged = results.filter((item) => item.status !== "ok")
+  const header = `External metric comparison: ${flagged.length}/${results.length} flagged`
+  const rows = flagged.length ? flagged : results
+
+  return [
+    header,
+    ...rows.map((item) => {
+      const diff =
+        item.relativeDiff === null
+          ? "n/a"
+          : `${(item.relativeDiff * 100).toFixed(2)}%`
+      return [
+        item.status.toUpperCase(),
+        item.entity,
+        item.metric,
+        `${item.llamaProvider}=${formatValue(item.llamaValue)}`,
+        `${item.externalProvider}=${formatValue(item.externalValue)}`,
+        `diff=${diff}`,
+        item.message,
+      ].join(" | ")
+    }),
+  ].join("\n")
+}
+
+function result(
+  llama: MetricSample,
+  external: MetricSample,
+  status: MetricComparisonStatus,
+  absoluteDiff: number | null,
+  relativeDiff: number | null,
+  timestampDriftSeconds: number | null,
+  message: string,
+): MetricComparisonResult {
+  return {
+    entity: llama.entity,
+    metric: llama.metric,
+    status,
+    llamaProvider: llama.provider,
+    externalProvider: external.provider,
+    llamaValue: isUsableNumber(llama.value) ? Number(llama.value) : null,
+    externalValue: isUsableNumber(external.value) ? Number(external.value) : null,
+    absoluteDiff,
+    relativeDiff,
+    timestampDriftSeconds,
+    message,
+    llamaUrl: llama.url,
+    externalUrl: external.url,
+  }
+}
+
+function getTimestampDrift(
+  llama: MetricSample,
+  external: MetricSample,
+): number | null {
+  if (llama.timestamp === undefined || external.timestamp === undefined)
+    return null
+  return Math.abs(llama.timestamp - external.timestamp)
+}
+
+function isUsableNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function formatValue(value: number | null): string {
+  if (value === null) return "n/a"
+  if (Math.abs(value) >= 1e9) return `${(value / 1e9).toFixed(2)}b`
+  if (Math.abs(value) >= 1e6) return `${(value / 1e6).toFixed(2)}m`
+  if (Math.abs(value) >= 1e3) return `${(value / 1e3).toFixed(2)}k`
+  return `${Math.round(value * 100) / 100}`
+}

--- a/defi/src/dataQuality/externalMetricComparison.ts
+++ b/defi/src/dataQuality/externalMetricComparison.ts
@@ -79,8 +79,9 @@ export function valueAtPath(input: any, path: string): any {
 /**
  * Like {@link valueAtPath} but coerces the result to a finite number.
  *
- * Returns `null` for `null`, `undefined`, empty string, NaN, Infinity,
- * or any non-numeric content.
+ * Only accepts finite numbers and strict numeric strings. Returns `null`
+ * for `null`, `undefined`, whitespace-only strings, booleans, arrays,
+ * objects, NaN, Infinity, or any non-numeric content.
  *
  * @param input - Object to extract from.
  * @param path - Dot-separated key path.
@@ -88,9 +89,16 @@ export function valueAtPath(input: any, path: string): any {
  */
 export function numberAtPath(input: any, path: string): number | null {
   const value = valueAtPath(input, path)
-  if (value === null || value === undefined || value === "") return null
+  if (value === null || value === undefined) return null
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value !== "string") return null
 
-  const parsed = typeof value === "number" ? value : Number(value)
+  const trimmed = value.trim()
+  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i.test(trimmed)) {
+    return null
+  }
+
+  const parsed = Number(trimmed)
   return Number.isFinite(parsed) ? parsed : null
 }
 
@@ -124,6 +132,18 @@ export function compareMetricSample(
   const criticalThreshold = options.criticalThreshold ?? 0.25
   const minAbsDiff = options.minAbsDiff ?? 0
 
+  if (!isUsableNumber(llama.value) || !isUsableNumber(external.value)) {
+    return result(
+      llama,
+      external,
+      "missing",
+      null,
+      null,
+      getTimestampDrift(llama, external),
+      "missing metric value",
+    )
+  }
+
   const timestampDriftSeconds = getTimestampDrift(llama, external)
   if (
     timestampDriftSeconds !== null &&
@@ -138,18 +158,6 @@ export function compareMetricSample(
       null,
       timestampDriftSeconds,
       "timestamps are outside allowed drift",
-    )
-  }
-
-  if (!isUsableNumber(llama.value) || !isUsableNumber(external.value)) {
-    return result(
-      llama,
-      external,
-      "missing",
-      null,
-      null,
-      timestampDriftSeconds,
-      "missing metric value",
     )
   }
 

--- a/defi/src/dataQuality/fetchWithRetry.test.ts
+++ b/defi/src/dataQuality/fetchWithRetry.test.ts
@@ -131,4 +131,21 @@ describe("UrlPayloadCache", () => {
     await cache.get("https://example.com/x")
     expect(mockFetch).toHaveBeenCalledTimes(2)
   })
+
+  test("evicts rejected fetches so later calls can recover", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(404, "Not Found"))
+      .mockResolvedValueOnce(okResponse({ x: 1 }))
+
+    const cache = new UrlPayloadCache()
+    await expect(
+      cache.get("https://example.com/recover", { retries: 0, backoffMs: 1 }),
+    ).rejects.toThrow(/404/)
+
+    await expect(
+      cache.get("https://example.com/recover", { retries: 0, backoffMs: 1 }),
+    ).resolves.toEqual({ x: 1 })
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/defi/src/dataQuality/fetchWithRetry.test.ts
+++ b/defi/src/dataQuality/fetchWithRetry.test.ts
@@ -1,0 +1,134 @@
+import fetch from "node-fetch"
+import { fetchJsonWithRetry, UrlPayloadCache } from "./fetchWithRetry"
+
+jest.mock("node-fetch", () => jest.fn())
+const mockFetch = fetch as unknown as jest.Mock
+
+const okResponse = (body: any) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => body,
+})
+
+const errResponse = (status: number, statusText = "err") => ({
+  ok: false,
+  status,
+  statusText,
+  json: async () => ({}),
+  text: async () => statusText,
+})
+
+describe("fetchJsonWithRetry", () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  test("returns parsed JSON on 200", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ hello: "world" }))
+    const result = await fetchJsonWithRetry("https://example.com/data.json")
+    expect(result).toEqual({ hello: "world" })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("retries on transient 503 then succeeds", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(503))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }))
+    const result = await fetchJsonWithRetry("https://example.com/data.json", {
+      retries: 2,
+      backoffMs: 1,
+    })
+    expect(result).toEqual({ ok: 1 })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("retries on 429 then succeeds", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(429, "Too Many Requests"))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }))
+    const result = await fetchJsonWithRetry("https://example.com/data.json", {
+      retries: 2,
+      backoffMs: 1,
+    })
+    expect(result).toEqual({ ok: 1 })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("gives up after max retries on persistent 500", async () => {
+    mockFetch.mockResolvedValue(errResponse(500))
+    await expect(
+      fetchJsonWithRetry("https://example.com/data.json", {
+        retries: 2,
+        backoffMs: 1,
+      }),
+    ).rejects.toThrow(/500/)
+    // initial + 2 retries = 3 attempts
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  test("does not retry on non-transient 404", async () => {
+    mockFetch.mockResolvedValue(errResponse(404, "Not Found"))
+    await expect(
+      fetchJsonWithRetry("https://example.com/data.json", {
+        retries: 2,
+        backoffMs: 1,
+      }),
+    ).rejects.toThrow(/404/)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not retry on non-transient 401", async () => {
+    mockFetch.mockResolvedValue(errResponse(401, "Unauthorized"))
+    await expect(
+      fetchJsonWithRetry("https://example.com/data.json", {
+        retries: 2,
+        backoffMs: 1,
+      }),
+    ).rejects.toThrow(/401/)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("UrlPayloadCache", () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  test("dedups concurrent requests for the same URL", async () => {
+    mockFetch.mockResolvedValue(okResponse({ x: 1 }))
+    const cache = new UrlPayloadCache()
+    const [a, b] = await Promise.all([
+      cache.get("https://example.com/x"),
+      cache.get("https://example.com/x"),
+    ])
+    expect(a).toEqual({ x: 1 })
+    expect(b).toEqual({ x: 1 })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("dedups sequential requests for the same URL", async () => {
+    mockFetch.mockResolvedValue(okResponse({ x: 2 }))
+    const cache = new UrlPayloadCache()
+    await cache.get("https://example.com/x")
+    await cache.get("https://example.com/x")
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test("different URLs are fetched independently", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse({ a: 1 }))
+      .mockResolvedValueOnce(okResponse({ b: 2 }))
+    const cache = new UrlPayloadCache()
+    const a = await cache.get("https://example.com/a")
+    const b = await cache.get("https://example.com/b")
+    expect(a).toEqual({ a: 1 })
+    expect(b).toEqual({ b: 2 })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test("clear() lets next get re-fetch", async () => {
+    mockFetch.mockResolvedValue(okResponse({ x: 1 }))
+    const cache = new UrlPayloadCache()
+    await cache.get("https://example.com/x")
+    cache.clear()
+    await cache.get("https://example.com/x")
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/defi/src/dataQuality/fetchWithRetry.ts
+++ b/defi/src/dataQuality/fetchWithRetry.ts
@@ -83,7 +83,10 @@ export class UrlPayloadCache {
   get(url: string, opts?: FetchOptions): Promise<unknown> {
     let payload = this.cache.get(url)
     if (!payload) {
-      payload = fetchJsonWithRetry(url, opts)
+      payload = fetchJsonWithRetry(url, opts).catch((error) => {
+        this.cache.delete(url)
+        throw error
+      })
       this.cache.set(url, payload)
     }
     return payload

--- a/defi/src/dataQuality/fetchWithRetry.ts
+++ b/defi/src/dataQuality/fetchWithRetry.ts
@@ -1,0 +1,96 @@
+import fetch from "node-fetch"
+import retry from "async-retry"
+
+/**
+ * Configuration for {@link fetchJsonWithRetry}.
+ */
+export interface FetchOptions {
+  /** Maximum number of retries on transient errors. Default: 3. */
+  retries?: number
+  /** Base backoff delay in milliseconds (exponential, with jitter). Default: 500. */
+  backoffMs?: number
+  /** Per-attempt timeout in milliseconds (via AbortController). Default: 10000. */
+  timeoutMs?: number
+}
+
+/** HTTP status codes considered transient and worth retrying. */
+const TRANSIENT_STATUS = new Set<number>([429, 500, 502, 503, 504])
+
+/**
+ * Fetches JSON from a URL with retry on transient HTTP errors.
+ *
+ * Retries on network errors and on transient HTTP statuses (429, 500, 502,
+ * 503, 504). Non-transient errors (4xx other than 429) bail immediately.
+ * Per-attempt timeout is enforced via AbortController.
+ *
+ * @param url - URL to fetch.
+ * @param opts - Retry / timeout configuration.
+ * @returns Parsed JSON body.
+ * @throws Error on persistent failure or non-transient HTTP status.
+ */
+export async function fetchJsonWithRetry(
+  url: string,
+  opts: FetchOptions = {},
+): Promise<unknown> {
+  const { retries = 3, backoffMs = 500, timeoutMs = 10_000 } = opts
+
+  return retry(
+    async (bail) => {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), timeoutMs)
+      try {
+        const response = await fetch(url, {
+          signal: controller.signal as unknown as undefined,
+        })
+        if (!response.ok) {
+          if (TRANSIENT_STATUS.has(response.status)) {
+            throw new Error(
+              `Transient ${response.status} ${response.statusText} on ${url}`,
+            )
+          }
+          bail(
+            new Error(
+              `Non-transient ${response.status} ${response.statusText} on ${url}`,
+            ),
+          )
+          return
+        }
+        return await response.json()
+      } finally {
+        clearTimeout(timeout)
+      }
+    },
+    { retries, minTimeout: backoffMs, factor: 2, randomize: true },
+  )
+}
+
+/**
+ * Per-run cache for fetched JSON payloads.
+ *
+ * Caches **promises**, not values, so concurrent calls for the same URL
+ * dedup correctly (only one underlying fetch is issued). Intended for use
+ * within a single CLI run; instantiate fresh each run.
+ */
+export class UrlPayloadCache {
+  private cache = new Map<string, Promise<unknown>>()
+
+  /**
+   * Returns the cached promise for `url`, or starts a fetch if not yet seen.
+   *
+   * @param url - URL to fetch.
+   * @param opts - Forwarded to {@link fetchJsonWithRetry} on cache miss.
+   */
+  get(url: string, opts?: FetchOptions): Promise<unknown> {
+    let payload = this.cache.get(url)
+    if (!payload) {
+      payload = fetchJsonWithRetry(url, opts)
+      this.cache.set(url, payload)
+    }
+    return payload
+  }
+
+  /** Empties the cache; subsequent {@link get} calls will re-fetch. */
+  clear(): void {
+    this.cache.clear()
+  }
+}

--- a/defi/src/dataQuality/integration.test.ts
+++ b/defi/src/dataQuality/integration.test.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch"
-import { runComparisons, Config } from "./runComparisons"
+import { runComparisons, Config, ConfigSchema } from "./runComparisons"
 
 jest.mock("node-fetch", () => jest.fn())
 const mockFetch = fetch as unknown as jest.Mock
@@ -17,6 +17,65 @@ const errResponse = (status: number) => ({
   statusText: "err",
   json: async () => ({}),
   text: async () => "err",
+})
+
+const validComparison = {
+  entity: "x",
+  metric: "y",
+  llamaUrl: "https://llama.test/x",
+  llamaPath: "value",
+  externalProvider: "external",
+  externalUrl: "https://external.test/x",
+  externalPath: "value",
+}
+
+describe("ConfigSchema", () => {
+  test("rejects unknown config keys so threshold typos do not silently default", () => {
+    const parsed = ConfigSchema.safeParse({
+      comparisons: [
+        {
+          ...validComparison,
+          warnThreshold: 0.1,
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  test("rejects negative threshold values", () => {
+    const parsed = ConfigSchema.safeParse({
+      comparisons: [
+        {
+          ...validComparison,
+          minAbsDiff: -1,
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  test("rejects criticalThreshold below warningThreshold", () => {
+    const parsed = ConfigSchema.safeParse({
+      comparisons: [
+        {
+          ...validComparison,
+          warningThreshold: 0.1,
+          criticalThreshold: 0.05,
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues[0].path).toEqual([
+        "comparisons",
+        0,
+        "criticalThreshold",
+      ])
+    }
+  })
 })
 
 describe("runComparisons (integration)", () => {

--- a/defi/src/dataQuality/integration.test.ts
+++ b/defi/src/dataQuality/integration.test.ts
@@ -1,0 +1,211 @@
+import fetch from "node-fetch"
+import { runComparisons, Config } from "./runComparisons"
+
+jest.mock("node-fetch", () => jest.fn())
+const mockFetch = fetch as unknown as jest.Mock
+
+const okResponse = (body: any) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => body,
+})
+
+const errResponse = (status: number) => ({
+  ok: false,
+  status,
+  statusText: "err",
+  json: async () => ({}),
+  text: async () => "err",
+})
+
+describe("runComparisons (integration)", () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  test("end-to-end: produces ok / warning / critical statuses by threshold", async () => {
+    const config: Config = {
+      comparisons: [
+        {
+          entity: "aave",
+          metric: "fees_24h",
+          llamaUrl: "https://llama.test/aave",
+          llamaPath: "fees",
+          externalProvider: "external",
+          externalUrl: "https://external.test/aave",
+          externalPath: "fees",
+          warningThreshold: 0.1,
+          criticalThreshold: 0.25,
+        },
+        {
+          entity: "uniswap",
+          metric: "tvl",
+          llamaUrl: "https://llama.test/uniswap",
+          llamaPath: "tvl",
+          externalProvider: "external",
+          externalUrl: "https://external.test/uniswap",
+          externalPath: "tvl",
+          warningThreshold: 0.1,
+          criticalThreshold: 0.25,
+        },
+        {
+          entity: "compound",
+          metric: "tvl",
+          llamaUrl: "https://llama.test/compound",
+          llamaPath: "tvl",
+          externalProvider: "external",
+          externalUrl: "https://external.test/compound",
+          externalPath: "tvl",
+          warningThreshold: 0.1,
+          criticalThreshold: 0.25,
+        },
+      ],
+    }
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "https://llama.test/aave") return okResponse({ fees: 100 })
+      if (url === "https://external.test/aave")
+        return okResponse({ fees: 105 }) // ~5% diff -> ok
+      if (url === "https://llama.test/uniswap")
+        return okResponse({ tvl: 1_000_000 })
+      if (url === "https://external.test/uniswap")
+        return okResponse({ tvl: 700_000 }) // 30% diff -> critical
+      if (url === "https://llama.test/compound") return okResponse({ tvl: 100 })
+      if (url === "https://external.test/compound")
+        return okResponse({ tvl: 80 }) // 20% diff -> warning
+      throw new Error(`unexpected url ${url}`)
+    })
+
+    const results = await runComparisons(config)
+
+    expect(results).toHaveLength(3)
+    expect(results[0].status).toBe("ok")
+    expect(results[1].status).toBe("critical")
+    expect(results[2].status).toBe("warning")
+    expect(results[1].relativeDiff).toBeCloseTo(0.3, 2)
+  })
+
+  test("two-pass cache: each unique URL fetched exactly once even when comparisons share URLs (regression: bug #3)", async () => {
+    const config: Config = {
+      comparisons: [
+        {
+          entity: "shared-fees",
+          metric: "fees",
+          llamaUrl: "https://llama.test/shared",
+          llamaPath: "fees_24h",
+          externalProvider: "external",
+          externalUrl: "https://external.test/a",
+          externalPath: "value",
+        },
+        {
+          entity: "shared-tvl",
+          metric: "tvl",
+          llamaUrl: "https://llama.test/shared", // SAME llama URL
+          llamaPath: "tvl",
+          externalProvider: "external",
+          externalUrl: "https://external.test/b",
+          externalPath: "value",
+        },
+      ],
+    }
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "https://llama.test/shared")
+        return okResponse({ fees_24h: 100, tvl: 1000 })
+      if (url === "https://external.test/a") return okResponse({ value: 100 })
+      if (url === "https://external.test/b") return okResponse({ value: 1000 })
+      throw new Error(`unexpected url ${url}`)
+    })
+
+    await runComparisons(config)
+
+    // 3 unique URLs => 3 fetch calls (not 4)
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    const sharedHits = mockFetch.mock.calls.filter(
+      (c) => c[0] === "https://llama.test/shared",
+    )
+    expect(sharedHits).toHaveLength(1)
+  })
+
+  test("timestamp paths populate timestamps and gate by drift (regression: bug #2)", async () => {
+    const config: Config = {
+      comparisons: [
+        {
+          entity: "x",
+          metric: "y",
+          llamaUrl: "https://llama.test/x",
+          llamaPath: "value",
+          llamaTimestampPath: "updatedAt",
+          externalProvider: "external",
+          externalUrl: "https://external.test/x",
+          externalPath: "value",
+          externalTimestampPath: "updatedAt",
+          maxTimestampDriftSeconds: 600,
+        },
+      ],
+    }
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "https://llama.test/x")
+        return okResponse({ value: 100, updatedAt: 1000 })
+      if (url === "https://external.test/x")
+        return okResponse({ value: 100, updatedAt: 99_999 })
+      throw new Error(`unexpected url ${url}`)
+    })
+
+    const results = await runComparisons(config)
+
+    expect(results[0].timestampDriftSeconds).toBe(98_999)
+    expect(results[0].status).toBe("warning")
+    expect(results[0].message).toMatch(/drift/i)
+  })
+
+  test("fetch failure on one URL: that comparison gets 'missing'; batch continues", async () => {
+    const config: Config = {
+      comparisons: [
+        {
+          entity: "broken",
+          metric: "y",
+          llamaUrl: "https://llama.test/broken",
+          llamaPath: "value",
+          externalProvider: "external",
+          externalUrl: "https://external.test/broken",
+          externalPath: "value",
+        },
+        {
+          entity: "ok",
+          metric: "y",
+          llamaUrl: "https://llama.test/ok",
+          llamaPath: "value",
+          externalProvider: "external",
+          externalUrl: "https://external.test/ok",
+          externalPath: "value",
+        },
+      ],
+    }
+
+    mockFetch.mockImplementation((url: string) => {
+      // 404 is non-transient — fetchJsonWithRetry bails immediately, no slow retries.
+      if (url === "https://llama.test/broken") return errResponse(404)
+      if (url === "https://external.test/broken") return errResponse(404)
+      if (url === "https://llama.test/ok") return okResponse({ value: 100 })
+      if (url === "https://external.test/ok") return okResponse({ value: 100 })
+      throw new Error(`unexpected url ${url}`)
+    })
+
+    const errored: string[] = []
+    const results = await runComparisons(config, {
+      onFetchError: (url) => errored.push(url),
+    })
+
+    expect(results).toHaveLength(2)
+    expect(results[0].status).toBe("missing")
+    expect(results[1].status).toBe("ok")
+    expect(errored).toEqual(
+      expect.arrayContaining([
+        "https://llama.test/broken",
+        "https://external.test/broken",
+      ]),
+    )
+  })
+})

--- a/defi/src/dataQuality/reportFormatter.test.ts
+++ b/defi/src/dataQuality/reportFormatter.test.ts
@@ -1,0 +1,174 @@
+import { formatJsonReport, formatMarkdownReport } from "./reportFormatter"
+import { MetricComparisonResult } from "./externalMetricComparison"
+
+const ok: MetricComparisonResult = {
+  entity: "aave",
+  metric: "fees_24h",
+  status: "ok",
+  llamaProvider: "llama",
+  externalProvider: "external",
+  llamaValue: 100,
+  externalValue: 105,
+  absoluteDiff: 5,
+  relativeDiff: 0.0476,
+  timestampDriftSeconds: null,
+  message: "within threshold",
+  llamaUrl: "https://api.llama.fi/aave",
+  externalUrl: "https://external.com/aave",
+}
+
+const critical: MetricComparisonResult = {
+  entity: "uniswap",
+  metric: "tvl",
+  status: "critical",
+  llamaProvider: "llama",
+  externalProvider: "external",
+  llamaValue: 1_000_000_000,
+  externalValue: 500_000_000,
+  absoluteDiff: 500_000_000,
+  relativeDiff: 0.5,
+  timestampDriftSeconds: null,
+  message: "outside critical threshold",
+  llamaUrl: "https://api.llama.fi/uniswap",
+  externalUrl: "https://external.com/uniswap",
+}
+
+const warning: MetricComparisonResult = {
+  entity: "compound",
+  metric: "fees_24h",
+  status: "warning",
+  llamaProvider: "llama",
+  externalProvider: "external",
+  llamaValue: 100,
+  externalValue: 80,
+  absoluteDiff: 20,
+  relativeDiff: 0.2,
+  timestampDriftSeconds: 7200,
+  message: "outside warning threshold",
+  llamaUrl: "https://api.llama.fi/compound",
+  externalUrl: "https://external.com/compound",
+}
+
+const missing: MetricComparisonResult = {
+  entity: "x",
+  metric: "y",
+  status: "missing",
+  llamaProvider: "llama",
+  externalProvider: "external",
+  llamaValue: null,
+  externalValue: null,
+  absoluteDiff: null,
+  relativeDiff: null,
+  timestampDriftSeconds: null,
+  message: "missing metric value",
+}
+
+const zeroZero: MetricComparisonResult = {
+  entity: "z",
+  metric: "y",
+  status: "ok",
+  llamaProvider: "llama",
+  externalProvider: "external",
+  llamaValue: 0,
+  externalValue: 0,
+  absoluteDiff: 0,
+  relativeDiff: null,
+  timestampDriftSeconds: null,
+  message: "both values are zero",
+}
+
+describe("formatJsonReport", () => {
+  test("emits stable schema with summary counts", () => {
+    const json = formatJsonReport([ok, critical, warning, missing, zeroZero])
+    const parsed = JSON.parse(json)
+
+    expect(parsed.schema_version).toBe("1.0.0")
+    expect(parsed.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(parsed.summary).toEqual({
+      total: 5,
+      ok: 2,
+      warning: 1,
+      critical: 1,
+      missing: 1,
+    })
+    expect(parsed.results).toHaveLength(5)
+  })
+
+  test("empty results yields zero counts and empty results array", () => {
+    const parsed = JSON.parse(formatJsonReport([]))
+    expect(parsed.summary).toEqual({
+      total: 0,
+      ok: 0,
+      warning: 0,
+      critical: 0,
+      missing: 0,
+    })
+    expect(parsed.results).toHaveLength(0)
+  })
+
+  test("output is valid pretty-printed JSON", () => {
+    const json = formatJsonReport([ok])
+    expect(json).toContain("\n")
+    expect(() => JSON.parse(json)).not.toThrow()
+  })
+
+  test("preserves all result fields verbatim", () => {
+    const parsed = JSON.parse(formatJsonReport([critical]))
+    expect(parsed.results[0]).toEqual(critical)
+  })
+})
+
+describe("formatMarkdownReport", () => {
+  test("includes header and summary section", () => {
+    const md = formatMarkdownReport([ok, critical])
+    expect(md).toMatch(/# DefiLlama Data Quality Report/)
+    expect(md).toMatch(/## Summary/)
+    expect(md).toMatch(/\*\*Total:\*\* 2/)
+    expect(md).toMatch(/\*\*Critical:\*\* 1/)
+    expect(md).toMatch(/\*\*OK:\*\* 1/)
+  })
+
+  test("flagged section lists critical/warning rows with linked sources", () => {
+    const md = formatMarkdownReport([ok, critical])
+    expect(md).toContain("## Flagged Comparisons")
+    expect(md).toContain("uniswap / tvl")
+    expect(md).toContain("CRITICAL")
+    expect(md).toContain("[source](https://api.llama.fi/uniswap)")
+    expect(md).toContain("[source](https://external.com/uniswap)")
+    expect(md).toContain("50.00%")
+  })
+
+  test("renders n/a for null relativeDiff", () => {
+    const md = formatMarkdownReport([missing])
+    expect(md).toContain("MISSING")
+    expect(md).toMatch(/Relative diff:.*n\/a/)
+  })
+
+  test("includes timestamp drift when present", () => {
+    const md = formatMarkdownReport([warning])
+    expect(md).toMatch(/Timestamp drift:.*7200s/)
+  })
+
+  test("when no flagged rows, emits an all-clear note", () => {
+    const md = formatMarkdownReport([ok, zeroZero])
+    expect(md).toMatch(/all comparisons are ok|no anomalies/i)
+    expect(md).not.toContain("## Flagged")
+  })
+
+  test("handles empty results gracefully", () => {
+    expect(formatMarkdownReport([])).toMatch(/no metric comparisons/i)
+  })
+
+  test("formats large numbers with k/m/b suffixes", () => {
+    const md = formatMarkdownReport([critical])
+    // critical has llamaValue 1_000_000_000 and externalValue 500_000_000
+    expect(md).toContain("1.00b")
+    expect(md).toContain("500.00m")
+  })
+
+  test("does not flag missing as ok", () => {
+    const md = formatMarkdownReport([ok, missing])
+    expect(md).toContain("MISSING")
+    expect(md).toContain("## Flagged")
+  })
+})

--- a/defi/src/dataQuality/reportFormatter.ts
+++ b/defi/src/dataQuality/reportFormatter.ts
@@ -1,0 +1,165 @@
+/**
+ * Report formatters for {@link MetricComparisonResult} arrays.
+ *
+ * Provides:
+ * - {@link formatJsonReport} — stable machine-readable JSON with schema
+ *   versioning and a summary counts block.
+ * - {@link formatMarkdownReport} — human-readable Markdown with linked
+ *   sources, intended for PR descriptions and curated sample reports.
+ *
+ * The plain-text one-line-per-row formatter lives in
+ * {@link ./externalMetricComparison.formatMetricComparisonReport} and is
+ * kept there to preserve backwards-compatibility with PR #11850's output.
+ */
+
+import { MetricComparisonResult } from "./externalMetricComparison"
+
+/** Schema version of the JSON report format. Bump on incompatible changes. */
+export const REPORT_SCHEMA_VERSION = "1.0.0"
+
+/** Counts of comparison results by status. */
+export interface ReportSummary {
+  total: number
+  ok: number
+  warning: number
+  critical: number
+  missing: number
+}
+
+/** Top-level shape of a JSON report. Useful for downstream consumers. */
+export interface JsonReport {
+  schema_version: string
+  generated_at: string
+  summary: ReportSummary
+  results: MetricComparisonResult[]
+}
+
+/**
+ * Aggregates an array of comparison results into status counts.
+ *
+ * @param results - Comparison results to summarize.
+ * @returns Counts of each status plus total.
+ */
+export function summarize(results: MetricComparisonResult[]): ReportSummary {
+  const summary: ReportSummary = {
+    total: results.length,
+    ok: 0,
+    warning: 0,
+    critical: 0,
+    missing: 0,
+  }
+  for (const r of results) summary[r.status]++
+  return summary
+}
+
+/**
+ * Renders comparison results as pretty-printed JSON.
+ *
+ * Output matches the {@link JsonReport} shape and is stable:
+ * downstream consumers can rely on `schema_version`, `generated_at`,
+ * `summary` (counts), and `results` (verbatim array of input).
+ *
+ * @param results - Comparison results to render.
+ * @returns Pretty-printed JSON string (2-space indent).
+ */
+export function formatJsonReport(results: MetricComparisonResult[]): string {
+  const report: JsonReport = {
+    schema_version: REPORT_SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    summary: summarize(results),
+    results,
+  }
+  return JSON.stringify(report, null, 2)
+}
+
+/**
+ * Renders comparison results as a human-readable Markdown report.
+ *
+ * Layout:
+ * - Title + generation timestamp
+ * - Summary table (counts by status)
+ * - "Flagged Comparisons" section listing every non-ok result with
+ *   linked sources, relative + absolute diff, and message
+ * - "All clear" note if no flagged rows
+ *
+ * Intended for PR descriptions, GitHub-rendered sample reports, and
+ * curated findings documents.
+ *
+ * @param results - Comparison results to render.
+ * @returns Markdown string.
+ */
+export function formatMarkdownReport(
+  results: MetricComparisonResult[],
+): string {
+  if (!results.length) return "No metric comparisons were run."
+
+  const summary = summarize(results)
+  const flagged = results.filter((r) => r.status !== "ok")
+
+  const lines: string[] = [
+    "# DefiLlama Data Quality Report",
+    "",
+    `**Generated:** ${new Date().toISOString()}`,
+    "",
+    "## Summary",
+    "",
+    `- **Total:** ${summary.total}`,
+    `- **OK:** ${summary.ok}`,
+    `- **Warning:** ${summary.warning}`,
+    `- **Critical:** ${summary.critical}`,
+    `- **Missing:** ${summary.missing}`,
+    "",
+  ]
+
+  if (flagged.length === 0) {
+    lines.push(
+      "All comparisons are ok — no anomalies detected.",
+      "",
+    )
+    return lines.join("\n")
+  }
+
+  lines.push("## Flagged Comparisons", "")
+
+  for (const r of flagged) {
+    lines.push(`### ${r.entity} / ${r.metric} — ${r.status.toUpperCase()}`, "")
+
+    const llamaSrc = r.llamaUrl ? ` ([source](${r.llamaUrl}))` : ""
+    const externalSrc = r.externalUrl ? ` ([source](${r.externalUrl}))` : ""
+
+    lines.push(
+      `- **DefiLlama (${r.llamaProvider}):** ${formatNumber(r.llamaValue)}${llamaSrc}`,
+    )
+    lines.push(
+      `- **External (${r.externalProvider}):** ${formatNumber(r.externalValue)}${externalSrc}`,
+    )
+
+    lines.push(
+      `- **Relative diff:** ${
+        r.relativeDiff === null ? "n/a" : `${(r.relativeDiff * 100).toFixed(2)}%`
+      }`,
+    )
+
+    if (r.absoluteDiff !== null) {
+      lines.push(`- **Absolute diff:** ${formatNumber(r.absoluteDiff)}`)
+    }
+
+    if (r.timestampDriftSeconds !== null) {
+      lines.push(`- **Timestamp drift:** ${r.timestampDriftSeconds}s`)
+    }
+
+    lines.push(`- **Message:** ${r.message}`, "")
+  }
+
+  return lines.join("\n")
+}
+
+/** Formats a number with k/m/b suffixes; returns "n/a" for null. */
+function formatNumber(value: number | null): string {
+  if (value === null) return "n/a"
+  const abs = Math.abs(value)
+  if (abs >= 1e9) return `${(value / 1e9).toFixed(2)}b`
+  if (abs >= 1e6) return `${(value / 1e6).toFixed(2)}m`
+  if (abs >= 1e3) return `${(value / 1e3).toFixed(2)}k`
+  return `${Math.round(value * 100) / 100}`
+}

--- a/defi/src/dataQuality/runComparisons.ts
+++ b/defi/src/dataQuality/runComparisons.ts
@@ -27,28 +27,40 @@ import {
 import { UrlPayloadCache } from "./fetchWithRetry"
 
 /** Zod schema for a single comparison entry. */
-export const ComparisonConfigSchema = z.object({
-  entity: z.string(),
-  metric: z.string(),
-  llamaUrl: z.string().url(),
-  llamaPath: z.string(),
-  /** Optional path for `llama` timestamp (refs #11830 Bug #2 fix). */
-  llamaTimestampPath: z.string().optional(),
-  externalProvider: z.string(),
-  externalUrl: z.string().url(),
-  externalPath: z.string(),
-  /** Optional path for external timestamp (refs #11830 Bug #2 fix). */
-  externalTimestampPath: z.string().optional(),
-  warningThreshold: z.number().optional(),
-  criticalThreshold: z.number().optional(),
-  minAbsDiff: z.number().optional(),
-  maxTimestampDriftSeconds: z.number().optional(),
-})
+export const ComparisonConfigSchema = z
+  .object({
+    entity: z.string(),
+    metric: z.string(),
+    llamaUrl: z.string().url(),
+    llamaPath: z.string(),
+    /** Optional path for `llama` timestamp (refs #11830 Bug #2 fix). */
+    llamaTimestampPath: z.string().optional(),
+    externalProvider: z.string(),
+    externalUrl: z.string().url(),
+    externalPath: z.string(),
+    /** Optional path for external timestamp (refs #11830 Bug #2 fix). */
+    externalTimestampPath: z.string().optional(),
+    warningThreshold: z.number().nonnegative().optional(),
+    criticalThreshold: z.number().nonnegative().optional(),
+    minAbsDiff: z.number().nonnegative().optional(),
+    maxTimestampDriftSeconds: z.number().nonnegative().optional(),
+  })
+  .strict()
+  .refine(
+    ({ warningThreshold, criticalThreshold }) =>
+      warningThreshold === undefined ||
+      criticalThreshold === undefined ||
+      criticalThreshold >= warningThreshold,
+    {
+      path: ["criticalThreshold"],
+      message: "criticalThreshold must be greater than or equal to warningThreshold",
+    },
+  )
 
 /** Zod schema for a full config file. */
 export const ConfigSchema = z.object({
   comparisons: z.array(ComparisonConfigSchema),
-})
+}).strict()
 
 /** A single comparison entry. */
 export type Comparison = z.infer<typeof ComparisonConfigSchema>

--- a/defi/src/dataQuality/runComparisons.ts
+++ b/defi/src/dataQuality/runComparisons.ts
@@ -1,0 +1,152 @@
+/**
+ * Pipeline that turns a {@link Config} into an array of
+ * {@link MetricComparisonResult} via two passes:
+ *
+ *   Pass 1: collect every unique URL across all comparisons; resolve them
+ *           in parallel through a {@link UrlPayloadCache}.
+ *   Pass 2: synchronously map each comparison to a result by reading the
+ *           prefetched payloads and calling {@link compareMetricSample}.
+ *
+ * The two-pass split is the fix for refs #11830 Bug #3 — every URL is
+ * fetched exactly once per run, so two comparisons sharing an endpoint
+ * cannot read different snapshots from it.
+ *
+ * Bug #2 (timestamp paths never wired) is fixed here too: the config now
+ * carries optional `llamaTimestampPath` / `externalTimestampPath`, and
+ * Pass 2 populates `MetricSample.timestamp` from those paths so that
+ * `maxTimestampDriftSeconds` actually gates results.
+ */
+
+import { z } from "zod"
+import {
+  compareMetricSample,
+  numberAtPath,
+  MetricComparisonOptions,
+  MetricComparisonResult,
+} from "./externalMetricComparison"
+import { UrlPayloadCache } from "./fetchWithRetry"
+
+/** Zod schema for a single comparison entry. */
+export const ComparisonConfigSchema = z.object({
+  entity: z.string(),
+  metric: z.string(),
+  llamaUrl: z.string().url(),
+  llamaPath: z.string(),
+  /** Optional path for `llama` timestamp (refs #11830 Bug #2 fix). */
+  llamaTimestampPath: z.string().optional(),
+  externalProvider: z.string(),
+  externalUrl: z.string().url(),
+  externalPath: z.string(),
+  /** Optional path for external timestamp (refs #11830 Bug #2 fix). */
+  externalTimestampPath: z.string().optional(),
+  warningThreshold: z.number().optional(),
+  criticalThreshold: z.number().optional(),
+  minAbsDiff: z.number().optional(),
+  maxTimestampDriftSeconds: z.number().optional(),
+})
+
+/** Zod schema for a full config file. */
+export const ConfigSchema = z.object({
+  comparisons: z.array(ComparisonConfigSchema),
+})
+
+/** A single comparison entry. */
+export type Comparison = z.infer<typeof ComparisonConfigSchema>
+
+/** Top-level config (a list of comparisons). */
+export type Config = z.infer<typeof ConfigSchema>
+
+/** Options for {@link runComparisons}. */
+export interface RunComparisonsOptions {
+  /** Inject a cache (useful for testing or sharing across runs). */
+  cache?: UrlPayloadCache
+  /** Per-fetch retry / timeout options forwarded to the cache. */
+  fetchOptions?: { retries?: number; backoffMs?: number; timeoutMs?: number }
+  /** Callback invoked per failed URL (already isolated — batch continues). */
+  onFetchError?: (url: string, error: unknown) => void
+}
+
+/**
+ * Runs all comparisons declared in `config` and returns one result per entry.
+ *
+ * Failures are isolated: a fetch error makes the corresponding comparison's
+ * value `null`, which produces a `missing` status for that row. Other rows
+ * are unaffected.
+ *
+ * @param config - Validated config (use {@link ConfigSchema} to parse).
+ * @param opts - Optional cache, fetch options, and error callback.
+ * @returns Array of results, one per `comparisons[]` entry, in input order.
+ */
+export async function runComparisons(
+  config: Config,
+  opts: RunComparisonsOptions = {},
+): Promise<MetricComparisonResult[]> {
+  const cache = opts.cache ?? new UrlPayloadCache()
+
+  // Pass 1: resolve every unique URL in parallel.
+  const urls = [
+    ...new Set(
+      config.comparisons.flatMap((c) => [c.llamaUrl, c.externalUrl]),
+    ),
+  ]
+  const settled = await Promise.allSettled(
+    urls.map((u) => cache.get(u, opts.fetchOptions)),
+  )
+  const payloads = new Map<string, unknown | null>()
+  for (let i = 0; i < urls.length; i++) {
+    const r = settled[i]
+    if (r.status === "fulfilled") {
+      payloads.set(urls[i], r.value)
+    } else {
+      payloads.set(urls[i], null)
+      opts.onFetchError?.(urls[i], r.reason)
+    }
+  }
+
+  // Pass 2: synchronous compare per entry.
+  return config.comparisons.map((c) => {
+    const llamaPayload = payloads.get(c.llamaUrl) ?? null
+    const externalPayload = payloads.get(c.externalUrl) ?? null
+
+    const llamaTimestamp =
+      c.llamaTimestampPath && llamaPayload !== null
+        ? numberAtPath(llamaPayload, c.llamaTimestampPath) ?? undefined
+        : undefined
+
+    const externalTimestamp =
+      c.externalTimestampPath && externalPayload !== null
+        ? numberAtPath(externalPayload, c.externalTimestampPath) ?? undefined
+        : undefined
+
+    const options: MetricComparisonOptions = {
+      warningThreshold: c.warningThreshold,
+      criticalThreshold: c.criticalThreshold,
+      minAbsDiff: c.minAbsDiff,
+      maxTimestampDriftSeconds: c.maxTimestampDriftSeconds,
+    }
+
+    return compareMetricSample(
+      {
+        provider: "llama",
+        entity: c.entity,
+        metric: c.metric,
+        value:
+          llamaPayload === null ? null : numberAtPath(llamaPayload, c.llamaPath),
+        timestamp: llamaTimestamp,
+        url: c.llamaUrl,
+      },
+      {
+        provider: c.externalProvider,
+        entity: c.entity,
+        metric: c.metric,
+        value:
+          externalPayload === null
+            ? null
+            : numberAtPath(externalPayload, c.externalPath),
+        timestamp: externalTimestamp,
+        url: c.externalUrl,
+      },
+      options,
+    )
+  })
+}


### PR DESCRIPTION
## Summary

Adds a small CLI for running data-quality checks by comparing DefiLlama
metrics against another JSON source.

The tool is config-driven: each config defines the two URLs, JSON paths,
thresholds, and optional timestamp fields. It fetches each unique URL once,
compares the values, and reports rows as `ok`, `warning`, `critical`, or
`missing`.

## What changed

- Added `npm run compare-external-metrics`
- Added retrying JSON fetches with per-run URL caching
- Added metric comparison logic with relative/absolute thresholds
- Added optional timestamp drift checks
- Added text, JSON, and Markdown report output
- Added a sample config and README for adding more checks
- Added tests for the fetcher, comparator, reports, CLI parser, and
  integration flow

## Validation

cd defi
node_modules/.bin/jest --testPathPattern="dataQuality|compareExternalMetrics" \
--runInBand --no-coverage --forceExit

Passes locally: 5 suites, 55 tests.