### PR TITLE
Added Chainlink as primary oracle for Aave V4

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -15255,6 +15255,7 @@ const data5: Protocol[] = [
     module: "aave-v4/index.js",
     twitter: "aave",
     audit_links: ["https://aave.com/security"],
+    oraclesBreakdown: [ { name: "Chainlink", type: "Primary", proof: ["https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/4", "https://aave.com/docs/ecosystem/oracle"]} ],
     listedAt: 1774886314,
     parentProtocol: "parent#aave",
     dimensions: {


### PR DESCRIPTION
Hello Defillama team,

This PR adds Chainlink as the primary oracle for Aave V4, as Aave continues to rely on Chainlink as its core oracle infrastructure.

From Aave’s official oracle documentation, Chainlink Price Feeds are the canonical oracle system used by the protocol for secure and reliable asset pricing:
https://aave.com/docs/ecosystem/oracle

In the Aave V4 activation governance discussion, Aave confirms that standard Chainlink feeds are used in current deployments and that Chainlink SVR (Smart Value Recapture) feeds are intended to be integrated into V4 equivalently:
https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/4

This demonstrates both:

- existing reliance on Chainlink for core pricing infrastructure
- explicit intent to continue using Chainlink feeds in Aave V4

Since oracle pricing directly determines collateral valuation, borrowing power, and liquidations, Chainlink plays a critical role in securing the economic value of assets within Aave V4 markets.

Screenshots:

<img width="1480" height="342" alt="aave_v4_docs_screenshot_2" src="https://github.com/user-attachments/assets/2bd6b110-888a-4bba-90ee-fdef75319f24" />

<img width="1530" height="632" alt="aave_v4_docs_screenshot_1" src="https://github.com/user-attachments/assets/e52045cf-4334-4a6e-8102-070c3b5c6209" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chainlink oracle metadata with associated proof URLs to the Aave V4 protocol, enhancing oracle information visibility for protocol details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->