### PR TITLE
Add AlphaToken XAUa price adapter

### DIFF
--- a/coins/src/adapters/index.ts
+++ b/coins/src/adapters/index.ts
@@ -190,6 +190,7 @@ export default {
   wisdomtree: require("./rwa/wisdomtree"),
   townsquare: require("./townsquare"),
   axc: require("./rwa/axc"),
+  alphatoken: require("./rwa/alphatoken"),
   notional: require("./yield/notional"),
   shift: require("./yield/shift"),
   makina: require("./yield/makina"),

--- a/coins/src/adapters/rwa/alphatoken.ts
+++ b/coins/src/adapters/rwa/alphatoken.ts
@@ -1,0 +1,43 @@
+import {
+  addToDBWritesList,
+  getTokenAndRedirectDataMap,
+} from "../utils/database";
+import { Write } from "../utils/dbInterfaces";
+import { getTokenInfo } from "../utils/erc20";
+
+const XAUA_ADDRESS = "0xF7303119E4E58C1F912cfC39D30f0167429A3dc2";
+const XAU_USD_FEED = "metal.xau:usd";
+const GRAMS_PER_TROY_OUNCE = 31.1034768;
+
+export async function alphatoken(timestamp: number = 0) {
+  const writes: Write[] = [];
+  const [prices, metadata] = await Promise.all([
+    getTokenAndRedirectDataMap([XAU_USD_FEED], "pyth", timestamp),
+    getTokenInfo("ethereum", [XAUA_ADDRESS], undefined, {
+      timestamp,
+    }),
+  ]);
+  const xauUsd = prices[XAU_USD_FEED]?.price;
+  const decimalsRes = metadata.decimals?.[0];
+  const symbolRes = metadata.symbols?.[0];
+
+  if (!xauUsd) return writes;
+  if (!decimalsRes?.success || decimalsRes.output == null) return writes;
+  if (!symbolRes?.success || symbolRes.output == null) return writes;
+
+  const xauaUsd = xauUsd / GRAMS_PER_TROY_OUNCE;
+
+  addToDBWritesList(
+    writes,
+    "ethereum",
+    XAUA_ADDRESS,
+    xauaUsd,
+    Number(decimalsRes.output),
+    String(symbolRes.output),
+    timestamp,
+    "alphatoken",
+    0.9,
+  );
+
+  return writes;
+}


### PR DESCRIPTION
Adds a coins adapter for AlphaToken XAUa on Ethereum.

- Prices XAUa from DefiLlama's existing Pyth Metal.XAU:USD feed
- Converts troy-ounce gold pricing to per-gram pricing using 31.1034768 grams per troy ounce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New alphatoken adapter enables real-time XAUA token pricing on the Ethereum network. The system fetches live XAU/USD market data and automatically converts prices from troy ounce basis to gram basis for accurate token valuations. Token information is fully integrated and continuously synchronized with current market rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->