### PR TITLE
optimize dimensions route generation

### DIFF
--- a/defi/src/api2/routes/dimensions.test.ts
+++ b/defi/src/api2/routes/dimensions.test.ts
@@ -1,0 +1,183 @@
+jest.mock("../cache/file-cache", () => ({
+  readRouteData: jest.fn(),
+  storeRouteData: jest.fn(),
+}));
+
+import { AdapterType, AdaptorRecordType, ADAPTER_TYPES } from "../../adaptors/data/types";
+import { storeRouteData } from "../cache/file-cache";
+import { buildProtocolRouteIndex, generateDimensionsResponseFiles } from "./dimensions";
+
+const mockedStoreRouteData = storeRouteData as jest.MockedFunction<typeof storeRouteData>;
+
+function emptyAdapterCache() {
+  return {
+    protocolSummaries: {},
+    parentProtocolSummaries: {},
+    summaries: {},
+    allChains: [],
+  } as any;
+}
+
+function summary(overrides: any = {}) {
+  return {
+    chart: {},
+    chartBreakdown: {},
+    chainSummary: {},
+    categorySummary: {},
+    recordCount: 1,
+    ...overrides,
+  };
+}
+
+function buildDimensionsCache() {
+  const recordType = AdaptorRecordType.dailyVolume;
+  const cache: any = Object.fromEntries(ADAPTER_TYPES.map((adapterType) => [adapterType, emptyAdapterCache()]));
+
+  cache[AdapterType.DEXS] = {
+    ...emptyAdapterCache(),
+    allChains: ["Ethereum", "Arbitrum"],
+    protocolSummaries: {
+      "1": {
+        info: {
+          defillamaId: "1",
+          name: "Eth Dex",
+          category: "Dexs",
+          chains: ["Ethereum"],
+        },
+        summaries: {
+          [recordType]: summary({
+            total24h: 10,
+            totalAllTime: 100,
+            chainSummary: {
+              ethereum: summary({ total24h: 10, totalAllTime: 100 }),
+            },
+          }),
+        },
+      },
+      "2": {
+        info: {
+          defillamaId: "2",
+          name: "Arb Lend",
+          category: "Lending",
+          chains: ["Arbitrum"],
+        },
+        summaries: {
+          [recordType]: summary({
+            total24h: 20,
+            totalAllTime: 200,
+            chainSummary: {
+              arbitrum: summary({ total24h: 20, totalAllTime: 200 }),
+            },
+          }),
+        },
+      },
+      "3": {
+        info: {
+          defillamaId: "3",
+          name: "Multi Dex",
+          category: "Dexs",
+          tags: ["Dexs", "Trading"],
+          chains: ["Ethereum", "Arbitrum"],
+        },
+        summaries: {
+          [recordType]: summary({
+            total24h: 30,
+            totalAllTime: 300,
+            chainSummary: {
+              ethereum: summary({ total24h: 11, totalAllTime: 110 }),
+              arbitrum: summary({ total24h: 19, totalAllTime: 190 }),
+            },
+          }),
+        },
+      },
+      "4": {
+        info: {
+          defillamaId: "4",
+          name: "Empty Dex",
+          category: "Dexs",
+          chains: ["Ethereum"],
+        },
+        summaries: {
+          [recordType]: summary({
+            recordCount: 0,
+            chainSummary: {
+              ethereum: summary({ recordCount: 0 }),
+            },
+          }),
+        },
+      },
+    },
+    summaries: {
+      [recordType]: summary({
+        total24h: 60,
+        totalAllTime: 600,
+        chainSummary: {
+          ethereum: summary({ total24h: 21, totalAllTime: 210 }),
+          arbitrum: summary({ total24h: 39, totalAllTime: 390 }),
+        },
+        categorySummary: {
+          Dexs: summary({
+            total24h: 40,
+            totalAllTime: 400,
+            chainSummary: {
+              ethereum: summary({ total24h: 21, totalAllTime: 210 }),
+              arbitrum: summary({ total24h: 19, totalAllTime: 190 }),
+            },
+          }),
+          Lending: summary({
+            total24h: 20,
+            totalAllTime: 200,
+            chainSummary: {
+              arbitrum: summary({ total24h: 20, totalAllTime: 200 }),
+            },
+          }),
+        },
+      }),
+    },
+  };
+
+  return cache;
+}
+
+function storedData(route: string) {
+  const call = mockedStoreRouteData.mock.calls.find(([storedRoute]) => storedRoute === route);
+  return call?.[1] as any;
+}
+
+describe("dimensions route generation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("indexes protocol rows by chain, category, and category-chain", () => {
+    const cache = buildDimensionsCache()[AdapterType.DEXS];
+    const routeIndex = buildProtocolRouteIndex(cache.protocolSummaries, AdaptorRecordType.dailyVolume);
+
+    expect(routeIndex.all.map((row) => row.info.name)).toEqual(["Eth Dex", "Arb Lend", "Multi Dex"]);
+    expect(routeIndex.byChain.get("ethereum")?.map((row) => row.info.name)).toEqual(["Eth Dex", "Multi Dex"]);
+    expect(routeIndex.byCategory.get("Dexs")?.map((row) => row.info.name)).toEqual(["Eth Dex", "Multi Dex"]);
+    expect(routeIndex.byCategory.get("Trading")?.map((row) => row.info.name)).toEqual(["Multi Dex"]);
+    expect(routeIndex.byCategoryChain.get("Dexs")?.get("arbitrum")?.map((row) => row.info.name)).toEqual(["Multi Dex"]);
+  });
+
+  test("uses indexed rows when generating overview and category files", async () => {
+    await generateDimensionsResponseFiles(buildDimensionsCache());
+
+    expect(storedData("dimensions/dexs/dv-all").protocols.map((protocol: any) => protocol.name)).toEqual([
+      "Eth Dex",
+      "Arb Lend",
+      "Multi Dex",
+    ]);
+    expect(storedData("dimensions/dexs/dv-chain/ethereum-all").protocols.map((protocol: any) => protocol.name)).toEqual([
+      "Eth Dex",
+      "Multi Dex",
+    ]);
+    expect(storedData("dimensions/dexs/dv-category/dexs").protocols.map((protocol: any) => protocol.name)).toEqual([
+      "Eth Dex",
+      "Multi Dex",
+    ]);
+    expect(storedData("dimensions/dexs/dv-category/dexs-chain/arbitrum").protocols.map((protocol: any) => protocol.name)).toEqual([
+      "Multi Dex",
+    ]);
+  });
+});

--- a/defi/src/api2/routes/dimensions.ts
+++ b/defi/src/api2/routes/dimensions.ts
@@ -25,6 +25,8 @@ function getPercentage(a: number, b: number) {
 const validMetricTypesSet = new Set(Object.values(AdapterType)) as Set<string>
 const validRecordTypesSet = new Set(Object.values(AdaptorRecordType)) as Set<string>
 const unixStartOfTodayTimestamp = timeSToUnix(getTimeSDaysAgo(0))
+const protocolInfoKeys = ['defillamaId', 'name', 'displayName', 'module', 'category', 'logo', 'chains', 'protocolType', 'methodologyURL', 'methodology', 'childProtocols', 'parentProtocol', 'slug', 'linkedProtocols', 'doublecounted', 'breakdownMethodology', 'hasLabelBreakdown',]
+const protocolDataKeys = ['total24h', 'total48hto24h', 'total7d', 'total14dto7d', 'total60dto30d', 'total30d', 'total1y', 'totalAllTime', 'average1y', 'monthlyAverage1y', 'change_1d', 'change_7d', 'change_1m', 'change_7dover7d', 'change_30dover30d', 'breakdown24h', 'breakdown30d', 'total14dto7d', 'total7DaysAgo', 'total30DaysAgo']
 const protocolChainBreakdownKeys = [
   'total24h',
   'total48hto24h',
@@ -44,6 +46,19 @@ const protocolChainBreakdownKeys = [
   'change_7dover7d',
   'change_30dover30d',
 ] as const
+
+type ProtocolRouteRow = {
+  id: string,
+  info: any,
+  summary: any,
+}
+
+type ProtocolRouteIndex = {
+  all: ProtocolRouteRow[],
+  byChain: Map<string, ProtocolRouteRow[]>,
+  byCategory: Map<string, ProtocolRouteRow[]>,
+  byCategoryChain: Map<string, Map<string, ProtocolRouteRow[]>>,
+}
 
 function getEventParameters(req: HyperExpress.Request, isSummary = true) {
   const isProRoute = !!(req as any).isProRoute as boolean
@@ -97,18 +112,106 @@ function getEventParameters(req: HyperExpress.Request, isSummary = true) {
   return response
 }
 
+export function buildProtocolRouteIndex(protocolSummaries: any = {}, recordType: AdaptorRecordType): ProtocolRouteIndex {
+  const index: ProtocolRouteIndex = {
+    all: [],
+    byChain: new Map(),
+    byCategory: new Map(),
+    byCategoryChain: new Map(),
+  }
+
+  for (const [id, protocolSummary] of Object.entries(protocolSummaries) as any) {
+    const { summaries, info } = protocolSummary
+    const summary = summaries?.[recordType]
+    if (!summary) continue;
+    if (!summary.recordCount) continue;
+
+    const row = { id, info, summary }
+    index.all.push(row)
+
+    const protocolChainKeys = Object.entries(summary.chainSummary ?? {})
+      .filter(([chain, chainSummary]: any) => chainSummary?.recordCount && info?.chains?.includes(getChainLabelFromKey(chain)))
+      .map(([chain]) => chain)
+
+    for (const chain of protocolChainKeys) {
+      addToMapArray(index.byChain, chain, row)
+    }
+
+    for (const category of getProtocolCategories(info)) {
+      addToMapArray(index.byCategory, category, row)
+
+      for (const chain of protocolChainKeys) {
+        let chainMap = index.byCategoryChain.get(category)
+        if (!chainMap) {
+          chainMap = new Map()
+          index.byCategoryChain.set(category, chainMap)
+        }
+        addToMapArray(chainMap, chain, row)
+      }
+    }
+  }
+
+  return index
+
+  function addToMapArray(map: Map<string, ProtocolRouteRow[]>, key: string, row: ProtocolRouteRow) {
+    let rows = map.get(key)
+    if (!rows) {
+      rows = []
+      map.set(key, rows)
+    }
+    rows.push(row)
+  }
+}
+
+function getProtocolCategories(info: any): Array<string> {
+  if (!info) return [];
+  // We treat tags same as category and use labels (not slugs) for keys, only use slugs on storage and query.
+  let _pCategories = info.category ? [info.category] : [];
+  if (info.tags) _pCategories = _pCategories.concat(info.tags);
+  return [...new Set(_pCategories)];
+}
+
+function formatProtocolRows({
+  rows, chain,
+}: {
+  rows: ProtocolRouteRow[],
+  chain?: string,
+}) {
+  let protocolTotalAllTimeSum = 0
+
+  const protocols = rows.map(({ summary: rootSummary, info }: ProtocolRouteRow) => {
+    const res: any = {}
+    const summary = chain ? rootSummary?.chainSummary?.[chain] : rootSummary
+
+    if (summary)
+      protocolDataKeys.forEach(key => res[key] = summary[key])
+
+    // sometimes a protocol is disabled or id is changed, we should disregard these data
+    if (!summary && !info) return null
+
+    if (!summary?.recordCount) return null; // if there are no data points, we should filter out the protocol
+    if (summary?.totalAllTime) protocolTotalAllTimeSum += summary.totalAllTime
+
+    protocolInfoKeys.filter(key => info?.[key]).forEach(key => res[key] = info?.[key])
+    res.id = res.defillamaId ?? res.id
+    return res
+  }).filter((i: any) => i)
+
+  return { protocols, protocolTotalAllTimeSum }
+}
+
 async function getOverviewProcess({
-  recordType, cacheData, chain,
+  recordType, cacheData, chain, routeIndex,
 }: {
   recordType: AdaptorRecordType,
   cacheData: any,
   chain?: string,
+  routeIndex?: ProtocolRouteIndex,
 }) {
   const { summaries, allChains, protocolSummaries = {} } = cacheData
   if (chain)
     chain = getChainKeyFromLabel(chain) // normalize chain name like 'zksync-era' -> 'era' 
 
-  const chainDisplayName = chain ? getChainLabelFromKey(chain) : null
   let summary = chain ? summaries[recordType]?.chainSummary[chain] : summaries[recordType]
   const response: any = {}
   if (!summary) summary = {}
@@ -130,51 +233,23 @@ async function getOverviewProcess({
   responseKeys.forEach(key => {
     response[key] = summary[key]
   })
-  let protocolTotalAllTimeSum = 0
-
   response.change_1d = getPercentage(summary.total24h, summary.total48hto24h)
   response.change_7d = getPercentage(summary.total24h, summary.total7DaysAgo)
   response.change_1m = getPercentage(summary.total24h, summary.total30DaysAgo)
   response.change_7dover7d = getPercentage(summary.total7d, summary.total14dto7d)
   response.change_30dover30d = getPercentage(summary.total30d, summary.total60dto30d)
 
-  // These fields are for the protocol level data
-  const protocolInfoKeys = ['defillamaId', 'name', 'displayName', 'module', 'category', 'logo', 'chains', 'protocolType', 'methodologyURL', 'methodology', 'childProtocols', 'parentProtocol', 'slug', 'linkedProtocols', 'doublecounted', 'breakdownMethodology', 'hasLabelBreakdown',]
-  const protocolDataKeys = ['total24h', 'total48hto24h', 'total7d', 'total14dto7d', 'total60dto30d', 'total30d', 'total1y', 'totalAllTime', 'average1y', 'monthlyAverage1y', 'change_1d', 'change_7d', 'change_1m', 'change_7dover7d', 'change_30dover30d', 'breakdown24h', 'breakdown30d', 'total14dto7d', 'total7DaysAgo', 'total30DaysAgo']
-
-  response.protocols = Object.entries(protocolSummaries).map(([_id, { summaries, info }]: any) => {
-    const res: any = {}
-
-    let summary = summaries?.[recordType]
-    if (chain) {
-      if (!info?.chains.includes(chainDisplayName)) return null
-      summary = summary?.chainSummary[chain]
-    }
-
-
-    if (summary)
-      protocolDataKeys.forEach(key => res[key] = summary[key])
-
-    // sometimes a protocol is diabled or id is changed, we should disregard these data 
-    if (!summary && !info) {
-      // console.log('no data found', _id, info)
-      return null
-    }
-
-    if (!summary?.recordCount) return null; // if there are no data points, we should filter out the protocol
-    if (summary?.totalAllTime) protocolTotalAllTimeSum += summary.totalAllTime
-
-    protocolInfoKeys.filter(key => info?.[key]).forEach(key => res[key] = info?.[key])
-    res.id = res.defillamaId ?? res.id
-    return res
-  }).filter((i: any) => i)
+  routeIndex = routeIndex ?? buildProtocolRouteIndex(protocolSummaries, recordType)
+  const rows = chain ? routeIndex.byChain.get(chain) ?? [] : routeIndex.all
+  const { protocols, protocolTotalAllTimeSum } = formatProtocolRows({ rows, chain })
+  response.protocols = protocols
   if (!response.totalAllTime) response.totalAllTime = protocolTotalAllTimeSum
 
   return response
 }
 
 // chain is key: ethereum, bsc
-async function getCategoryData({ recordType, cacheData, category, chain }: { recordType: AdaptorRecordType, cacheData: any, category: string, chain?: string }) {
+async function getCategoryData({ recordType, cacheData, category, chain, routeIndex }: { recordType: AdaptorRecordType, cacheData: any, category: string, chain?: string, routeIndex?: ProtocolRouteIndex }) {
   const { summaries, protocolSummaries = {} } = cacheData
 
   const chainDisplayName = chain ? getChainLabelFromKey(chain) : null
@@ -198,57 +273,19 @@ async function getCategoryData({ recordType, cacheData, category, chain }: { rec
   responseKeys.forEach(key => {
     response[key] = summary[key]
   })
-  let protocolTotalAllTimeSum = 0
-
   response.change_1d = getPercentage(summary.total24h, summary.total48hto24h)
   response.change_7d = getPercentage(summary.total24h, summary.total7DaysAgo)
   response.change_1m = getPercentage(summary.total24h, summary.total30DaysAgo)
   response.change_7dover7d = getPercentage(summary.total7d, summary.total14dto7d)
   response.change_30dover30d = getPercentage(summary.total30d, summary.total60dto30d)
 
-  // These fields are for the protocol level data
-  const protocolInfoKeys = ['defillamaId', 'name', 'displayName', 'module', 'category', 'logo', 'chains', 'protocolType', 'methodologyURL', 'methodology', 'childProtocols', 'parentProtocol', 'slug', 'linkedProtocols', 'doublecounted', 'breakdownMethodology', 'hasLabelBreakdown',]
-  const protocolDataKeys = ['total24h', 'total48hto24h', 'total7d', 'total14dto7d', 'total60dto30d', 'total30d', 'total1y', 'totalAllTime', 'average1y', 'monthlyAverage1y', 'change_1d', 'change_7d', 'change_1m', 'change_7dover7d', 'change_30dover30d', 'breakdown24h', 'breakdown30d', 'total14dto7d', 'total7DaysAgo', 'total30DaysAgo']
-
-  response.protocols = Object.entries(protocolSummaries).map(([_id, { summaries, info }]: any) => {
-    const res: any = {}
-    const categories = getProtocolCategories(info)
-    if (!categories.includes(category)) return null
-
-    let summary = summaries?.[recordType]
-    if (chain) {
-      if (!info?.chains.includes(chainDisplayName)) return null
-      summary = summary?.chainSummary[chain]
-    }
-
-    if (summary)
-      protocolDataKeys.forEach(key => res[key] = summary[key])
-
-    // sometimes a protocol is diabled or id is changed, we should disregard these data 
-    if (!summary && !info) {
-      // console.log('no data found', _id, info)
-      return null
-    }
-
-    if (!summary?.recordCount) return null; // if there are no data points, we should filter out the protocol
-    if (summary?.totalAllTime) protocolTotalAllTimeSum += summary.totalAllTime
-
-    protocolInfoKeys.filter(key => info?.[key]).forEach(key => res[key] = info?.[key])
-    res.id = res.defillamaId ?? res.id
-    return res
-  }).filter((i: any) => i)
+  routeIndex = routeIndex ?? buildProtocolRouteIndex(protocolSummaries, recordType)
+  const rows = chain ? routeIndex.byCategoryChain.get(category)?.get(chain) ?? [] : routeIndex.byCategory.get(category) ?? []
+  const { protocols, protocolTotalAllTimeSum } = formatProtocolRows({ rows, chain })
+  response.protocols = protocols
   if (!response.totalAllTime) response.totalAllTime = protocolTotalAllTimeSum
 
   return response
-  
-  function getProtocolCategories(info: any): Array<string> {
-    if (!info) return [];
-    // we treat tags same as category and use labels (not slugs) for keys, only use slugs on storage and query
-    // ex: we use 'Dexs' when cumputing data, and use 'dexs' as storage and query on api later
-    let _pCategories = info.category ? [info.category] : [];
-    if (info.tags) _pCategories = _pCategories.concat(info.tags);
-    return _pCategories;
-  }
 }
 
 // some protocols dont support pulling current day data (can only pull daily data after the day is complete instead of past 24 hours)
@@ -782,9 +819,10 @@ export async function generateDimensionsResponseFiles(cache: Record<AdapterType,
     for (const recordType of recordTypes) {
       const timeKey = `dimensions-gen-files ${adapterType} ${recordType}`
       console.time(timeKey)
+      const routeIndex = buildProtocolRouteIndex(protocolSummaries, recordType)
 
       // fetch and store overview of each record type
-      const allData = await getOverviewProcess({ recordType, cacheData, })
+      const allData = await getOverviewProcess({ recordType, cacheData, routeIndex, })
       await storeRouteData(`dimensions/${adapterType}/${recordType}-all`, allData)
       allData.totalDataChart = []
       allData.totalDataChartBreakdown = []
@@ -796,7 +834,7 @@ export async function generateDimensionsResponseFiles(cache: Record<AdapterType,
 
       for (const chainLabel of chains) {
         let chain = getChainKeyFromLabel(chainLabel)
-        const data = await getOverviewProcess({ recordType, cacheData, chain })
+        const data = await getOverviewProcess({ recordType, cacheData, chain, routeIndex })
         await storeRouteData(`dimensions/${adapterType}/${recordType}-chain/${chain}-all`, data)
         for (const [date, value] of data.totalDataChart) {
           totalDataChartByChain[date] = totalDataChartByChain[date] || {}
@@ -825,7 +863,7 @@ export async function generateDimensionsResponseFiles(cache: Record<AdapterType,
       if (summaries && summaries[recordType] && summaries[recordType].categorySummary) {
         for (const [category, categorySummary] of Object.entries(summaries[recordType].categorySummary)) {
           const categorySlug = sluggifyCategoryString(category); // convert to slug Dexs -> dexs
-          const categoryData = await getCategoryData({ recordType, cacheData, category: category });
+          const categoryData = await getCategoryData({ recordType, cacheData, category: category, routeIndex });
           await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}-chart`, categoryData.totalDataChart);
           await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}-chart-protocol-breakdown`, categoryData.totalDataChartBreakdown);
           await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}`, { ...categoryData, totalDataChart: undefined, totalDataChartBreakdown: undefined });
@@ -841,7 +879,7 @@ export async function generateDimensionsResponseFiles(cache: Record<AdapterType,
           const chartPerChainItems: Record<string, any> = {};
           for (const chain of Object.keys(categorySummary.chainSummary ?? {})) {
             const chainLabel = getChainLabelFromKey(chain);
-            const categoryChainData = await getCategoryData({ recordType, cacheData, category: category, chain });
+            const categoryChainData = await getCategoryData({ recordType, cacheData, category: category, chain, routeIndex });
             await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}-chain/${chain}-chart`, categoryChainData.totalDataChart);
             await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}-chain/${chain}-chart-protocol-breakdown`, categoryChainData.totalDataChartBreakdown);
             await storeRouteData(`dimensions/${adapterType}/${recordType}-category/${categorySlug}-chain/${chain}`, { ...categoryChainData, totalDataChart: undefined, totalDataChartBreakdown: undefined });


### PR DESCRIPTION
## Summary

Precompute protocol route indexes during dimensions response file generation so overview, chain, category, and category-chain route artifacts no longer repeatedly scan every protocol summary.

The new index groups protocol rows by:

- all protocols
- chain
- category/tag
- category + chain

This keeps existing aggregate chart/totals generation unchanged while reducing repeated protocol filtering work from roughly `O(P * routes)` to `O(P + matchedRows)` per adapter/record type.

## Testing

- `npx jest src/api2/routes/dimensions.test.ts --runInBand`