### PR TITLE
Add LUKSO Hyperlane USDC token mapping

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -10428,6 +10428,11 @@
       "to": "coingecko#fabs",
       "decimals": 18,
       "symbol": "FABS"
+    },
+    "0xe0c2e4f894d4cd33626e33b24582559f3156e1ab": {
+      "to": "coingecko#usd-coin",
+      "decimals": 6,
+      "symbol": "USDC"
     }
   },
   "joltify": {

--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -10430,7 +10430,7 @@
       "symbol": "FABS"
     },
     "0xe0c2e4f894d4cd33626e33b24582559f3156e1ab": {
-      "to": "coingecko#usd-coin",
+      "to": "coingecko#hyperlane-bridged-usdc-lukso",
       "decimals": 6,
       "symbol": "USDC"
     }


### PR DESCRIPTION
Add LUKSO Hyperlane USDC token mapping.

Validation:
- Verified tokenMapping.json parses as valid JSON.
- Confirmed diff is limited to coins/src/adapters/tokenMapping.json.

Note: Jest was not run because coins/node_modules is absent and installing dependencies is blocked by the repository's stale package-lock (previous npm ci --ignore-scripts failed on missing AWS/clickhouse packages and version mismatches). No lockfiles were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for USDC stablecoin on the Elysium chain, enabling users to interact with this token on the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->