### PR TITLE
chore: add chain to Gaming Dex

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34887,7 +34887,7 @@ const data3_2: Protocol[] = [
     gecko_id: null,
     cmcId: null,
     tags: ["Weighted Pool AMM"],
-    chains: ["DeFiVerse"],
+    chains: ["DeFiVerse", "Oasys", "MegaETH"],
     module: "gaming-dex/index.js",
     twitter: "GamingDEX_Oasys",
     forkedFromIds: ["2611"],

--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -34880,7 +34880,7 @@ const data3_2: Protocol[] = [
     symbol: "-",
     url: "https://www.gaming-dex.com",
     description:
-      "Gaming DEX is a DeFi infrastructure protocol that provides token liquidity.It will be implemented on DeFi Verse, a Blockchain for Games-related Oasys Layer 2 blockchain.",
+      "Gaming DEX is a DeFi infrastructure protocol that provides token liquidity. It is implemented on Oasys and megaETH.",
     chain: "DeFiVerse",
     logo: `${baseIconsUrl}/gaming-dex.jpg`,
     audits: "0",


### PR DESCRIPTION
- Add chain MegaETH to Gaming Dex

https://megaeth.gaming-dex.com/#/megaeth/pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gaming DEX protocol now supports Oasys and megaETH blockchains in addition to existing chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->