### PR TITLE
coins: add opt-in Uniswap V3 pool discovery

### DIFF
--- a/coins/src/adapters/other/unknownTokensV3.ts
+++ b/coins/src/adapters/other/unknownTokensV3.ts
@@ -1,13 +1,25 @@
-import { getApi } from "../utils/sdk";
-import getWrites from "../utils/getWrites";
+import type { ChainApi } from "@defillama/sdk";
 import { runInPromisePool } from "@defillama/sdk/build/generalUtil";
-const projectName = "unknownTokensV3";
+import getWrites from "../utils/getWrites";
+import { getApi } from "../utils/sdk";
+import {
+  CHAIN_V3_CONFIG,
+  SLOT0_SQRT_PRICE_ABI,
+  discoverV3Pool,
+  priceFromSqrtPriceX96,
+} from "../utils/uniV3PoolDiscovery";
+import type { DiscoveredPool } from "../utils/uniV3PoolDiscovery";
 
-const slot0Abi =
-  "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint32 feeProtocol, bool unlocked)";
+const PROJECT_NAME = "unknownTokensV3";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-const config: any = {
-  // [token]: uniV3pool
+const autoDiscoveredTokens: Record<string, string[]> = {
+  polygon: [
+    "0x38fd02Dc840F099772392f2DFe3A3BEE9Aab3AB7", // BRTH
+  ],
+};
+
+const explicitPools: Record<string, Record<string, string>> = {
   blast: {
     "0x216a5a1135a9dab49fa9ad865e0f22fe22b5630a":
       "0x017f31dc55144f24836c2566ed7dc651256c338a", // PUMP
@@ -15,8 +27,8 @@ const config: any = {
   bsc: {
     "0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3":
       "0xfc18301B94a77D91015bb90D5249827c506846Ae", // stBTC
-    "0xb8a1eD561C914F22BD69b0bb4558ad5A89FeAAE1": 
-      "0xc089253e8e28ef1213d7158b0add26e014175339" // ART
+    "0xb8a1eD561C914F22BD69b0bb4558ad5A89FeAAE1":
+      "0xc089253e8e28ef1213d7158b0add26e014175339", // ART
   },
   map: {
     "0x756af1d3810a01d3292fad62f295bbcc6c200aea":
@@ -47,9 +59,9 @@ const config: any = {
       "0xD80e75fAf4cc02F6447287D5b1EF195EAc19FfD9", // hOHM
     "0xec3502a9f98f151af52ee6cb423a0afe7bbf5a19":
       "0x2a943E0432b22a3C3cD65B8c9045259B791f96B8", // HAUST
-    "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44": 
+    "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44":
       "0xC5c134A1f112efA96003f8559Dba6fAC0BA77692", // WHITE
-    "0x63d74d22E689C715a04F2C13962b1f77F443d35b": 
+    "0x63d74d22E689C715a04F2C13962b1f77F443d35b":
       "0x206239406AbcCf730493e4b133b30df546F9Ff43", // DUSD
   },
   kroma: {
@@ -75,78 +87,144 @@ const config: any = {
   base: {
     "0xf7178122A087eF8F5c7BeA362b7DaBE38F20Bf05":
       "0x2019DEB4E18107A2FD8B4acBC7e3878037336fc2", // OMNI
+    "0xe66E3A37C3274Ac24FE8590f7D84A2427194DC17":
+      "0x9d228792a392838be03293ba93f406f3e8077b8d", // stkWELL
   },
   hyperliquid: {
     "0x876e7F2f30935118a654fc0E1f807aFc49EFe500":
       "0xe9c02ca07931f9670fa87217372b3c9aa5a8a934", // PUP
+    "0x067b0C72aa4C6Bd3BFEFfF443c536DCd6a25a9C8":
+      "0x006418DcD73f6Da03A667ad161cCB9B39CeEEa60", // HYBR
   },
   etlk: {
-    "0x93f5475da60143c50e8be3fed10c143b0cf8b9e9": 
+    "0x93f5475da60143c50e8be3fed10c143b0cf8b9e9":
       "0x86d2f4ef99915652bfc3adf29683752334582b4d", // VNXAU
-    "0x6Ce393fF9Ed5465CC4DEf456B8401e03cEF64d5e": 
-    "0x35C888a9afc0866Fec5bBAdEf790e5EC1d845653", // RARE
-  }
+    "0x6Ce393fF9Ed5465CC4DEf456B8401e03cEF64d5e":
+      "0x35C888a9afc0866Fec5bBAdEf790e5EC1d845653", // RARE
+  },
 };
 
-const configCustomAbi: any = {
-  base: {
-    "0xe66E3A37C3274Ac24FE8590f7D84A2427194DC17": { 
-      pool: "0x9d228792a392838be03293ba93f406f3e8077b8d", // stkWELL
-      abi: "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, bool unlocked)"
-    }
-  },
-  hyperliquid: {
-    "0x067b0C72aa4C6Bd3BFEFfF443c536DCd6a25a9C8": { 
-      pool: "0x006418DcD73f6Da03A667ad161cCB9B39CeEEa60", // HYBR
-      abi: "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, bool unlocked)"
-    }
-  },
+interface ResolvedPool {
+  token: string;
+  pool: string;
 }
 
-export function unknownTokensV3(timestamp: number = 0) {
-  return Promise.all(
-    Object.keys(config).map((chain) => getTokenPrice(chain, timestamp)),
+async function resolvePools(
+  api: ChainApi,
+  chain: string,
+): Promise<ResolvedPool[]> {
+  const resolved: ResolvedPool[] = [];
+  const claimed = new Set<string>();
+
+  for (const [token, pool] of Object.entries(explicitPools[chain] ?? {})) {
+    const tokenLc = token.toLowerCase();
+    resolved.push({ token: tokenLc, pool });
+    claimed.add(tokenLc);
+  }
+
+  const toDiscover = (autoDiscoveredTokens[chain] ?? []).filter(
+    (t) => !claimed.has(t.toLowerCase()),
   );
+  if (toDiscover.length === 0 || !CHAIN_V3_CONFIG[chain]) return resolved;
+
+  const discoveries: (DiscoveredPool | null)[] = await runInPromisePool({
+    items: toDiscover,
+    concurrency: 5,
+    processor: (token: string) => discoverV3Pool(api, chain, token),
+  });
+
+  discoveries.forEach((d, i) => {
+    if (!d) return;
+    resolved.push({ token: toDiscover[i].toLowerCase(), pool: d.pool });
+  });
+
+  return resolved;
 }
 
-async function getTokenPrice(chain: string, timestamp: number) {
+interface PriceEntry {
+  underlying: string;
+  price: number;
+}
+
+async function getChainPrices(chain: string, timestamp: number) {
   const api = await getApi(chain, timestamp);
-  const pricesObject: any = {};
+  const resolved = await resolvePools(api, chain);
+  if (resolved.length === 0) return [];
 
-  const pools: any = Object.values(config[chain]);
-  const customAbiPools: any = Object.values(configCustomAbi[chain] ?? {});
+  const pools = resolved.map((r) => r.pool);
+  const [token0s, token1s, slot0s] = await Promise.all([
+    api.multiCall({ abi: "address:token0", calls: pools, permitFailure: true }),
+    api.multiCall({ abi: "address:token1", calls: pools, permitFailure: true }),
+    api.multiCall({
+      abi: SLOT0_SQRT_PRICE_ABI,
+      calls: pools,
+      permitFailure: true,
+    }),
+  ]);
 
-  const tokens = [...Object.keys(config[chain]), ...Object.keys(configCustomAbi[chain] ?? [])];
-  const token0s = await api.multiCall({ abi: "address:token0", calls: [...pools, ...customAbiPools.map((p: any) => p.pool)] });
-  const token1s = await api.multiCall({ abi: "address:token1", calls: [...pools, ...customAbiPools.map((p: any) => p.pool)] });
-
-  const regularSlot0s = await api.multiCall({ abi: slot0Abi, calls: pools });
-  const customSlot0s: any[] = await runInPromisePool({
-    items: customAbiPools,
-    concurrency: 5,
-    processor: async (p: any) =>  api.call({ abi: p.abi, target: p.pool })
-  })
-
-  const tokens0Decimals = await api.multiCall({
+  const decimals = await api.multiCall({
     abi: "erc20:decimals",
-    calls: token0s,
+    calls: [...token0s, ...token1s].map((token) => token ?? ZERO_ADDRESS),
+    permitFailure: true,
   });
-  const tokens1Decimals = await api.multiCall({
-    abi: "erc20:decimals",
-    calls: token1s,
-  });
+  const decimals0 = decimals.slice(0, token0s.length);
+  const decimals1 = decimals.slice(token0s.length);
 
-  [...regularSlot0s, ...customSlot0s].forEach((v: any, i: number) => {
-    const token = tokens[i].toLowerCase();
-    let token0 = token0s[i].toLowerCase();
-    let price =
-      Math.pow(1.0001, v.tick) *
-      10 ** (tokens0Decimals[i] - tokens1Decimals[i]);
-    if (token !== token0) price = 1 / price;
-    pricesObject[token] = {
-      underlying: token0 === token ? token1s[i] : token0,
+  const pricesObject: Record<string, PriceEntry> = {};
+  resolved.forEach((r, i) => {
+    const sqrtRaw = slot0s[i];
+    const t0 = token0s[i];
+    const t1 = token1s[i];
+    const d0 = decimals0[i];
+    const d1 = decimals1[i];
+    if (!sqrtRaw || !t0 || !t1 || d0 == null || d1 == null) return;
+
+    const sqrtPriceX96 = BigInt(sqrtRaw);
+    if (sqrtPriceX96 === BigInt(0)) return;
+
+    const decimals0Num = Number(d0);
+    const decimals1Num = Number(d1);
+    if (
+      !Number.isFinite(decimals0Num) ||
+      !Number.isFinite(decimals1Num) ||
+      decimals0Num < 0 ||
+      decimals1Num < 0
+    )
+      return;
+
+    const token0Lc = String(t0).toLowerCase();
+    const token1Lc = String(t1).toLowerCase();
+    const isToken0 = r.token === token0Lc;
+    if (!isToken0 && r.token !== token1Lc) return;
+
+    const token0PerToken1 = priceFromSqrtPriceX96(
+      sqrtPriceX96,
+      decimals0Num,
+      decimals1Num,
+    );
+    const price = isToken0 ? token0PerToken1 : 1 / token0PerToken1;
+    if (!Number.isFinite(price) || price <= 0) return;
+
+    pricesObject[r.token] = {
+      underlying: isToken0 ? token1Lc : token0Lc,
       price,
     };
   });
-  return getWrites({ chain, timestamp, pricesObject, projectName });
+
+  return getWrites({
+    chain,
+    timestamp,
+    pricesObject,
+    projectName: PROJECT_NAME,
+  });
+}
+
+export function unknownTokensV3(timestamp: number = 0) {
+  const chains = new Set<string>([
+    ...Object.keys(explicitPools),
+    ...Object.keys(autoDiscoveredTokens),
+  ]);
+  return Promise.all(
+    [...chains].map((chain) => getChainPrices(chain, timestamp)),
+  );
 }

--- a/coins/src/adapters/utils/uniV3PoolDiscovery.test.ts
+++ b/coins/src/adapters/utils/uniV3PoolDiscovery.test.ts
@@ -1,0 +1,117 @@
+import {
+  CHAIN_V3_CONFIG,
+  UNI_V3_FEE_TIERS,
+  discoverV3Pool,
+  priceFromSqrtPriceX96,
+} from "./uniV3PoolDiscovery";
+
+const Q96 = BigInt(2) ** BigInt(96);
+
+describe("priceFromSqrtPriceX96", () => {
+  it("returns 1 for parity sqrtPrice and equal decimals", () => {
+    expect(priceFromSqrtPriceX96(Q96, 18, 18)).toBeCloseTo(1, 12);
+  });
+
+  it("squares the sqrtPrice ratio", () => {
+    expect(priceFromSqrtPriceX96(BigInt(2) * Q96, 0, 0)).toBeCloseTo(4, 12);
+    expect(priceFromSqrtPriceX96(BigInt(3) * Q96, 0, 0)).toBeCloseTo(9, 12);
+  });
+
+  it("applies the (decimals0 - decimals1) adjustment", () => {
+    // raw price = 1; token0 has 12 more decimals than token1, so 1 token0
+    // (human) = 10^12 token1 (human).
+    expect(priceFromSqrtPriceX96(Q96, 18, 6)).toBeCloseTo(1e12, 0);
+    expect(priceFromSqrtPriceX96(Q96, 6, 18)).toBeCloseTo(1e-12, 18);
+  });
+
+  it("returns NaN for non-positive sqrtPrice", () => {
+    expect(priceFromSqrtPriceX96(BigInt(0), 18, 18)).toBeNaN();
+  });
+
+  it("recovers the WETH/USDC ratio at a realistic spot", () => {
+    // USDC/WETH 0.05% on Ethereum; token0 = USDC (6 dec), token1 = WETH (18 dec).
+    // At 1 ETH = $3000 the raw token1/token0 ratio is 10^18 / (3000 * 10^6)
+    // = 10^12 / 3000, so sqrtPriceX96 ~= sqrt(10^12 / 3000) * 2^96.
+    const rawPrice = 1e12 / 3000;
+    const sqrtPriceX96 = BigInt(Math.floor(Math.sqrt(rawPrice) * Number(Q96)));
+    const price = priceFromSqrtPriceX96(sqrtPriceX96, 6, 18);
+    // price is USDC denominated in WETH (i.e. 1 USDC ~= 1/3000 WETH).
+    expect(price).toBeCloseTo(1 / 3000, 6);
+  });
+});
+
+describe("CHAIN_V3_CONFIG", () => {
+  it("uses canonical Uniswap V3 factory addresses on supported chains", () => {
+    const canonicalFactory = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+    for (const chain of [
+      "ethereum",
+      "polygon",
+      "arbitrum",
+      "optimism",
+    ] as const) {
+      expect(CHAIN_V3_CONFIG[chain]?.factory).toBe(canonicalFactory);
+    }
+    // Base uses a Base-specific factory address.
+    expect(CHAIN_V3_CONFIG.base?.factory).toBe(
+      "0x33128a8fC17869897dcE68Ed026d694621f6FDfD",
+    );
+  });
+
+  it("populates at least one reference token per chain", () => {
+    for (const [chain, cfg] of Object.entries(CHAIN_V3_CONFIG)) {
+      expect(cfg.references.length).toBeGreaterThan(0);
+      cfg.references.forEach((addr) => {
+        expect(addr).toMatch(/^0x[0-9a-fA-F]{40}$/);
+        expect(addr).toBeTruthy();
+        expect(chain).toBeTruthy();
+      });
+    }
+  });
+
+  it("includes Polygon USDT as a reference token", () => {
+    expect(CHAIN_V3_CONFIG.polygon?.references).toContain(
+      "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+    );
+  });
+});
+
+describe("UNI_V3_FEE_TIERS", () => {
+  it("matches the four canonical Uniswap V3 fee tiers", () => {
+    expect([...UNI_V3_FEE_TIERS]).toEqual([100, 500, 3000, 10000]);
+  });
+});
+
+describe("discoverV3Pool", () => {
+  const token = "0x38fd02Dc840F099772392f2DFe3A3BEE9Aab3AB7";
+  const usdt = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
+  const pool = "0xaa98E21F7504395024746A9369ca6E20d6F30d01";
+  const zero = "0x0000000000000000000000000000000000000000";
+  type GetPoolCall = { params: [string, string, number] };
+  type FakeMultiCallParams = { abi: string; calls: GetPoolCall[] | string[] };
+
+  it("searches Polygon's 0.01% BRTH/USDT pool and returns it when liquid", async () => {
+    const api = {
+      multiCall: jest.fn(async ({ abi, calls }: FakeMultiCallParams) => {
+        if (String(abi).includes("getPool")) {
+          return (calls as GetPoolCall[]).map((call) => {
+            const [tokenArg, referenceArg, feeArg] = call.params;
+            return tokenArg === token && referenceArg === usdt && feeArg === 100
+              ? pool
+              : zero;
+          });
+        }
+
+        if (String(abi).includes("liquidity")) return ["36467137254691505"];
+        throw new Error(`Unexpected ABI ${abi}`);
+      }),
+    };
+
+    await expect(
+      discoverV3Pool(
+        api as unknown as Parameters<typeof discoverV3Pool>[0],
+        "polygon",
+        token,
+      ),
+    ).resolves.toEqual({ pool, reference: usdt, fee: 100 });
+  });
+});

--- a/coins/src/adapters/utils/uniV3PoolDiscovery.test.ts
+++ b/coins/src/adapters/utils/uniV3PoolDiscovery.test.ts
@@ -1,9 +1,11 @@
 import {
   CHAIN_V3_CONFIG,
+  SLOT0_SQRT_PRICE_ABI,
   UNI_V3_FEE_TIERS,
   discoverV3Pool,
   priceFromSqrtPriceX96,
 } from "./uniV3PoolDiscovery";
+import { ethers } from "ethers";
 
 const Q96 = BigInt(2) ** BigInt(96);
 
@@ -18,8 +20,6 @@ describe("priceFromSqrtPriceX96", () => {
   });
 
   it("applies the (decimals0 - decimals1) adjustment", () => {
-    // raw price = 1; token0 has 12 more decimals than token1, so 1 token0
-    // (human) = 10^12 token1 (human).
     expect(priceFromSqrtPriceX96(Q96, 18, 6)).toBeCloseTo(1e12, 0);
     expect(priceFromSqrtPriceX96(Q96, 6, 18)).toBeCloseTo(1e-12, 18);
   });
@@ -29,13 +29,9 @@ describe("priceFromSqrtPriceX96", () => {
   });
 
   it("recovers the WETH/USDC ratio at a realistic spot", () => {
-    // USDC/WETH 0.05% on Ethereum; token0 = USDC (6 dec), token1 = WETH (18 dec).
-    // At 1 ETH = $3000 the raw token1/token0 ratio is 10^18 / (3000 * 10^6)
-    // = 10^12 / 3000, so sqrtPriceX96 ~= sqrt(10^12 / 3000) * 2^96.
     const rawPrice = 1e12 / 3000;
     const sqrtPriceX96 = BigInt(Math.floor(Math.sqrt(rawPrice) * Number(Q96)));
     const price = priceFromSqrtPriceX96(sqrtPriceX96, 6, 18);
-    // price is USDC denominated in WETH (i.e. 1 USDC ~= 1/3000 WETH).
     expect(price).toBeCloseTo(1 / 3000, 6);
   });
 });
@@ -51,7 +47,6 @@ describe("CHAIN_V3_CONFIG", () => {
     ] as const) {
       expect(CHAIN_V3_CONFIG[chain]?.factory).toBe(canonicalFactory);
     }
-    // Base uses a Base-specific factory address.
     expect(CHAIN_V3_CONFIG.base?.factory).toBe(
       "0x33128a8fC17869897dcE68Ed026d694621f6FDfD",
     );
@@ -78,6 +73,51 @@ describe("CHAIN_V3_CONFIG", () => {
 describe("UNI_V3_FEE_TIERS", () => {
   it("matches the four canonical Uniswap V3 fee tiers", () => {
     expect([...UNI_V3_FEE_TIERS]).toEqual([100, 500, 3000, 10000]);
+  });
+});
+
+describe("SLOT0_SQRT_PRICE_ABI", () => {
+  const sqrtPriceX96 = BigInt("123456789012345678901234567890");
+
+  it("decodes the first return word from canonical 7-field slot0 data", () => {
+    const minimalSlot0 = new ethers.Interface([SLOT0_SQRT_PRICE_ABI]);
+    const canonicalSlot0 = new ethers.Interface([
+      "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint32 feeProtocol, bool unlocked)",
+    ]);
+
+    const encoded = canonicalSlot0.encodeFunctionResult("slot0", [
+      sqrtPriceX96,
+      -123,
+      1,
+      2,
+      3,
+      4,
+      true,
+    ]);
+
+    expect(minimalSlot0.decodeFunctionResult("slot0", encoded)[0]).toBe(
+      sqrtPriceX96,
+    );
+  });
+
+  it("decodes the first return word from 6-field fork slot0 data", () => {
+    const minimalSlot0 = new ethers.Interface([SLOT0_SQRT_PRICE_ABI]);
+    const forkSlot0 = new ethers.Interface([
+      "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, bool unlocked)",
+    ]);
+
+    const encoded = forkSlot0.encodeFunctionResult("slot0", [
+      sqrtPriceX96,
+      -123,
+      1,
+      2,
+      3,
+      true,
+    ]);
+
+    expect(minimalSlot0.decodeFunctionResult("slot0", encoded)[0]).toBe(
+      sqrtPriceX96,
+    );
   });
 });
 

--- a/coins/src/adapters/utils/uniV3PoolDiscovery.ts
+++ b/coins/src/adapters/utils/uniV3PoolDiscovery.ts
@@ -1,0 +1,203 @@
+import { ChainApi } from "@defillama/sdk";
+
+/**
+ * Pool discovery and price math for canonical Uniswap V3 deployments.
+ *
+ * Anything that follows the canonical Uniswap V3 factory + pool interface
+ * (UniswapV3Factory.getPool / UniswapV3Pool.slot0 / UniswapV3Pool.liquidity)
+ * works through this module. Forks that diverge on the factory address but
+ * keep the pool interface should still work as long as a chain entry is
+ * added to CHAIN_V3_CONFIG. Forks that diverge on the pool interface (e.g.
+ * a non-standard slot0 layout) still need an explicit (token -> pool) entry
+ * in the consuming adapter.
+ */
+
+/** Canonical Uniswap V3 fee tiers, in hundredths of a bip (1e-6). */
+export const UNI_V3_FEE_TIERS = [100, 500, 3000, 10000] as const;
+
+/**
+ * Minimal ABI that decodes only the first word (sqrtPriceX96) of slot0.
+ *
+ * Trailing return data is silently dropped by the EVM ABI decoder, so this
+ * single ABI is correct for both the standard 7-field slot0 layout and the
+ * 6-field variant used by some forks (e.g. PancakeSwap V3). This obsoletes
+ * the older approach of maintaining a per-pool custom ABI registry.
+ */
+export const SLOT0_SQRT_PRICE_ABI =
+  "function slot0() view returns (uint160 sqrtPriceX96)";
+
+const FACTORY_GET_POOL_ABI =
+  "function getPool(address tokenA, address tokenB, uint24 fee) view returns (address pool)";
+
+const POOL_LIQUIDITY_ABI = "function liquidity() view returns (uint128)";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const Q96 = BigInt(2) ** BigInt(96);
+const ZERO = BigInt(0);
+
+export interface ChainV3Config {
+  /** UniswapV3Factory address on this chain. */
+  factory: string;
+  /**
+   * Tokens whose price is reliably populated by other adapters. Discovery
+   * pairs the target token against each of these (across every fee tier)
+   * and selects the deepest resulting pool.
+   */
+  references: string[];
+}
+
+export interface DiscoveredPool {
+  pool: string;
+  reference: string;
+  fee: (typeof UNI_V3_FEE_TIERS)[number];
+}
+
+/**
+ * Per-chain configuration for canonical Uniswap V3 deployments.
+ *
+ * Only chains where Uniswap V3 itself is deployed belong here. Forks with
+ * different factories (PancakeSwap V3 on BSC, SushiSwap V3, etc.) are not
+ * canonical Uniswap V3; register explicit (token -> pool) entries in the
+ * consuming adapter instead.
+ */
+export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
+  ethereum: {
+    factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+    references: [
+      "0xA0b86991c6218b36c1d19d4a2E9Eb0cE3606eB48", // USDC
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI
+    ],
+  },
+  polygon: {
+    factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+    references: [
+      "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", // USDC (native)
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", // USDC.e (bridged)
+      "0xc2132D05D31c914a87C6611C10748AEb04B58e8F", // USDT
+      "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619", // WETH
+      "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270", // WMATIC
+    ],
+  },
+  arbitrum: {
+    factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+    references: [
+      "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC (native)
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8", // USDC.e
+      "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", // USDT
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH
+    ],
+  },
+  optimism: {
+    factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+    references: [
+      "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", // USDC (native)
+      "0x7F5c764cBc14f9669B88837ca1490cCa17c31607", // USDC.e
+      "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58", // USDT
+      "0x4200000000000000000000000000000000000006", // WETH
+    ],
+  },
+  base: {
+    factory: "0x33128a8fC17869897dcE68Ed026d694621f6FDfD",
+    references: [
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+      "0x4200000000000000000000000000000000000006", // WETH
+    ],
+  },
+};
+
+/**
+ * Convert a Uniswap V3 sqrtPriceX96 into the human-decimal price of token0
+ * denominated in token1.
+ *
+ * Uniswap stores price as `sqrt(token1/token0) * 2^96` over raw token units.
+ * Squaring and adjusting for decimals yields the price of one token0 (in
+ * human units) in token1 (human units):
+ *
+ *     price = (sqrtPriceX96 / 2^96)^2 * 10^(decimals0 - decimals1)
+ *
+ * Uses the canonical Uniswap math; `Math.pow(1.0001, tick)` is a lossy
+ * approximation derived from this and should not be substituted.
+ */
+export function priceFromSqrtPriceX96(
+  sqrtPriceX96: bigint,
+  decimals0: number,
+  decimals1: number,
+): number {
+  if (sqrtPriceX96 <= ZERO) return NaN;
+  const sqrt = Number(sqrtPriceX96) / Number(Q96);
+  return sqrt * sqrt * 10 ** (decimals0 - decimals1);
+}
+
+/**
+ * Discover a canonical Uniswap V3 pool to price `token` against on `chain`.
+ *
+ * Searches the cross of (chain references x fee tiers), drops candidates
+ * the factory reports as unmapped or that report zero/failed liquidity,
+ * and returns the survivor with the highest in-range `liquidity()`.
+ *
+ * NOTE on ranking: `liquidity()` is in `sqrt(reserve0 * reserve1)` units
+ * over raw token amounts, so values across pools with *different* reference
+ * tokens (e.g. a USDC pool vs. a WETH pool) are not directly comparable in
+ * USD-equivalent depth. For tokens that have a clearly dominant pool this
+ * is irrelevant; for tokens with non-trivial liquidity against multiple
+ * decimal-disparate references, the ranking can choose suboptimally. Use
+ * an explicit `(token -> pool)` override at the call site when that matters.
+ *
+ * Returns `null` when no candidate has non-zero liquidity, or when the
+ * chain has no V3 config.
+ */
+export async function discoverV3Pool(
+  api: ChainApi,
+  chain: string,
+  token: string,
+): Promise<DiscoveredPool | null> {
+  const cfg = CHAIN_V3_CONFIG[chain];
+  if (!cfg) return null;
+
+  const candidates = cfg.references.flatMap((reference) =>
+    UNI_V3_FEE_TIERS.map((fee) => ({ reference, fee })),
+  );
+
+  const poolAddrs: (string | null)[] = await api.multiCall({
+    abi: FACTORY_GET_POOL_ABI,
+    target: cfg.factory,
+    calls: candidates.map((c) => ({ params: [token, c.reference, c.fee] })),
+    permitFailure: true,
+  });
+
+  const live: DiscoveredPool[] = [];
+  poolAddrs.forEach((addr, i) => {
+    if (!addr || addr.toLowerCase() === ZERO_ADDRESS) return;
+    live.push({
+      pool: addr,
+      reference: candidates[i].reference,
+      fee: candidates[i].fee,
+    });
+  });
+
+  if (live.length === 0) return null;
+
+  const liquidities: (string | null)[] = await api.multiCall({
+    abi: POOL_LIQUIDITY_ABI,
+    calls: live.map((l) => l.pool),
+    permitFailure: true,
+  });
+
+  let bestPool: DiscoveredPool | null = null;
+  let bestLiquidity: bigint = ZERO;
+  for (let i = 0; i < live.length; i++) {
+    const raw = liquidities[i];
+    if (raw == null) continue;
+    const liquidity = BigInt(raw);
+    if (liquidity === ZERO) continue;
+    if (bestPool === null || liquidity > bestLiquidity) {
+      bestPool = live[i];
+      bestLiquidity = liquidity;
+    }
+  }
+
+  return bestPool;
+}

--- a/coins/src/adapters/utils/uniV3PoolDiscovery.ts
+++ b/coins/src/adapters/utils/uniV3PoolDiscovery.ts
@@ -1,28 +1,7 @@
-import { ChainApi } from "@defillama/sdk";
+import type { ChainApi } from "@defillama/sdk";
 
-/**
- * Pool discovery and price math for canonical Uniswap V3 deployments.
- *
- * Anything that follows the canonical Uniswap V3 factory + pool interface
- * (UniswapV3Factory.getPool / UniswapV3Pool.slot0 / UniswapV3Pool.liquidity)
- * works through this module. Forks that diverge on the factory address but
- * keep the pool interface should still work as long as a chain entry is
- * added to CHAIN_V3_CONFIG. Forks that diverge on the pool interface (e.g.
- * a non-standard slot0 layout) still need an explicit (token -> pool) entry
- * in the consuming adapter.
- */
-
-/** Canonical Uniswap V3 fee tiers, in hundredths of a bip (1e-6). */
 export const UNI_V3_FEE_TIERS = [100, 500, 3000, 10000] as const;
 
-/**
- * Minimal ABI that decodes only the first word (sqrtPriceX96) of slot0.
- *
- * Trailing return data is silently dropped by the EVM ABI decoder, so this
- * single ABI is correct for both the standard 7-field slot0 layout and the
- * 6-field variant used by some forks (e.g. PancakeSwap V3). This obsoletes
- * the older approach of maintaining a per-pool custom ABI registry.
- */
 export const SLOT0_SQRT_PRICE_ABI =
   "function slot0() view returns (uint160 sqrtPriceX96)";
 
@@ -37,13 +16,7 @@ const Q96 = BigInt(2) ** BigInt(96);
 const ZERO = BigInt(0);
 
 export interface ChainV3Config {
-  /** UniswapV3Factory address on this chain. */
   factory: string;
-  /**
-   * Tokens whose price is reliably populated by other adapters. Discovery
-   * pairs the target token against each of these (across every fee tier)
-   * and selects the deepest resulting pool.
-   */
   references: string[];
 }
 
@@ -53,14 +26,6 @@ export interface DiscoveredPool {
   fee: (typeof UNI_V3_FEE_TIERS)[number];
 }
 
-/**
- * Per-chain configuration for canonical Uniswap V3 deployments.
- *
- * Only chains where Uniswap V3 itself is deployed belong here. Forks with
- * different factories (PancakeSwap V3 on BSC, SushiSwap V3, etc.) are not
- * canonical Uniswap V3; register explicit (token -> pool) entries in the
- * consuming adapter instead.
- */
 export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
   ethereum: {
     factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
@@ -74,8 +39,8 @@ export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
   polygon: {
     factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
     references: [
-      "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", // USDC (native)
-      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", // USDC.e (bridged)
+      "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", // USDC
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", // USDC.e
       "0xc2132D05D31c914a87C6611C10748AEb04B58e8F", // USDT
       "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619", // WETH
       "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270", // WMATIC
@@ -84,7 +49,7 @@ export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
   arbitrum: {
     factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
     references: [
-      "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC (native)
+      "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC
       "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8", // USDC.e
       "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", // USDT
       "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH
@@ -93,7 +58,7 @@ export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
   optimism: {
     factory: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
     references: [
-      "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", // USDC (native)
+      "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", // USDC
       "0x7F5c764cBc14f9669B88837ca1490cCa17c31607", // USDC.e
       "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58", // USDT
       "0x4200000000000000000000000000000000000006", // WETH
@@ -108,19 +73,6 @@ export const CHAIN_V3_CONFIG: Record<string, ChainV3Config> = {
   },
 };
 
-/**
- * Convert a Uniswap V3 sqrtPriceX96 into the human-decimal price of token0
- * denominated in token1.
- *
- * Uniswap stores price as `sqrt(token1/token0) * 2^96` over raw token units.
- * Squaring and adjusting for decimals yields the price of one token0 (in
- * human units) in token1 (human units):
- *
- *     price = (sqrtPriceX96 / 2^96)^2 * 10^(decimals0 - decimals1)
- *
- * Uses the canonical Uniswap math; `Math.pow(1.0001, tick)` is a lossy
- * approximation derived from this and should not be substituted.
- */
 export function priceFromSqrtPriceX96(
   sqrtPriceX96: bigint,
   decimals0: number,
@@ -131,24 +83,6 @@ export function priceFromSqrtPriceX96(
   return sqrt * sqrt * 10 ** (decimals0 - decimals1);
 }
 
-/**
- * Discover a canonical Uniswap V3 pool to price `token` against on `chain`.
- *
- * Searches the cross of (chain references x fee tiers), drops candidates
- * the factory reports as unmapped or that report zero/failed liquidity,
- * and returns the survivor with the highest in-range `liquidity()`.
- *
- * NOTE on ranking: `liquidity()` is in `sqrt(reserve0 * reserve1)` units
- * over raw token amounts, so values across pools with *different* reference
- * tokens (e.g. a USDC pool vs. a WETH pool) are not directly comparable in
- * USD-equivalent depth. For tokens that have a clearly dominant pool this
- * is irrelevant; for tokens with non-trivial liquidity against multiple
- * decimal-disparate references, the ranking can choose suboptimally. Use
- * an explicit `(token -> pool)` override at the call site when that matters.
- *
- * Returns `null` when no candidate has non-zero liquidity, or when the
- * chain has no V3 config.
- */
 export async function discoverV3Pool(
   api: ChainApi,
   chain: string,


### PR DESCRIPTION
Closes https://github.com/DefiLlama/peggedassets-server/issues/743

BRTH on Polygon returns empty from `coins.llama.fi` because no write-side coins adapter prices it. `markets/uniswap/v3.ts` only prices one hardcoded Ethereum token, and `other/unknownTokensV3.ts` had no Polygon coverage.

This adds opt-in canonical Uniswap V3 pool discovery for `unknownTokensV3`:

- Tokens listed in `autoDiscoveredTokens` are resolved through `factory.getPool(token, reference, fee)`.
- Discovery checks configured reference tokens across canonical fee tiers `[100, 500, 3000, 10000]`.
- Zero-address and zero-liquidity pools are ignored.
- The surviving pool with highest active `liquidity()` is used for slot0 pricing.

BRTH is enrolled on Polygon and resolves to the BRTH/USDT 0.01% pool at `0xaa98e21f7504395024746a9369ca6e20d6f30d01`.

This remains opt-in by design: tokens still need explicit enrollment, but pool addresses no longer need to be hand-curated when the chain uses a canonical Uniswap V3 factory.

Also included:

- Shared `sqrtPriceX96` price math using `(sqrtPriceX96 / 2^96)^2 * 10^(decimals0 - decimals1)` (matches uniswap math)
- A single minimal `slot0()` ABI that decodes both 7-field canonical pools and6-field fork pools because only the first return word is consumed.
- Existing custom-ABI entries for stkWELL and HYBR collapsed into normal explicit pool entries.

### Caveats

- Pool ranking uses raw active `liquidity()`, which is not USD-normalized across very different reference assets such as USDC and WETH. If that matters for a token, use an explicit pool override.
- Discovery is not generic token indexing. It only runs for tokens listed in `autoDiscoveredTokens`.
- `CHAIN_V3_CONFIG` only includes chains and references verified for this PR.

### Verification

- Unit tests for `priceFromSqrtPriceX96`.
- Mocked discovery-path test for BRTH/USDT/100 resolving to the expected pool.
- Live check: `unknownTokensV3()` emits BRTH at `~0.195` USD with symbol `BRTH`, decimals `18`, confidence `0.98`.
- Manual RPC checks confirmed:
  - `factory.getPool(BRTH, USDT, 100) = 0xaa98e21f7504395024746a9369ca6e20d6f30d01`
  - pool liquidity is non-zero
  - minimal `slot0()` decoding works for BRTH, stkWELL, and HYBR pools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid pool discovery: explicit overrides plus automatic canonical Uniswap V3 pool detection across chains.
* **Bug Fixes**
  * More robust price extraction with validation for missing/invalid pool data, decimals handling, and non-finite prices.
* **Refactor**
  * Consolidated pool handling so discovered/explicit pools use a single standardized pool interface.
* **Tests**
  * Added tests covering pool discovery, price computation, ABI decoding and configuration validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->