### PR TITLE
correct gohm price - use the olympus staking contract rate

### DIFF
--- a/coins/src/adapters/other/gohm.ts
+++ b/coins/src/adapters/other/gohm.ts
@@ -1,0 +1,31 @@
+import { getApi } from "../utils/sdk";
+import getWrites from "../utils/getWrites";
+
+const gOHM = "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f"
+const OHM = "0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5"
+const chain = "ethereum";
+
+export default async function getTokenPrice(timestamp: number) {
+  const api = await getApi('ethereum', timestamp);
+  const [
+    gOhmToOhmRate,
+  ] = await Promise.all([
+    api.call({ target: gOHM, abi: 'function balanceFrom(uint256) view returns (uint256)', params: [String(1e18)] })
+  ])
+
+  const pricesObject: any = {};
+  pricesObject[gOHM] = {
+    price: gOhmToOhmRate / 10 ** 9,
+    underlying: OHM,
+    decimals: 18,
+    symbol: "gOHM",
+    confidence: 1,
+  };
+  const writes = await getWrites({
+    chain,
+    timestamp,
+    pricesObject,
+    projectName: "gOHM",
+  });
+  return writes;
+}

--- a/coins/src/adapters/other/index.ts
+++ b/coins/src/adapters/other/index.ts
@@ -35,6 +35,7 @@ import gmdV2 from "./gmdV2";
 import { getApi } from "../utils/sdk";
 import getWrites from "../utils/getWrites";
 import cap from "./cap";
+import gohm from "./gohm";
 
 export { glp };
 
@@ -586,5 +587,6 @@ export const adapters = {
   karakWrapped,
   matrixdock,
   dsu, 
-  cap
+  cap,
+  gohm
 };


### PR DESCRIPTION
Resolves https://github.com/DefiLlama/defillama-server/issues/11899

```
LOCAL_TEST="true" ts-node -T src/test.ts gohm
==== Testing gohm ====
gOhmToOhmRate 269238508004
ohmPrice {
  decimals: 9,
  symbol: 'OHM',
  price: 19.108944293913375,
  timestamp: 1777607942,
  confidence: 0.99,
  chain: 'ethereum',
  address: '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5'
}
[
  {
    SK: 1777608537,
    PK: 'asset#ethereum:0x0ab87046fbb341d058f17cbc4c1133f25a20a52f',
    price: 5144.863651224786,
    adapter: 'olympus',
    confidence: 1
  },
  {
    SK: 0,
    PK: 'asset#ethereum:0x0ab87046fbb341d058f17cbc4c1133f25a20a52f',
    price: 5144.863651224786,
    symbol: 'gOHM',
    decimals: 18,
    redirect: undefined,
    timestamp: 1777608537,
    adapter: 'olympus',
    confidence: 1
  }
]
```

This matches the USD value given by llama swap
https://swap.defillama.com/?chain=ethereum&from=0x0ab87046fbb341d058f17cbc4c1133f25a20a52f&tab=swap&to=0xdac17f958d2ee523a2206206994597c13d831ec7
<img width="515" height="302" alt="image" src="https://github.com/user-attachments/assets/0c54ff30-259f-4f58-8d59-73b2b8bd4c12" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gOHM token price adapter for querying real-time price data from on-chain sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->