### PR TITLE
fix: update api2 metrics by category

### DIFF
--- a/defi/src/api2/routes/dimensions.ts
+++ b/defi/src/api2/routes/dimensions.ts
@@ -490,10 +490,8 @@ export function getDimensionOverviewRoutes(route: 'overview' | 'chart' | 'chart-
       let filterCategory = category;
       if (!filterCategory) filterCategory = DefaultAdapterTypeCategoryMap[adaptorType];
       
-      let routeFileExt = '';
-      if (route === 'overview') routeFileExt = '';
-      else routeFileExt += route;
-      const routeSubPath = `${adaptorType}/${dataType}-category/${filterCategory}-${routeFileExt}`;
+      const routeFileExt = route === 'overview' ? '' : `-${route}`;
+      const routeSubPath = `${adaptorType}/${dataType}-category/${filterCategory}${routeFileExt}`;
       const routeFile = `dimensions/${routeSubPath}`; 
       
       const data = await readRouteData(routeFile);
@@ -541,10 +539,8 @@ export function getDimensionChainRoutes(route: 'overview' | 'chart' | 'chart-pro
       let filterCategory = category;
       if (!filterCategory) filterCategory = DefaultAdapterTypeCategoryMap[adaptorType];
       
-      let routeFileExt = '';
-      if (route === 'overview') routeFileExt = '';
-      else routeFileExt += route;
-      const routeSubPath = `${adaptorType}/${dataType}-category/${filterCategory}-chain/${chainKeyFilter}-${routeFileExt}`;
+      const routeFileExt = route === 'overview' ? '' : `-${route}`;
+      const routeSubPath = `${adaptorType}/${dataType}-category/${filterCategory}-chain/${chainKeyFilter}${routeFileExt}`;
       const routeFile = `dimensions/${routeSubPath}`;
       
       const data = await readRouteData(routeFile);
@@ -562,10 +558,8 @@ export function getDimensionCategoryRoutes(route: 'overview' | 'chart' | 'chart-
 
     if (!category) return errorResponse(res, 'Category not supported', { statusCode: 400 })
     
-    let routeFileExt = '';
-    if (route === 'overview') routeFileExt = '';
-    else routeFileExt += route;
-    const routeSubPath = `${adaptorType}/${dataType}-category/${category}-${routeFileExt}`;
+    const routeFileExt = route === 'overview' ? '' : `-${route}`;
+    const routeSubPath = `${adaptorType}/${dataType}-category/${category}${routeFileExt}`;
     const routeFile = `dimensions/${routeSubPath}`; 
     
     const data = await readRouteData(routeFile);
@@ -582,10 +576,8 @@ export function getDimensionCategoryChainRoutes(route: 'overview' | 'chart' | 'c
 
     if (!category) return errorResponse(res, 'Category not supported', { statusCode: 400 })
     
-    let routeFileExt = '';
-    if (route === 'overview') routeFileExt = '';
-    else routeFileExt += route;
-    const routeSubPath = `${adaptorType}/${dataType}-category/${category}-chain/${chainKeyFilter}-${routeFileExt}`;
+    const routeFileExt = route === 'overview' ? '' : `-${route}`;
+    const routeSubPath = `${adaptorType}/${dataType}-category/${category}-chain/${chainKeyFilter}${routeFileExt}`;
     const routeFile = `dimensions/${routeSubPath}`; 
     
     const data = await readRouteData(routeFile);
@@ -593,6 +585,51 @@ export function getDimensionCategoryChainRoutes(route: 'overview' | 'chart' | 'c
     if (!data) return errorResponse(res, 'Internal server error', { statusCode: 500 });
 
     return successResponse(res, data);
+  }
+}
+
+/**
+ * GET /v2/overview/dimension-categories
+ * Returns aggregated dimension metrics across all categories.
+ * Shape: { [category]: { chains: {...}, [adapterType]: { [recordType]: { '24h', '7d', '30d' } } } }
+ */
+export async function getDimensionCategoriesOverview(_req: HyperExpress.Request, res: HyperExpress.Response) {
+  const data = await readRouteData('dimensions/category-agg-data');
+  if (!data) return errorResponse(res, 'Category data not available', { statusCode: 500 });
+  return successResponse(res, data);
+}
+
+/**
+ * GET /v2/metrics/:type/categories
+ * Returns the list of available categories for a specific adapter type,
+ * along with their aggregate metrics (24h, 7d, 30d).
+ */
+export function getDimensionCategoryMetricsByType() {
+  return async function (req: HyperExpress.Request, res: HyperExpress.Response) {
+    const { adaptorType, dataType } = getEventParameters(req, true);
+
+    // Read the full category aggregate data
+    const categoryAggData = await readRouteData('dimensions/category-agg-data');
+    if (!categoryAggData) return errorResponse(res, 'Category data not available', { statusCode: 500 });
+
+    // Filter to only categories that have data for this adapter type and record type
+    const result: any = {};
+    for (const [category, categoryData] of Object.entries(categoryAggData as any)) {
+      const adapterData = categoryData?.[adaptorType];
+      if (!adapterData) continue;
+
+      const recordData = adapterData[dataType];
+      if (!recordData) continue;
+
+      result[category] = {
+        ...recordData,
+        chains: categoryData.chains ? Object.keys(categoryData.chains).filter((chain: string) => {
+          return categoryData.chains[chain]?.[adaptorType]?.[dataType];
+        }) : [],
+      };
+    }
+
+    return successResponse(res, result);
   }
 }
 

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -15,7 +15,7 @@ import { cache, getLastHourlyRecord, getLastHourlyTokensUsd, protocolHasMisrepre
 import { cachedCraftParentProtocolV2, craftParentProtocolV2 } from "../utils/craftParentProtocolV2";
 import { craftProtocolV2 } from "../utils/craftProtocolV2";
 import { getDimensionsMetadata } from "../utils/dimensionsUtils";
-import { getDimensionCategoryChainRoutes, getDimensionCategoryRoutes, getDimensionChainRoutes, getDimensionOverviewRoutes, getDimensionProtocolFileRoute, getDimensionProtocolRoutes, getOverviewFileRoute, } from "./dimensions";
+import { getDimensionCategoryChainRoutes, getDimensionCategoryRoutes, getDimensionCategoryMetricsByType, getDimensionCategoriesOverview, getDimensionChainRoutes, getDimensionOverviewRoutes, getDimensionProtocolFileRoute, getDimensionProtocolRoutes, getOverviewFileRoute, } from "./dimensions";
 import { errorResponse, errorWrapper as ew, fileResponse, successResponse } from "./utils";
 import { readRouteData } from "../cache/file-cache";
 
@@ -168,6 +168,9 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/v2/chart/fork/protocol/:protocol", ew(getForksRoutes('chart-total')))
 
   // v2 - dimensions
+
+  router.get("/v2/overview/dimension-categories", ew(getDimensionCategoriesOverview))
+  router.get("/v2/metrics/:type/categories", ew(getDimensionCategoryMetricsByType()))
 
   router.get("/v2/metrics/:type", ew(getDimensionOverviewRoutes('overview')))
   router.get("/v2/chart/:type", ew(getDimensionOverviewRoutes('chart')))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "defillama-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION

## Summary
Fix broken category route file paths and add new APIs for metrics per categories.
## Bug Fix: Trailing dash in category overview routes
When `route === 'overview'`, `routeFileExt` was `''` but the path was built as:

The stored cache key has no trailing dash: `dexs`. This caused all category overview lookups to silently return 500.

**Fixed in 4 functions:**
- `returnSubCategoryData()` — affects `/v2/metrics/dexs`, `/v2/metrics/derivatives`, etc.
- `returnSubCategoryChainData()` — affects `/v2/metrics/dexs/chain/:chain`, etc.
- `getDimensionCategoryRoutes()` — affects `/v2/metrics/:type/category/:category`
- `getDimensionCategoryChainRoutes()` — affects `/v2/metrics/:type/category/:category/chain/:chain`

Chart and breakdown routes (`-chart`, `-chart-protocol-breakdown`, etc.) were unaffected since they produced valid extensions.

## New APIs

| Endpoint | Description |
|---|---|
| `GET /v2/overview/dimension-categories` | Aggregated 24h/7d/30d metrics for all categories across all adapter types |
| `GET /v2/metrics/:type/categories` | Categories filtered by adapter type with per-category metrics and available chains |

Both endpoints serve the pre-computed `category-agg-data` that was already being generated by `generateDimensionsResponseFiles` but had no public route.

## Files Changed

- `defi/src/api2/routes/dimensions.ts` — bug fixes + 2 new handlers
- `defi/src/api2/routes/index.ts` — import + route registration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoint to query aggregated dimension category data overview
  * Added endpoint to retrieve dimension category metrics filtered by adapter type and data type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->