### PR TITLE
Add Delphi and Gensyn chain listing

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1488,5 +1488,27 @@ const data6: Protocol[] = [
       "open-interest": "dango-oi",
     }
   },
+  {
+    id: "7778",
+    name: "Delphi",
+    address: null,
+    symbol: "-",
+    url: "https://app.delphi.fyi/",
+    description: "Delphi is an information market platform where anyone can create markets and trade on outcomes - settled by AI with verifiable results.",
+    chain: "Gensyn",
+    logo: `${baseIconsUrl}/delphi-gensyn.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Prediction Market",
+    chains: ["Gensyn"],
+    module: "dummy.js",
+    twitter: "delphi_fyi",
+    listedAt: 1777636152,
+    dimensions: {
+      fees: "delphi",
+      dexs: "delphi",
+    },
+  },
 ];
 export default data6;

--- a/defi/src/utils/normalizeChain.ts
+++ b/defi/src/utils/normalizeChain.ts
@@ -5964,6 +5964,19 @@ export const chainCoingeckoIds = {
     url: "https://www.pharos.xyz/",
     chainId: 1672,
   },
+  "Gensyn": {
+    geckoId: "gensyn",
+    symbol: "AI",
+    cmcId: null,
+    categories: ["EVM", "Rollup"],
+    parent: {
+      chain: "Ethereum",
+      types: ["L2", "gas"],
+    },
+    twitter: "GensynFND",
+    url: "https://gensyn.network/",
+    chainId: 685689,
+  },
   "Arweave": {
     geckoId: "arweave",
     symbol: "AR",
@@ -6234,6 +6247,7 @@ const chainLabelMap = {
   "mythos": "Mythos",
   "heima": "Heima",
   "dango": "Dango",
+  "gensyn": "Gensyn",
 } as { [key: string]: string }
 
 // When we decide to change the display name of a chain, we add the mapping for the new name here


### PR DESCRIPTION
## Summary
- add Delphi protocol with fees and DEX dimensions
- add Gensyn chain metadata for protocol listing validation

Delphi website: https://app.delphi.fyi
Delphi Twitter: https://x.com/delphi_fyi
Gensyn website: https://gensyn.network
Gensyn Twitter: https://x.com/GensynFND

## Related PRs
- DefiLlama/defillama-sdk#215
- DefiLlama/dimension-adapters#6720
- DefiLlama/icons#2371

## Checks
- pnpm exec jest --testPathPattern='protocols/data.test' --no-coverage --forceExit
- pnpm run prebuild
