### PR TITLE
feat: wire CEX volume/OI adapters and prefer first-party data on /cexs

### DIFF
--- a/defi/src/api2/cron-task/cex.ts
+++ b/defi/src/api2/cron-task/cex.ts
@@ -6,6 +6,7 @@ import { cexsData, cg_volume_cexs } from "../../protocols/cex";
 import { getLatestProtocolItems } from "../db";
 import { hourlyTvl, hourlyUsdTokensTvl } from "../../utils/getLastRecord";
 import { pgGetInflows } from "../db/inflows";
+import { fetchAllFirstPartyData } from "./cexFirstParty";
 
 const isTESTMode = process.env.CEX_TEST_MODE === "true";
 const cacheKey = "cron-task/cex-last-update";
@@ -208,6 +209,21 @@ function sortDataAndFormatNumbers(src: any) {
 }
 
 async function addSpotAndDerivData() {
+  // Step 1: Fetch first-party data for supported exchanges (cached, direct from exchange APIs)
+  const firstPartyResults = await fetchAllFirstPartyData(isTESTMode);
+
+  // Step 2: Apply first-party data to matching CEX entries
+  for (const [name, data] of Object.entries(firstPartyResults)) {
+    const cex = cexDataNameMap[name] as any;
+    if (!cex) continue;
+    cex.spotVolume = data.spotVolume;
+    cex.derivVolume = data.derivVolume;
+    cex.oi = data.oi;
+    if (cex.cleanAssetsTvl) cex.leverage = cex.oi / cex.cleanAssetsTvl;
+    cex._dataSource = "first-party";
+  }
+
+  // Step 3: Fall back to CoinGecko for exchanges without first-party data
   const SPOT_DATA_URL = "https://api.coingecko.com/api/v3/exchanges?per_page=1000";
   const DERIV_DATA_URL = "https://api.coingecko.com/api/v3/derivatives/exchanges?per_page=1000";
 
@@ -219,21 +235,13 @@ async function addSpotAndDerivData() {
 
   spotData.forEach((item: any) => {
     const cex = cexCgIdMap[item.id] as any;
-    if (!cex) {
-      // console.warn(`CEX with cgId ${item.id} not found in protocols data spot volume: ${item.name}`)
-      return;
-    }
-
+    if (!cex || cex._dataSource === "first-party") return;
     cex.spotVolume = item.trade_volume_24h_btc * btcPrice;
   });
 
   derivData.forEach((item: any) => {
     const cex = cexCgDerivIdMap[item.id] as any;
-    if (!cex) {
-      // console.warn(`CEX with cgDeriv ${item.id} not found in protocols data deriv volume: ${item.name}`)
-      return;
-    }
-
+    if (!cex || cex._dataSource === "first-party") return;
     cex.oi = item.open_interest_btc * btcPrice;
     cex.derivVolume = item.trade_volume_24h_btc * btcPrice;
     if (cex.cleanAssetsTvl) cex.leverage = cex.oi / cex.cleanAssetsTvl;

--- a/defi/src/api2/cron-task/cexFirstParty.ts
+++ b/defi/src/api2/cron-task/cexFirstParty.ts
@@ -1,0 +1,52 @@
+import * as sdk from "@defillama/sdk";
+import type { CexVolumeResult } from "../../../dimension-adapters/helpers/cex";
+
+export type FirstPartyData = { spotVolume: number; derivVolume: number; oi: number };
+
+function toFirstPartyData(result: CexVolumeResult): FirstPartyData {
+  return { spotVolume: result.dailySpotVolume, derivVolume: result.dailyDerivativesVolume, oi: result.openInterest };
+}
+
+async function fetchExchange(fetchFn: keyof typeof import("../../../dimension-adapters/helpers/cex")): Promise<FirstPartyData> {
+  const mod = await import("../../../dimension-adapters/helpers/cex");
+  const result = await (mod[fetchFn] as () => Promise<CexVolumeResult>)();
+  return toFirstPartyData(result);
+}
+
+// Maps CEX name (as used in cexsData) to its exchange API fetcher.
+// To add a new exchange, add an entry here pointing to the corresponding
+// function name in dimension-adapters/helpers/cex.ts.
+const FIRST_PARTY_EXCHANGES: Record<string, Parameters<typeof fetchExchange>[0]> = {
+  "Binance": "fetchBinance",
+  "Bybit": "fetchBybit",
+  "OKX": "fetchOkx",
+};
+
+/**
+ * Fetch volume and OI directly from exchange APIs for supported CEXes.
+ * Results are cached via sdk.cache to avoid redundant calls within the
+ * cron interval.
+ */
+export async function fetchAllFirstPartyData(isTESTMode: boolean): Promise<Record<string, FirstPartyData>> {
+  const cacheKey = "cex/first-party-data";
+  const cached = await sdk.cache.readExpiringJsonCache(cacheKey).catch(() => null);
+  if (cached) return cached as Record<string, FirstPartyData>;
+
+  const results: Record<string, FirstPartyData> = {};
+  const entries = Object.entries(FIRST_PARTY_EXCHANGES);
+  const settled = await Promise.allSettled(entries.map(([, fn]) => fetchExchange(fn)));
+
+  settled.forEach((result, i) => {
+    const name = entries[i][0];
+    if (result.status === "fulfilled") {
+      results[name] = result.value;
+      if (isTESTMode)
+        console.log(`CEX first-party data for ${name}: spot=$${(result.value.spotVolume / 1e9).toFixed(2)}B, deriv=$${(result.value.derivVolume / 1e9).toFixed(2)}B, oi=$${(result.value.oi / 1e9).toFixed(2)}B`);
+    } else {
+      console.warn(`CEX first-party fetch failed for ${name}: ${result.reason}`);
+    }
+  });
+
+  await sdk.cache.writeExpiringJsonCache(cacheKey, results, { expireAfter: 10 * 60 * 1000 }); // cache for 10 min
+  return results;
+}

--- a/defi/src/protocols/data2.ts
+++ b/defi/src/protocols/data2.ts
@@ -19797,6 +19797,10 @@ const data2: Protocol[] = [
     module: "binance/index.js",
     twitter: "binance",
     listedAt: 1668170565,
+    dimensions: {
+      derivatives: "binance",
+      "open-interest": "binance-oi",
+    },
   },
   {
     id: "2270",
@@ -19860,6 +19864,10 @@ const data2: Protocol[] = [
     module: "okex/index.js",
     twitter: "okx",
     listedAt: 1668185769,
+    dimensions: {
+      derivatives: "okx",
+      "open-interest": "okx-oi",
+    },
   },
   {
     id: "2273",
@@ -20121,6 +20129,10 @@ const data2: Protocol[] = [
     module: "bybit/index.js",
     twitter: "Bybit_Official",
     listedAt: 1668595021,
+    dimensions: {
+      derivatives: "bybit",
+      "open-interest": "bybit-oi",
+    },
   },
   /*
   {


### PR DESCRIPTION
## Summary

Wires the new CEX adapters (DefiLlama/dimension-adapters#6652) into the protocol registry and updates the CEX cron task to prefer first-party exchange data over CoinGecko (happy to switch to CoinGecko if the team prefers consistency with the `/cexs` page). Closes #11121.

### How it works

1. CEX cron task calls `fetchAllFirstPartyData()` which fetches volume/OI directly from Binance, Bybit, and OKX public APIs (cached for 10 min)
2. Applies first-party data to matching CEX entries, marks them with `_dataSource: "first-party"`
3. Falls back to CoinGecko for all other exchanges (existing behavior unchanged)
4. Exchanges with first-party data are skipped in the CoinGecko step

### Adding a new exchange

1. Add fetch function in `dimension-adapters/helpers/cex.ts`
2. Add entry to `FIRST_PARTY_EXCHANGES` map in `cexFirstParty.ts`
3. Add `dimensions` to the protocol entry in `data2.ts`

Linked PR: DefiLlama/dimension-adapters#6652