### PR TITLE
fix: stop api test fallthrough

### DIFF
--- a/defi/ui-tool/src/server.ts
+++ b/defi/ui-tool/src/server.ts
@@ -244,6 +244,7 @@ async function start() {
           break;
         case 'api-test-stop':
           stopApiTests();
+          break;
         case 'spikes-runCommand':
           runSpikesCommand(ws, data.data);
           break;


### PR DESCRIPTION
add missing break after 'api-test-stop' to prevent fallthrough, which could incorrectly trigger spike command when stopping API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stopping API tests could inadvertently trigger unintended operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->