### PR TITLE
Optimize batch historical coin lookups

### DIFF
--- a/coins/src/getBatchHistoricalCoins.ts
+++ b/coins/src/getBatchHistoricalCoins.ts
@@ -16,7 +16,7 @@ export async function fetchDBData(
   searchWidth: number = defaultSearchWidth
 ) {
   let response = {} as any;
-  const promises: Promise<any>[] = [];
+  const tasks: Array<() => Promise<void>> = [];
 
   const coinQueries: string[] = Object.keys(coinsObj);
   const { PKTransforms, coins } = await getBasicCoins(coinQueries);
@@ -25,8 +25,8 @@ export async function fetchDBData(
     PKTransforms[coin.PK].forEach((coinName) => {
       const timestamps: number[] = coinsObj[coinName];
       if (!Array.isArray(timestamps)) return;
-      promises.push(
-        ...timestamps.map(async (timestamp) => {
+      tasks.push(
+        ...timestamps.map((timestamp) => async () => {
           const finalCoin: any = await getRecordClosestToTimestamp(
             coin.redirect ?? coin.PK,
             timestamp,
@@ -59,9 +59,9 @@ export async function fetchDBData(
   });
 
   await runInPromisePool({
-    items: promises,
+    items: tasks,
     concurrency: 7,
-    processor: async (promise: any) => await promise,
+    processor: async (task: () => Promise<void>) => task(),
   });
 
   return response;

--- a/coins/src/getBatchHistoricalCoins.ts
+++ b/coins/src/getBatchHistoricalCoins.ts
@@ -25,8 +25,8 @@ export async function fetchDBData(
     PKTransforms[coin.PK].forEach((coinName) => {
       const timestamps: number[] = coinsObj[coinName];
       if (!Array.isArray(timestamps)) return;
-      tasks.push(
-        ...timestamps.map((timestamp) => async () => {
+      for (const timestamp of timestamps) {
+        tasks.push(async () => {
           const finalCoin: any = await getRecordClosestToTimestamp(
             coin.redirect ?? coin.PK,
             timestamp,
@@ -53,8 +53,8 @@ export async function fetchDBData(
               confidence: coin.confidence,
             });
           }
-        })
-      );
+        });
+      }
     });
   });
 

--- a/coins/src/utils/getCoinsUtils.ts
+++ b/coins/src/utils/getCoinsUtils.ts
@@ -34,7 +34,7 @@ export const batchGetLatest = (pks: string[]) =>
 
 export async function getBasicCoins(requestedCoins: string[]) {
   const PKTransforms = {} as { [pk: string]: string[] };
-  const pks: string[] = [];
+  const pks = new Set<string>();
   requestedCoins.forEach((coin) => {
     const pk = coinToPK(coin);
     if (PKTransforms[pk]) {
@@ -42,9 +42,9 @@ export async function getBasicCoins(requestedCoins: string[]) {
     } else {
       PKTransforms[pk] = [coin];
     }
-    pks.push(pk);
+    pks.add(pk);
   });
-  const coins = await batchGetLatest(pks);
+  const coins = await batchGetLatest([...pks]);
   return { coins, PKTransforms };
 }
 


### PR DESCRIPTION
### Summary
*  Fix concurrency limiting in getBatchHistoricalCoins by passing deferred tasks to the promise pool instead of  already-started promises
*  De-dupe coin PKs in getBasicCoins before batch reads
* Preserve PKTransforms behavior so duplicate aliases and casing variants still resolve separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched historical coin fetches to deferred task execution while preserving concurrency, improving reliability of batched requests.
  * Replaced duplicate-key accumulation with a deduplication set for coin partition keys, reducing memory use and improving lookup efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->