### PR TITLE
add easya-kickstart listing (id 7777)

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1471,7 +1471,7 @@ const data6: Protocol[] = [
     url: "https://kickstart.easya.io/",
     description: "Permissionless ideas launchpad on Solana built on top of Meteora Dynamic Bonding Curve",
     chain: "Solana",
-    logo: `${baseIconsUrl}/easya-kickstart.jpg`,
+    logo: `${baseIconsUrl}/easya-kickstart.svg`,
     audits: "0",
     gecko_id: null,
     cmcId: null,

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1463,5 +1463,27 @@ const data6: Protocol[] = [
     twitter: "Neronaxyz",
     listedAt: 1777660684
   },
+  {
+    id: "7777",
+    name: "EasyA Kickstart",
+    address: null,
+    symbol: "-",
+    url: "https://kickstart.easya.io/",
+    description: "Permissionless ideas launchpad on Solana built on top of Meteora Dynamic Bonding Curve",
+    chain: "Solana",
+    logo: `${baseIconsUrl}/easya-kickstart.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Launchpad",
+    chains: ["Solana"],
+    module: "easya-kickstart/index.js",
+    twitter: "EasyA_Kickstart",
+    listedAt: 1777673109,
+    dimensions: {
+      fees: "easya-kickstart",
+      dexs: "easya-kickstart",
+    },
+  },
 ];
 export default data6;


### PR DESCRIPTION
Adds new entry id 7777 (EasyA Kickstart) to `data6.ts`.

EasyA Kickstart is a permissionless ideas launchpad on Solana built on top of Meteora Dynamic Bonding Curve.

Companion PRs:
- TVL adapter: DefiLlama/DefiLlama-Adapters#19067
- Volume + Fees adapter: DefiLlama/dimension-adapters#6749

Entry fields:
- `name`: EasyA Kickstart
- `url`: https://kickstart.easya.io/
- `chain` / `chains`: Solana
- `category`: Launchpad
- `twitter`: EasyA_Kickstart
- `module`: easya-kickstart/index.js
- `dimensions.fees`: easya-kickstart
- `dimensions.dexs`: easya-kickstart

Logo: SVG (vector, square, brand color #52FFA1 with black mark) to be attached via edit after PR creation. Happy to convert / send a different format if needed.
