### PR TITLE
Fix: Active/New user metrics are double counted

### DIFF
--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -26,17 +26,20 @@ const blacklistedAppCategorySet = new Set([
 const blacklistedAppIdSet = new Set([
   '4695', // bloXroute
 ])
+
 // Set-cardinality types, counts of distinct entities, are NOT additive across adaptors.
 // For these, chain rollup can NOT sum/concat per-protocol values.
 // Active/New User: per Chain + per Protocol => results in double-count.
-// Instead we can rely on the chain-level adapter count(DISTINCT) from raw txs.
-const isChainAdapter = (id?: string) => id?.startsWith('chain#') ?? false
-const SET_CARDINALITY_SOURCES = new Map<AdaptorRecordType, (id?: string) => boolean>([
+// Instead we can rely on the chain-level adapter count(DISTINCT) from raw txs,
+// or any info provided by ProtocolAdaptor type
+type CardinalityFilter = (info?: ProtocolAdaptor) => boolean
+const isChainAdapter: CardinalityFilter = (info) => info?.defillamaId?.startsWith('chain#') ?? false
+const SET_CARDINALITY_SOURCES = new Map<AdaptorRecordType, CardinalityFilter>([
   [AdaptorRecordType.dailyActiveUsers, isChainAdapter],
   [AdaptorRecordType.dailyNewUsers,    isChainAdapter],
 ])
 
-function getProtocolAppMetricsFlag(info: any) {
+function getProtocolAppMetricsFlag(info: ProtocolAdaptor) {
   if (info.protocolType && info.protocolType !== ProtocolType.PROTOCOL) return false
   if (info.category && blacklistedAppCategorySet.has(info.category!)) return false
   let id = info.id2 ?? info.id
@@ -464,7 +467,7 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
             const cardinalityFilter = SET_CARDINALITY_SOURCES.get(recordType)
             if (cardinalityFilter) {
               // for counts of distinct values
-              if (cardinalityFilter(protocolId)) chainSummary.chart[timeS] = value
+              if (cardinalityFilter(protocol.info)) chainSummary.chart[timeS] = value
             } else {
               // for counts of additive values
               chainSummary.chart[timeS] = (chainSummary.chart[timeS] ?? 0) + value
@@ -498,18 +501,17 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
         if (recordType === AdaptorRecordType.dailyAppFees) recordLabel = AdaptorRecordType.dailyFees
         if (recordType === AdaptorRecordType.dailyAppRevenue) recordLabel = AdaptorRecordType.dailyRevenue
 
-        const debugParams = { protocolId, }
         const categoriesParam = (!isParentProtocol && protocol.info.protocolType !== ProtocolType.CHAIN) ? _pCategories : undefined
-        addToSummary({ record: todayRecord?.aggObject[recordLabel], summaryKey: 'total24h', recordType, protocolSummary, skipChainSummary, protocolLatestRecord: protocolLatestRecord?.aggObject[recordLabel], categories: categoriesParam, debugParams, })
-        addToSummary({ record: yesterdayRecord?.aggObject[recordLabel], summaryKey: 'total48hto24h', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ record: _protocolData.sevenDaysAgo?.aggObject[recordType], summaryKey: 'total7DaysAgo', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ record: _protocolData.thirtyDaysAgo?.aggObject[recordType], summaryKey: 'total30DaysAgo', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ records: _protocolData.lastWeekData, summaryKey: 'total7d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        // addToSummary({ records: _protocolData.lastTwoWeekData, summaryKey: 'total14d', recordType, protocolSummary, skipChainSummary, debugParams, })
-        addToSummary({ records: _protocolData.lastTwoWeekToOneWeekData, summaryKey: 'total14dto7d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ records: _protocolData.last30DaysData, summaryKey: 'total30d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ records: _protocolData.last60to30DaysData, summaryKey: 'total60dto30d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
-        addToSummary({ records: _protocolData.lastOneYearData, summaryKey: 'total1y', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, debugParams, })
+        addToSummary({ record: todayRecord?.aggObject[recordLabel], summaryKey: 'total24h', recordType, protocolSummary, skipChainSummary, protocolLatestRecord: protocolLatestRecord?.aggObject[recordLabel], categories: categoriesParam, info: protocol.info, })
+        addToSummary({ record: yesterdayRecord?.aggObject[recordLabel], summaryKey: 'total48hto24h', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ record: _protocolData.sevenDaysAgo?.aggObject[recordType], summaryKey: 'total7DaysAgo', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ record: _protocolData.thirtyDaysAgo?.aggObject[recordType], summaryKey: 'total30DaysAgo', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ records: _protocolData.lastWeekData, summaryKey: 'total7d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        // addToSummary({ records: _protocolData.lastTwoWeekData, summaryKey: 'total14d', recordType, protocolSummary, skipChainSummary, })
+        addToSummary({ records: _protocolData.lastTwoWeekToOneWeekData, summaryKey: 'total14dto7d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ records: _protocolData.last30DaysData, summaryKey: 'total30d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ records: _protocolData.last60to30DaysData, summaryKey: 'total60dto30d', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
+        addToSummary({ records: _protocolData.lastOneYearData, summaryKey: 'total1y', recordType, protocolSummary, skipChainSummary, categories: categoriesParam, info: protocol.info, })
 
         // add record count
         const allKeys = Object.keys(protocol.records)
@@ -661,18 +663,18 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
       }
     }
 
-    function addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, protocolSummary, skipChainSummary = false, protocolLatestRecord, categories, debugParams, }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, protocolSummary: any, skipChainSummary?: boolean, protocolLatestRecord?: any, categories?: Array<string>, debugParams?: any }) {
+    function addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, protocolSummary, skipChainSummary = false, protocolLatestRecord, categories, info, }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, protocolSummary: any, skipChainSummary?: boolean, protocolLatestRecord?: any, categories?: Array<string>, info?: any }) {
       // protocolLatestRecord ?? record is a hack to show latest data as protocol's 24h data but not use that record for computing chain/global summary
-      if (protocolSummary) _addToSummary({ record: protocolLatestRecord ?? record, records, recordType, summaryKey, chainSummaryKey, summary: protocolSummary, debugParams, })
+      if (protocolSummary) _addToSummary({ record: protocolLatestRecord ?? record, records, recordType, summaryKey, chainSummaryKey, summary: protocolSummary, })
       // For set-cardinality types (e.g. dailyActiveUsers) only the chain adapter contributes to the chain rollup.
       // For additive types, we need to skip updating summary because underlying child data is already used to update the summary
       const cardinalityFilter = SET_CARDINALITY_SOURCES.get(recordType)
-      if (cardinalityFilter ? cardinalityFilter(debugParams?.protocolId) : !skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey, debugParams })
+      if (cardinalityFilter ? cardinalityFilter(info) : !skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey })
       // add to category summary
       if (categories && categories.length > 0) _addToCategorySummary({ record: protocolLatestRecord ?? record, records, categories, recordType, summaryKey })
     }
 
-    function _addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, summary, debugParams }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, summary?: any, debugParams?: any }) {
+    function _addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, summary }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, summary?: any }) {
       if (!chainSummaryKey) chainSummaryKey = summaryKey
       if (record) records = [record]
       if (!records?.length) return;
@@ -685,7 +687,7 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
       records.forEach(({ value, chains }: { value: number, chains: IJSON<number> }) => {
         // if (!value) return;
         if (typeof value !== 'number') {
-          console.log(value, chains, recordType, summaryKey, adapterType, debugParams?.protocolId, 'value is not a number')
+          console.log(value, chains, recordType, summaryKey, adapterType, 'value is not a number')
           return;
         }
         summary[summaryKey] = (summary[summaryKey] ?? 0) + value

--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -381,8 +381,13 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
               summary.chartBreakdown[timeS] = {}
             }
 
-            summary.chart[timeS] += value
-            summary.chartBreakdown[timeS][protocolName] = value
+            const globalCardinalityFilter = SET_CARDINALITY_SOURCES.get(recordType)
+            if (!globalCardinalityFilter || globalCardinalityFilter(protocol.info)) {
+              // additive types: every protocol contributes
+              // set-cardinality types: only chain-adapter contributes
+              summary.chart[timeS] += value
+              summary.chartBreakdown[timeS][protocolName] = value
+            }
           }
 
           if (timestamp > protocolRecord.latestTimestamp) {

--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -27,6 +27,15 @@ const blacklistedAppIdSet = new Set([
   '4695', // bloXroute
 ])
 
+// Set-cardinality types, counts of distinct entities, are NOT additive across adaptors.
+// For these, chain rollup can NOT sum/concat per-protocol values.
+// Active/New User: per Chain + per Protocol => results in double-count.
+// Instead we can rely on the chain-level adapter count(DISTINCT) from raw txs.
+const SET_CARDINALITY_RECORD_TYPES = new Set<AdaptorRecordType>([
+  AdaptorRecordType.dailyActiveUsers,
+  AdaptorRecordType.dailyNewUsers,
+])
+
 function getProtocolAppMetricsFlag(info: any) {
   if (info.protocolType && info.protocolType !== ProtocolType.PROTOCOL) return false
   if (info.category && blacklistedAppCategorySet.has(info.category!)) return false
@@ -36,7 +45,6 @@ function getProtocolAppMetricsFlag(info: any) {
 }
 
 function getTimeData(moveADayBack = false) {
-
   const lastTimeString = getTimeSDaysAgo(0, moveADayBack)
   const dayBeforeLastTimeString = getTimeSDaysAgo(1, moveADayBack)
   const weekAgoTimeString = getTimeSDaysAgo(7, moveADayBack)
@@ -452,7 +460,14 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
             if (!chainSummary.earliestTimestamp || timestamp < chainSummary.earliestTimestamp)
               chainSummary.earliestTimestamp = timestamp
 
-            chainSummary.chart[timeS] = (chainSummary.chart[timeS] ?? 0) + value
+            const isSetCardinality = SET_CARDINALITY_RECORD_TYPES.has(recordType)
+            if (isSetCardinality) {
+              // for counts of distinct values
+              if (protocolId?.startsWith('chain#')) chainSummary.chart[timeS] = value 
+            } else {
+              // for counts of additive values
+              chainSummary.chart[timeS] = (chainSummary.chart[timeS] ?? 0) + value
+            }
             if (!chainSummary.chartBreakdown[timeS]) chainSummary.chartBreakdown[timeS] = {}
             chainSummary.chartBreakdown[timeS][protocolName] = value
           })
@@ -648,11 +663,15 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
     function addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, protocolSummary, skipChainSummary = false, protocolLatestRecord, categories, debugParams, }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, protocolSummary: any, skipChainSummary?: boolean, protocolLatestRecord?: any, categories?: Array<string>, debugParams?: any }) {
       // protocolLatestRecord ?? record is a hack to show latest data as protocol's 24h data but not use that record for computing chain/global summary
       if (protocolSummary) _addToSummary({ record: protocolLatestRecord ?? record, records, recordType, summaryKey, chainSummaryKey, summary: protocolSummary, debugParams, })
-      // we need to skip updating summary because underlying child data is already used to update the summary
-      if (!skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey, debugParams })
+      // For set-cardinality types only the chain adapter contributes to the chain rollup.
+      // For additive types, we need to skip updating summary because underlying child data is already used to update the summary
+      const isSetCardinality = SET_CARDINALITY_RECORD_TYPES.has(recordType)
+      const isChainAdapter = debugParams?.protocolId?.startsWith('chain#')
+      if (isSetCardinality ? isChainAdapter : !skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey, debugParams })
       // add to category summary
       if (categories && categories.length > 0) _addToCategorySummary({ record: protocolLatestRecord ?? record, records, categories, recordType, summaryKey })
     }
+
     function _addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, summary, debugParams }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, summary?: any, debugParams?: any }) {
       if (!chainSummaryKey) chainSummaryKey = summaryKey
       if (record) records = [record]

--- a/defi/src/api2/cron-task/dimensions.ts
+++ b/defi/src/api2/cron-task/dimensions.ts
@@ -26,14 +26,14 @@ const blacklistedAppCategorySet = new Set([
 const blacklistedAppIdSet = new Set([
   '4695', // bloXroute
 ])
-
 // Set-cardinality types, counts of distinct entities, are NOT additive across adaptors.
 // For these, chain rollup can NOT sum/concat per-protocol values.
 // Active/New User: per Chain + per Protocol => results in double-count.
 // Instead we can rely on the chain-level adapter count(DISTINCT) from raw txs.
-const SET_CARDINALITY_RECORD_TYPES = new Set<AdaptorRecordType>([
-  AdaptorRecordType.dailyActiveUsers,
-  AdaptorRecordType.dailyNewUsers,
+const isChainAdapter = (id?: string) => id?.startsWith('chain#') ?? false
+const SET_CARDINALITY_SOURCES = new Map<AdaptorRecordType, (id?: string) => boolean>([
+  [AdaptorRecordType.dailyActiveUsers, isChainAdapter],
+  [AdaptorRecordType.dailyNewUsers,    isChainAdapter],
 ])
 
 function getProtocolAppMetricsFlag(info: any) {
@@ -45,6 +45,7 @@ function getProtocolAppMetricsFlag(info: any) {
 }
 
 function getTimeData(moveADayBack = false) {
+
   const lastTimeString = getTimeSDaysAgo(0, moveADayBack)
   const dayBeforeLastTimeString = getTimeSDaysAgo(1, moveADayBack)
   const weekAgoTimeString = getTimeSDaysAgo(7, moveADayBack)
@@ -460,10 +461,10 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
             if (!chainSummary.earliestTimestamp || timestamp < chainSummary.earliestTimestamp)
               chainSummary.earliestTimestamp = timestamp
 
-            const isSetCardinality = SET_CARDINALITY_RECORD_TYPES.has(recordType)
-            if (isSetCardinality) {
+            const cardinalityFilter = SET_CARDINALITY_SOURCES.get(recordType)
+            if (cardinalityFilter) {
               // for counts of distinct values
-              if (protocolId?.startsWith('chain#')) chainSummary.chart[timeS] = value 
+              if (cardinalityFilter(protocolId)) chainSummary.chart[timeS] = value
             } else {
               // for counts of additive values
               chainSummary.chart[timeS] = (chainSummary.chart[timeS] ?? 0) + value
@@ -663,11 +664,10 @@ ${tableToString(invalidFinancialStatementRecords, ['protocol', 'timeframe', 'key
     function addToSummary({ record, records = [], recordType, summaryKey, chainSummaryKey, protocolSummary, skipChainSummary = false, protocolLatestRecord, categories, debugParams, }: { records?: any[], recordType: AdaptorRecordType, summaryKey: string, chainSummaryKey?: string, record?: any, protocolSummary: any, skipChainSummary?: boolean, protocolLatestRecord?: any, categories?: Array<string>, debugParams?: any }) {
       // protocolLatestRecord ?? record is a hack to show latest data as protocol's 24h data but not use that record for computing chain/global summary
       if (protocolSummary) _addToSummary({ record: protocolLatestRecord ?? record, records, recordType, summaryKey, chainSummaryKey, summary: protocolSummary, debugParams, })
-      // For set-cardinality types only the chain adapter contributes to the chain rollup.
+      // For set-cardinality types (e.g. dailyActiveUsers) only the chain adapter contributes to the chain rollup.
       // For additive types, we need to skip updating summary because underlying child data is already used to update the summary
-      const isSetCardinality = SET_CARDINALITY_RECORD_TYPES.has(recordType)
-      const isChainAdapter = debugParams?.protocolId?.startsWith('chain#')
-      if (isSetCardinality ? isChainAdapter : !skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey, debugParams })
+      const cardinalityFilter = SET_CARDINALITY_SOURCES.get(recordType)
+      if (cardinalityFilter ? cardinalityFilter(debugParams?.protocolId) : !skipChainSummary) _addToSummary({ record, records, recordType, summaryKey, chainSummaryKey, debugParams })
       // add to category summary
       if (categories && categories.length > 0) _addToCategorySummary({ record: protocolLatestRecord ?? record, records, categories, recordType, summaryKey })
     }


### PR DESCRIPTION
## Summary
The figures for Active/New users for some chains are inflated/double-counted. 

The [dimensions cron task](defi/src/api2/cron-task/dimensions.ts) assumes that every adapter is additive. However, this is not the case for sets that counts over unique values, such as New/Active Addresses.

This PR introduces a simple lookup table to distinguish additive-type adapters from set-cardinality-type adapters:
- overwrites the value with chain adapters value **only**
- doesnt consider the other adapters in that chain that are also reporting a value for whitelisted types: Active/New Addresses. 

## Discovery
For Ethereum on 28 Apr 2026 the chart shows ~434k:
<img width="1189" height="434" alt="chain-ethereum-master-chart" src="https://github.com/user-attachments/assets/e473a041-881e-49ed-8ae4-ad339d3e3574" />

while the chain adapter for Ethereum shows ~429k. Correct data comes from Allium, wallet count straight from `<chain>.raw.transactions`:
<img width="362" height="185" alt="adapter-ethereum-29apr" src="https://github.com/user-attachments/assets/3a2d5d35-d4d9-4895-8440-0655cde53d69" />

Meaning the value shown in the website also factors in some double-counting. For Ethereum, around ~5k users.

## Root cause

In [`defi/src/api2/cron-task/dimensions.ts`](defi/src/api2/cron-task/dimensions.ts) the chain rollup is built additively at two sites:

- **Per-day chart** ([dimensions.ts L467 in master](defi/src/api2/cron-task/dimensions.ts)):

  ```ts
  chainSummary.chart[timeS] = (chainSummary.chart[timeS] ?? 0) + value
  ```

- **Aggregate windows** (`total24h`, `total7d`, …) in `_addToSummary` ([dimensions.ts L698 in master](defi/src/api2/cron-task/dimensions.ts)):

  ```ts
  chainSummary[chainSummaryKey!] += value
  ```

Both correct for additive metrics (`dailyVolume`, `dailyFees`, `dailyTransactionsCount`). However, both are faulty for set-cardinalities, where `|A ∪ B| ≠ |A| + |B|`. We can simply rely on the _chain adapter_ value as the source of distinct addresses.

### Bob uses Sushiwap and Uniswap on Ethereum
Bob has one wallet. Bob makes a trade on Uniswap and a trade on Sushi on Ethereum, in the same day. Three adapters see Bob:

- the Ethereum chain adapter counts Bob once (`count(DISTINCT) = 1`);
- the Uniswap protocol adapter reports Bob in its DAU as `1`;
- the Sushi protocol adapter reports Bob in its DAU as `1`.

Master's `+=` chain rollup sums all three: `1 + 1 + 1 = 3`. 

## Fix
Some possible fixes I discarded:
- Stop emitting `dailyActiveUsers` etc from protocol-routers, or rename it to prevent confusion: requires a complete overview of the implementation, issue will arise later again for other metrics.
- Only sum the adapter values: This will cause chains with no chain-adapter to show `0`. Not good.
- Change the queries to compare addresses: Even if we fetch all addresses and use hyper-log-log, thats a lot of unnecessary compute & **it doesnt make sense to not trust Allium.**

Fixing the double-count at the rollup keeps every adapter's existing semantic. Protocol pages keep showing per-protocol DAU, only the chain rollup's combine rule changes. 

## Verification

below is the result of the A/B for 28 Apr 2026:


### Global `dau` total24h
| Old (master) | New (patched) | Δ | Δ% |
|---:|---:|---:|---:|
| 5,929,238 | 5,648,065 | -281,173 | -4.74% |

### Per-chain `dau`
| Chain | Old (master) | New (patched) | Δ | Δ% |
|---|---:|---:|---:|---:|
| bsc | 2,801,311 | 2,701,294 | -100,017 | -3.57% |
| polygon | 915,297 | 743,179 | -172,118 | -18.80% |
| avax | 635,353 | 635,061 | -292 | -0.05% |
| ethereum | 434,772 | 429,815 | -4,957 | -1.14% |
| base | 389,284 | 386,645 | -2,639 | -0.68% |
| arbitrum | 316,136 | 314,843 | -1,293 | -0.41% |
| litecoin | 281,114 | 281,114 | +0 | +0.00% |
| elrond | 88,507 | 88,507 | +0 | +0.00% |
| bitcoincash | 29,123 | 29,123 | +0 | +0.00% |
| optimism | 19,168 | 19,009 | -159 | -0.83% |
| cardano | 16,336 | 16,336 | +0 | +0.00% |
| scroll | 1,759 | 1,759 | +0 | +0.00% |
| katana | 1,243 | 1,243 | +0 | +0.00% |
| polygonzkevm | 137 | 137 | +0 | +0.00% |

## Notes on scope
- I assume Polygon has many active protocol-level adapters whose user overlap heavily, so the inflation was substantial there. Might need a health check here.
- Any chain that doesn't have a chain-adapter will now show `0`. Alternatively, it could have shown the _sum of adapter reported values_. I have checked and there are no chains that fit this description. So there are no fixes required here.
- Despite ai review, having additive sum within sub-categories is acceptable &  the best we can do: Bob using Uniswap and Sushi on Ethereum counts as 2 DEX user interactions for the category, which makes sense. But Bob should be counted as 1 user on Ethereum, which we addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Daily Active Users and Daily New Users metric aggregation across multiple protocol sources to improve calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->