### PR TITLE
test: add unit tests for stablecoin volume spike detection

### DIFF
--- a/defi/src/server-scripts/storeStablecoinVolume.test.ts
+++ b/defi/src/server-scripts/storeStablecoinVolume.test.ts
@@ -1,0 +1,133 @@
+import {
+  collectHistoricalVolumes,
+  detectSpikesFromTotals,
+  isTokenBlacklisted,
+  median,
+  type VolumeCache,
+} from "./storeStablecoinVolume";
+
+describe("storeStablecoinVolume spike helpers", () => {
+  describe("median", () => {
+    it("returns 0 for empty list", () => {
+      expect(median([])).toBe(0);
+    });
+
+    it("returns middle value for odd length", () => {
+      expect(median([3, 1, 2])).toBe(2);
+    });
+
+    it("returns mean of middle two for even length", () => {
+      expect(median([10, 1, 2, 3])).toBe((2 + 3) / 2);
+    });
+  });
+
+  describe("isTokenBlacklisted", () => {
+    it("returns true for all-days blacklist entries", () => {
+      const ts = Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000);
+      expect(isTokenBlacklisted("DUSD", ts)).toBe(true);
+    });
+
+    it("returns true for specific-date blacklist entries", () => {
+      const ts = Math.floor(new Date("2022-08-14T12:00:00Z").getTime() / 1000);
+      expect(isTokenBlacklisted("USDZ", ts)).toBe(true);
+    });
+
+    it("returns false for non-blacklisted tokens", () => {
+      const ts = Math.floor(new Date("2022-08-14T12:00:00Z").getTime() / 1000);
+      expect(isTokenBlacklisted("USDC", ts)).toBe(false);
+    });
+  });
+
+  describe("collectHistoricalVolumes", () => {
+    it("collects only positive finite volumes and excludes current timestamp", () => {
+      const t1 = 1_700_000_000;
+      const t2 = t1 + 86400;
+      const t3 = t2 + 86400;
+      const cache: VolumeCache = {
+        [String(t1)]: { timestamp: t1, chains: { ethereum: { tokens: { USDC: 10 }, currencies: {} } } },
+        [String(t2)]: { timestamp: t2, chains: { ethereum: { tokens: { USDC: 0, USDT: 5 }, currencies: {} } } },
+        [String(t3)]: { timestamp: t3, chains: { ethereum: { tokens: { USDC: Number.POSITIVE_INFINITY as any }, currencies: {} } } },
+      };
+
+      expect(collectHistoricalVolumes(cache, "ethereum", "USDC", t1)).toEqual([]); // excluded, and others are invalid
+      expect(collectHistoricalVolumes(cache, "ethereum", "USDT", t2)).toEqual([]); // excluded
+      expect(collectHistoricalVolumes(cache, "ethereum", "USDC", t2)).toEqual([10]); // t1 only
+    });
+  });
+
+  describe("detectSpikesFromTotals", () => {
+    function mkHistory(values: number[], chain = "ethereum", token = "USDC", baseTs = 1_700_000_000): VolumeCache {
+      const out: VolumeCache = {};
+      values.forEach((v, i) => {
+        const ts = baseTs + i * 86400;
+        out[String(ts)] = { timestamp: ts, chains: { [chain]: { tokens: { [token]: v }, currencies: {} } } };
+      });
+      return out;
+    }
+
+    it("does not flag when past observations < min", () => {
+      const timestamp = 1_700_999_999;
+      const history = mkHistory([1, 1, 1, 1, 1]); // 5 obs
+      const totals = new Map<string, number>([["ethereum|USDC", 1_000_000_000]]);
+
+      const { spiked, spikes } = detectSpikesFromTotals(totals, history, timestamp, {
+        spikeAbsFloor: 1,
+        spikeRatio: 2,
+        spikeMinObs: 10,
+      });
+
+      expect(spiked.size).toBe(0);
+      expect(spikes).toEqual([]);
+    });
+
+    it("does not flag when total is below abs floor", () => {
+      const timestamp = 1_700_999_999;
+      const history = mkHistory(new Array(12).fill(1_000));
+      const totals = new Map<string, number>([["ethereum|USDC", 999]]);
+
+      const { spiked } = detectSpikesFromTotals(totals, history, timestamp, {
+        spikeAbsFloor: 1_000,
+        spikeRatio: 2,
+        spikeMinObs: 10,
+      });
+
+      expect(spiked.size).toBe(0);
+    });
+
+    it("flags when total >= abs floor and >= ratio * median", () => {
+      const timestamp = 1_700_999_999;
+      const history = mkHistory(new Array(12).fill(1_000_000)); // median = 1_000_000
+      const totals = new Map<string, number>([["ethereum|USDC", 3_000_000_000]]); // 3000x vs median=1M
+
+      const { spiked, spikes } = detectSpikesFromTotals(totals, history, timestamp, {
+        spikeAbsFloor: 200_000_000,
+        spikeRatio: 1000,
+        spikeMinObs: 10,
+      });
+
+      expect(spiked.has("ethereum|USDC")).toBe(true);
+      expect(spikes).toHaveLength(1);
+      expect(spikes[0]).toMatchObject({
+        chain: "ethereum",
+        token: "USDC",
+        volume: 3_000_000_000,
+        median: 1_000_000,
+      });
+    });
+
+    it("does not flag when median is 0", () => {
+      const timestamp = 1_700_999_999;
+      const history = mkHistory(new Array(12).fill(0));
+      const totals = new Map<string, number>([["ethereum|USDC", 1_000_000_000]]);
+
+      const { spiked } = detectSpikesFromTotals(totals, history, timestamp, {
+        spikeAbsFloor: 1,
+        spikeRatio: 2,
+        spikeMinObs: 10,
+      });
+
+      expect(spiked.size).toBe(0);
+    });
+  });
+});
+

--- a/defi/src/server-scripts/storeStablecoinVolume.ts
+++ b/defi/src/server-scripts/storeStablecoinVolume.ts
@@ -44,7 +44,7 @@ if (_refillIdx !== -1 && (!REFILL_DATE || !/^\d{4}-\d{2}-\d{2}$/.test(REFILL_DAT
 // tokens with known-bad volume data on allium; excluded from aggregation
 //   'all'    -> drop the token from every day
 //   string[] -> drop the token only on the listed YYYY-MM-DD dates (UTC)
-const TOKEN_BLACKLIST: Record<string, 'all' | string[]> = {
+export const TOKEN_BLACKLIST: Record<string, 'all' | string[]> = {
   DUSD: 'all',
   USDX: 'all',
   USDZ: ['2022-08-14'],  // example: blacklist USDZ on specific dates only
@@ -52,7 +52,7 @@ const TOKEN_BLACKLIST: Record<string, 'all' | string[]> = {
   SUSD: ['2025-08-06'],
 };
 
-function isTokenBlacklisted(token: string, dayTimestamp: number): boolean {
+export function isTokenBlacklisted(token: string, dayTimestamp: number): boolean {
   const rule = TOKEN_BLACKLIST[token];
   if (!rule) return false;
   if (rule === 'all') return true;
@@ -224,7 +224,7 @@ function formatToken(token: string): string {
   return token.toUpperCase();
 }
 
-interface DailyVolume {
+export interface DailyVolume {
   timestamp: number;
   chains: Record<string, {
     tokens: Record<string, number>;
@@ -232,13 +232,13 @@ interface DailyVolume {
   }>;
 }
 
-type VolumeCache = Record<string, DailyVolume>;
+export type VolumeCache = Record<string, DailyVolume>;
 
 function buildEmptyDaily(timestamp: number): DailyVolume {
   return { timestamp, chains: {} };
 }
 
-function median(xs: number[]): number {
+export function median(xs: number[]): number {
   const s = [...xs].sort((a, b) => a - b);
   const n = s.length;
   if (n === 0) return 0;
@@ -275,7 +275,7 @@ function logSpikes() {
   }
 }
 
-function collectHistoricalVolumes(cache: VolumeCache, chain: string, token: string, excludeTs: number): number[] {
+export function collectHistoricalVolumes(cache: VolumeCache, chain: string, token: string, excludeTs: number): number[] {
   const out: number[] = [];
   for (const [ts, daily] of Object.entries(cache)) {
     if (Number(ts) === excludeTs) continue;
@@ -283,6 +283,48 @@ function collectHistoricalVolumes(cache: VolumeCache, chain: string, token: stri
     if (typeof vol === 'number' && isFinite(vol) && vol > 0) out.push(vol);
   }
   return out;
+}
+
+export type SpikeDetectionOpts = {
+  spikeAbsFloor?: number;
+  spikeRatio?: number;
+  spikeMinObs?: number;
+};
+
+/**
+ * Pure spike detection helper used by queryDay().
+ * Returns the set of `${chain}|${token}` keys to drop for the provided timestamp.
+ */
+export function detectSpikesFromTotals(
+  totals: Map<string, number>,
+  history: VolumeCache,
+  timestamp: number,
+  opts: SpikeDetectionOpts = {},
+): { spiked: Set<string>; spikes: DetectedSpike[] } {
+  const spikeAbsFloor = opts.spikeAbsFloor ?? SPIKE_ABS_FLOOR;
+  const spikeRatio = opts.spikeRatio ?? SPIKE_RATIO;
+  const spikeMinObs = opts.spikeMinObs ?? SPIKE_MIN_OBS;
+
+  const spiked = new Set<string>();
+  const spikes: DetectedSpike[] = [];
+
+  for (const [k, total] of totals) {
+    if (total < spikeAbsFloor) continue;
+    const [chain, token] = k.split('|');
+    const past = collectHistoricalVolumes(history, chain, token, timestamp);
+    if (past.length < spikeMinObs) continue;
+    const med = median(past);
+    if (med <= 0) continue;
+    const ratio = total / med;
+    if (ratio >= spikeRatio) {
+      const date = new Date(timestamp * 1000).toISOString().split('T')[0];
+      const rec = { date, chain, token, volume: total, median: med, ratio, historyN: past.length };
+      spikes.push(rec);
+      spiked.add(k);
+    }
+  }
+
+  return { spiked, spikes };
 }
 
 async function loadCache(): Promise<VolumeCache> {
@@ -342,21 +384,8 @@ async function queryDay(timestamp: number, history: VolumeCache): Promise<DailyV
   }
 
   // detect spikes vs historical median for this (chain, token)
-  const spiked = new Set<string>();
-  for (const [k, total] of totals) {
-    if (total < SPIKE_ABS_FLOOR) continue;
-    const [chain, token] = k.split('|');
-    const past = collectHistoricalVolumes(history, chain, token, timestamp);
-    if (past.length < SPIKE_MIN_OBS) continue;
-    const med = median(past);
-    if (med <= 0) continue;
-    const ratio = total / med;
-    if (ratio >= SPIKE_RATIO) {
-      const date = new Date(timestamp * 1000).toISOString().split('T')[0];
-      detectedSpikes.push({ date, chain, token, volume: total, median: med, ratio, historyN: past.length });
-      spiked.add(k);
-    }
-  }
+  const { spiked, spikes } = detectSpikesFromTotals(totals, history, timestamp);
+  detectedSpikes.push(...spikes);
 
   // build daily, skipping spike-detected (blacklist already filtered above)
   const daily = buildEmptyDaily(timestamp);
@@ -369,7 +398,7 @@ async function queryDay(timestamp: number, history: VolumeCache): Promise<DailyV
   return daily;
 }
 
-(async function () {
+export async function main() {
   const currentTimestamp = getCurrentTimestamp();
   const yesterdayStart = getStartDayTimestamp(currentTimestamp - DAY);
   const startTs = getStartDayTimestamp(getUnixTimestamp(START_DATE));
@@ -429,4 +458,11 @@ async function queryDay(timestamp: number, history: VolumeCache): Promise<DailyV
   console.log(`# cache size: ${bytes.toLocaleString()} bytes (${mb.toFixed(2)} MB, ~${perDayKb.toFixed(2)} KB/day)`);
   logSpikes();
   console.log('');
-})()
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
#### Summary
- Export pure helpers for blacklist/median/historical volume collection
- Add detectSpikesFromTotals() and cover key threshold edge cases
- Keep script runnable via main() + require.main guard

#### Test
- Run `npm test -- --testPathPattern=server-scripts/storeStablecoinVolume.test.ts` from `/defi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for stablecoin volume spike detection, validating median calculations, token blacklist checks, historical volume collection, and spike detection logic across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->