### PR TITLE
optimize rwa perps aggregate chart generation

### DIFF
--- a/defi/src/rwa/perps/aggregate.ts
+++ b/defi/src/rwa/perps/aggregate.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { toStringArrayOrNull, toStringOrNull } from "../utils";
 import { UNKNOWN_PERPS_ASSET_GROUP, normalizePerpsAssetGroup } from "./server-helpers";
 import { perpsSlug, toFiniteNumberOrZero } from "./utils";
@@ -39,6 +40,22 @@ export type AggregateHistoricalRow = {
 export type PerpsChartMetricKey = "openInterest" | "volume24h" | "markets";
 export type PerpsOverviewBreakdown = "venue" | "assetGroup" | "assetClass" | "baseAsset";
 export type PerpsBreakdownChartRow = { timestamp: number } & Record<string, number>;
+export type PerpsAggregateHistoricalCharts = {
+  venueCharts: Record<string, AggregateHistoricalRow[]>;
+  categoryCharts: Record<string, AggregateHistoricalRow[]>;
+  overviewBreakdownCharts: Record<string, PerpsBreakdownChartRow[]>;
+  contractBreakdownCharts: Record<string, PerpsBreakdownChartRow[]>;
+};
+export type PerpsAggregateSyncMetadata = {
+  metadataHash?: string;
+  lastDailySyncTimestamp?: string | null;
+};
+
+type AggregateHistoricalContext = {
+  rows: AggregateHistoricalRow[];
+  rowsByVenue: Record<string, AggregateHistoricalRow[]>;
+  rowsByAssetGroup: Record<string, AggregateHistoricalRow[]>;
+};
 
 const BREAKDOWN_METRIC_KEYS: PerpsChartMetricKey[] = ["openInterest", "volume24h", "markets"];
 const OVERVIEW_BREAKDOWNS_BY_TARGET = {
@@ -55,6 +72,52 @@ function getMetadataMap(metadata: MetadataRecord[]) {
     }
   }
   return metadataMap;
+}
+
+function stableStringify(value: any): string {
+  if (value === undefined) return "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (!value || typeof value !== "object") return JSON.stringify(value);
+
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+export function getPerpsMetadataHash(metadata: MetadataRecord[]): string {
+  const normalizedMetadata = metadata
+    .map((entry) => {
+      const data = entry.data ?? {};
+      return {
+        id: entry.id,
+        data: {
+          contract: data.contract,
+          venue: data.venue,
+          referenceAsset: data.referenceAsset,
+          referenceAssetGroup: data.referenceAssetGroup,
+          assetClass: data.assetClass,
+          category: data.category,
+        },
+      };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+  return createHash("sha256").update(stableStringify(normalizedMetadata)).digest("hex");
+}
+
+export function canReusePerpsAggregateHistoricalCharts({
+  updatedDailyRecords,
+  lastDailySyncTimestamp,
+  metadataHash,
+  aggregateSyncMetadata,
+}: {
+  updatedDailyRecords: number;
+  lastDailySyncTimestamp: string | null;
+  metadataHash: string;
+  aggregateSyncMetadata: PerpsAggregateSyncMetadata | null;
+}): boolean {
+  return (
+    updatedDailyRecords === 0 &&
+    aggregateSyncMetadata?.metadataHash === metadataHash &&
+    aggregateSyncMetadata?.lastDailySyncTimestamp === lastDailySyncTimestamp
+  );
 }
 
 function normalizeCategoryList(value: unknown): string[] {
@@ -97,6 +160,18 @@ function buildBaseHistoricalRow(record: DailyRecord, metadataMap: Map<string, Me
 function buildHistoricalRows(dailyRecords: DailyRecord[], metadata: MetadataRecord[]): AggregateHistoricalRow[] {
   const metadataMap = getMetadataMap(metadata);
   return dailyRecords.map((record) => buildBaseHistoricalRow(record, metadataMap));
+}
+
+function buildAggregateHistoricalContext(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): AggregateHistoricalContext {
+  const rows = buildHistoricalRows(dailyRecords, metadata);
+  return {
+    rows,
+    rowsByVenue: buildGroupMap(rows, (row) => perpsSlug(row.venue)),
+    rowsByAssetGroup: buildGroupMap(rows, (row) => perpsSlug(getAssetGroupLabel(row))),
+  };
 }
 
 function sortHistoricalRows(rows: AggregateHistoricalRow[]) {
@@ -212,24 +287,18 @@ export function buildPerpsIdMap(metadata: MetadataRecord[]): Record<string, stri
   return idMap;
 }
 
-export function buildVenueHistoricalCharts(
-  dailyRecords: DailyRecord[],
-  metadata: MetadataRecord[]
+function sortVenueHistoricalCharts(
+  chartsByVenue: Record<string, AggregateHistoricalRow[]>
 ): Record<string, AggregateHistoricalRow[]> {
-  const chartsByVenue = buildGroupMap(buildHistoricalRows(dailyRecords, metadata), (row) => perpsSlug(row.venue));
-
+  const sortedChartsByVenue: Record<string, AggregateHistoricalRow[]> = {};
   for (const venueKey in chartsByVenue) {
-    sortHistoricalRows(chartsByVenue[venueKey]);
+    sortedChartsByVenue[venueKey] = sortHistoricalRows([...chartsByVenue[venueKey]]);
   }
 
-  return chartsByVenue;
+  return sortedChartsByVenue;
 }
 
-export function buildCategoryHistoricalCharts(
-  dailyRecords: DailyRecord[],
-  metadata: MetadataRecord[]
-): Record<string, AggregateHistoricalRow[]> {
-  const rows = buildHistoricalRows(dailyRecords, metadata);
+function buildCategoryHistoricalChartsFromRows(rows: AggregateHistoricalRow[]): Record<string, AggregateHistoricalRow[]> {
   const chartsByCategory: Record<string, AggregateHistoricalRow[]> = {};
 
   for (const row of rows) {
@@ -252,14 +321,9 @@ export function buildCategoryHistoricalCharts(
   return chartsByCategory;
 }
 
-export function buildOverviewBreakdownCharts(
-  dailyRecords: DailyRecord[],
-  metadata: MetadataRecord[]
-): Record<string, PerpsBreakdownChartRow[]> {
-  const rows = buildHistoricalRows(dailyRecords, metadata);
+function buildOverviewBreakdownChartsFromContext(context: AggregateHistoricalContext): Record<string, PerpsBreakdownChartRow[]> {
+  const { rows, rowsByVenue, rowsByAssetGroup } = context;
   const charts: Record<string, PerpsBreakdownChartRow[]> = {};
-  const rowsByVenue = buildGroupMap(rows, (row) => perpsSlug(row.venue));
-  const rowsByAssetGroup = buildGroupMap(rows, (row) => perpsSlug(getAssetGroupLabel(row)));
 
   for (const metric of BREAKDOWN_METRIC_KEYS) {
     for (const breakdown of OVERVIEW_BREAKDOWNS_BY_TARGET.all) {
@@ -291,14 +355,9 @@ export function buildOverviewBreakdownCharts(
   return charts;
 }
 
-export function buildContractBreakdownCharts(
-  dailyRecords: DailyRecord[],
-  metadata: MetadataRecord[]
-): Record<string, PerpsBreakdownChartRow[]> {
-  const rows = buildHistoricalRows(dailyRecords, metadata);
+function buildContractBreakdownChartsFromContext(context: AggregateHistoricalContext): Record<string, PerpsBreakdownChartRow[]> {
+  const { rows, rowsByVenue, rowsByAssetGroup } = context;
   const charts: Record<string, PerpsBreakdownChartRow[]> = {};
-  const rowsByVenue = buildGroupMap(rows, (row) => perpsSlug(row.venue));
-  const rowsByAssetGroup = buildGroupMap(rows, (row) => perpsSlug(getAssetGroupLabel(row)));
 
   for (const metric of BREAKDOWN_METRIC_KEYS) {
     charts[`contract-breakdown/all/${metric.toLowerCase()}.json`] = buildBreakdownChartRows(
@@ -331,4 +390,46 @@ export function buildContractBreakdownCharts(
   }
 
   return charts;
+}
+
+export function buildAllAggregateHistoricalCharts(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): PerpsAggregateHistoricalCharts {
+  const context = buildAggregateHistoricalContext(dailyRecords, metadata);
+  return {
+    venueCharts: sortVenueHistoricalCharts(context.rowsByVenue),
+    categoryCharts: buildCategoryHistoricalChartsFromRows(context.rows),
+    overviewBreakdownCharts: buildOverviewBreakdownChartsFromContext(context),
+    contractBreakdownCharts: buildContractBreakdownChartsFromContext(context),
+  };
+}
+
+export function buildVenueHistoricalCharts(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): Record<string, AggregateHistoricalRow[]> {
+  const rows = buildHistoricalRows(dailyRecords, metadata);
+  return sortVenueHistoricalCharts(buildGroupMap(rows, (row) => perpsSlug(row.venue)));
+}
+
+export function buildCategoryHistoricalCharts(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): Record<string, AggregateHistoricalRow[]> {
+  return buildCategoryHistoricalChartsFromRows(buildHistoricalRows(dailyRecords, metadata));
+}
+
+export function buildOverviewBreakdownCharts(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): Record<string, PerpsBreakdownChartRow[]> {
+  return buildOverviewBreakdownChartsFromContext(buildAggregateHistoricalContext(dailyRecords, metadata));
+}
+
+export function buildContractBreakdownCharts(
+  dailyRecords: DailyRecord[],
+  metadata: MetadataRecord[]
+): Record<string, PerpsBreakdownChartRow[]> {
+  return buildContractBreakdownChartsFromContext(buildAggregateHistoricalContext(dailyRecords, metadata));
 }

--- a/defi/src/rwa/perps/cron.ts
+++ b/defi/src/rwa/perps/cron.ts
@@ -6,6 +6,8 @@ import {
     getCacheVersion,
     getSyncMetadata,
     setSyncMetadata,
+    getAggregateSyncMetadata,
+    setAggregateSyncMetadata,
     storeHistoricalDataForId,
     readHistoricalDataForId,
     mergeHistoricalData,
@@ -21,11 +23,10 @@ import {
 import { getPercentChangeOrNull, toFiniteNumberOrZero, groupBy } from './utils';
 import { main as runPipeline } from './perps';
 import {
-    buildCategoryHistoricalCharts,
-    buildContractBreakdownCharts,
-    buildOverviewBreakdownCharts,
+    buildAllAggregateHistoricalCharts,
+    canReusePerpsAggregateHistoricalCharts,
+    getPerpsMetadataHash,
     buildPerpsIdMap,
-    buildVenueHistoricalCharts
 } from './aggregate';
 import { normalizePerpsMetadataInPlace, hasContractMetadata } from './constants';
 import { buildPerpsList } from './list';
@@ -35,6 +36,11 @@ interface PerpsMetadata {
     id: string;
     data: any;
 }
+
+type HistoricalChartsResult = {
+    updatedDailyRecords: number;
+    lastDailySyncTimestamp: string | null;
+};
 
 async function generateCurrentData(metadata: PerpsMetadata[]): Promise<any[]> {
     console.log('Generating current perps data...');
@@ -158,7 +164,7 @@ async function generateList(currentData: any[]): Promise<void> {
     console.log(`Generated list.json`);
 }
 
-async function generateHistoricalCharts(): Promise<void> {
+async function generateHistoricalCharts(): Promise<HistoricalChartsResult> {
     console.log('Generating historical charts...');
     const startTime = Date.now();
 
@@ -168,7 +174,10 @@ async function generateHistoricalCharts(): Promise<void> {
     const allRecords = await fetchAllDailyRecordsPG(lastSync);
     if (allRecords.length === 0) {
         console.log('No new records to process for charts.');
-        return;
+        return {
+            updatedDailyRecords: 0,
+            lastDailySyncTimestamp: syncMeta?.lastSyncTimestamp ?? null,
+        };
     }
 
     // Group records by id
@@ -199,25 +208,47 @@ async function generateHistoricalCharts(): Promise<void> {
 
     // Update sync metadata
     const maxUpdatedAt = await fetchMaxUpdatedAtPG();
+    const lastDailySyncTimestamp = maxUpdatedAt?.toISOString() || null;
     await setSyncMetadata({
-        lastSyncTimestamp: maxUpdatedAt?.toISOString() || null,
+        lastSyncTimestamp: lastDailySyncTimestamp,
         lastSyncDate: new Date().toISOString(),
         totalIds: (await fetchAllDailyIdsPG()).length,
     });
 
     console.log(`Generated charts for ${processedCount} markets in ${Date.now() - startTime}ms`);
+    return {
+        updatedDailyRecords: allRecords.length,
+        lastDailySyncTimestamp,
+    };
 }
 
-// TODO: perf — this fetches ALL daily records on every cron run (no lastSync filter).
-// Fine for now, but will need incremental sync like generateHistoricalCharts once history grows.
-async function generateAggregateHistoricalCharts(metadata: PerpsMetadata[]): Promise<void> {
+// Aggregate outputs are cross-market files, so updated daily rows or metadata changes
+// require a full rebuild; no-op cron runs can reuse the existing files.
+async function generateAggregateHistoricalCharts(
+    metadata: PerpsMetadata[],
+    { updatedDailyRecords, lastDailySyncTimestamp }: HistoricalChartsResult
+): Promise<void> {
     console.log('Generating aggregate historical charts...');
 
+    const metadataHash = getPerpsMetadataHash(metadata);
+    const aggregateSyncMetadata = await getAggregateSyncMetadata();
+    if (canReusePerpsAggregateHistoricalCharts({
+        updatedDailyRecords,
+        lastDailySyncTimestamp,
+        metadataHash,
+        aggregateSyncMetadata,
+    })) {
+        console.log('No new daily records or metadata changes for aggregate charts.');
+        return;
+    }
+
     const allDailyRecords = await fetchAllDailyRecordsPG();
-    const venueCharts = buildVenueHistoricalCharts(allDailyRecords, metadata);
-    const categoryCharts = buildCategoryHistoricalCharts(allDailyRecords, metadata);
-    const overviewBreakdownCharts = buildOverviewBreakdownCharts(allDailyRecords, metadata);
-    const contractBreakdownCharts = buildContractBreakdownCharts(allDailyRecords, metadata);
+    const {
+        venueCharts,
+        categoryCharts,
+        overviewBreakdownCharts,
+        contractBreakdownCharts,
+    } = buildAllAggregateHistoricalCharts(allDailyRecords, metadata);
 
     for (const venueKey in venueCharts) {
         const rows = venueCharts[venueKey];
@@ -262,6 +293,12 @@ async function generateAggregateHistoricalCharts(metadata: PerpsMetadata[]): Pro
     console.log(
         `Generated aggregate historical charts for ${venueChartCount} venues, ${categoryChartCount} categories, ${overviewBreakdownCount} overview breakdowns, and ${contractBreakdownCount} contract breakdowns`
     );
+
+    await setAggregateSyncMetadata({
+        lastGeneratedDate: new Date().toISOString(),
+        metadataHash,
+        lastDailySyncTimestamp,
+    });
 }
 
 // ── Main cron ────────────────────────────────────────────────────────────────
@@ -293,8 +330,8 @@ async function cron(): Promise<void> {
     await generateIdMap(metadata);
     await generateStats(currentData);
     await generateList(currentData);
-    await generateHistoricalCharts();
-    await generateAggregateHistoricalCharts(metadata);
+    const historicalChartsResult = await generateHistoricalCharts();
+    await generateAggregateHistoricalCharts(metadata, historicalChartsResult);
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     console.log(`[rwa-perps-cron] Complete in ${elapsed}s`);

--- a/defi/src/rwa/perps/file-cache.ts
+++ b/defi/src/rwa/perps/file-cache.ts
@@ -87,6 +87,12 @@ interface SyncMetadata {
     totalIds: number;
 }
 
+interface AggregateSyncMetadata {
+    lastGeneratedDate: string;
+    metadataHash: string;
+    lastDailySyncTimestamp: string | null;
+}
+
 export async function getSyncMetadata(): Promise<SyncMetadata | null> {
     const data = await readRouteData(SYNC_METADATA_FILE, { skipErrorLog: true });
     return data;
@@ -94,6 +100,17 @@ export async function getSyncMetadata(): Promise<SyncMetadata | null> {
 
 export async function setSyncMetadata(metadata: SyncMetadata): Promise<void> {
     await storeRouteData(SYNC_METADATA_FILE, metadata);
+}
+
+const AGGREGATE_SYNC_METADATA_FILE = 'aggregate-sync-metadata.json';
+
+export async function getAggregateSyncMetadata(): Promise<AggregateSyncMetadata | null> {
+    const data = await readRouteData(AGGREGATE_SYNC_METADATA_FILE, { skipErrorLog: true });
+    return data;
+}
+
+export async function setAggregateSyncMetadata(metadata: AggregateSyncMetadata): Promise<void> {
+    await storeRouteData(AGGREGATE_SYNC_METADATA_FILE, metadata);
 }
 
 // Historical data per ID

--- a/defi/src/rwa/perps/file-cache.ts
+++ b/defi/src/rwa/perps/file-cache.ts
@@ -52,6 +52,7 @@ async function storeData(subPath: string, data: any): Promise<void> {
         await fs.promises.writeFile(filePath, JSON.stringify(data));
     } catch (e) {
         console.error(`Error storing data to ${filePath}:`, (e as any)?.message);
+        throw e;
     }
 }
 

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -6,9 +6,12 @@ import { toFiniteNumberOrZero, getPercentChangeOrNull, perpsSlug, computeProtoco
 import { fileNameNormalizer, mergeHistoricalData } from "./file-cache";
 import { buildPerpsList } from "./list";
 import {
+  buildAllAggregateHistoricalCharts,
+  canReusePerpsAggregateHistoricalCharts,
   buildContractBreakdownCharts,
   buildCategoryHistoricalCharts,
   buildOverviewBreakdownCharts,
+  getPerpsMetadataHash,
   buildPerpsIdMap,
   buildVenueHistoricalCharts,
 } from "./aggregate";
@@ -493,6 +496,63 @@ describe("buildPerpsIdMap", () => {
   });
 });
 
+describe("getPerpsMetadataHash", () => {
+  it("is stable across metadata order and object key order", () => {
+    const first = getPerpsMetadataHash([
+      { id: "xyz:meta", data: { venue: "xyz", contract: "xyz:META", category: ["Equities"], fee: 0.01 } as any },
+      { id: "flx:gold", data: { referenceAssetGroup: "Commodities", contract: "flx:GOLD" } },
+    ]);
+    const second = getPerpsMetadataHash([
+      { id: "flx:gold", data: { contract: "flx:GOLD", referenceAssetGroup: "Commodities" } },
+      { id: "xyz:meta", data: { category: ["Equities"], contract: "xyz:META", venue: "xyz", fee: 0.02 } as any },
+    ]);
+    const changed = getPerpsMetadataHash([
+      { id: "flx:gold", data: { contract: "flx:GOLD", referenceAssetGroup: "Commodities" } },
+      { id: "xyz:meta", data: { category: ["Equities"], contract: "xyz:META", venue: "xyz-v2" } },
+    ]);
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(changed);
+  });
+});
+
+describe("canReusePerpsAggregateHistoricalCharts", () => {
+  it("only reuses aggregate charts when daily sync and metadata inputs both match", () => {
+    const aggregateSyncMetadata = {
+      metadataHash: "hash-a",
+      lastDailySyncTimestamp: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(canReusePerpsAggregateHistoricalCharts({
+      updatedDailyRecords: 0,
+      lastDailySyncTimestamp: "2026-01-01T00:00:00.000Z",
+      metadataHash: "hash-a",
+      aggregateSyncMetadata,
+    })).toBe(true);
+
+    expect(canReusePerpsAggregateHistoricalCharts({
+      updatedDailyRecords: 0,
+      lastDailySyncTimestamp: "2026-01-02T00:00:00.000Z",
+      metadataHash: "hash-a",
+      aggregateSyncMetadata,
+    })).toBe(false);
+
+    expect(canReusePerpsAggregateHistoricalCharts({
+      updatedDailyRecords: 1,
+      lastDailySyncTimestamp: "2026-01-01T00:00:00.000Z",
+      metadataHash: "hash-a",
+      aggregateSyncMetadata,
+    })).toBe(false);
+
+    expect(canReusePerpsAggregateHistoricalCharts({
+      updatedDailyRecords: 0,
+      lastDailySyncTimestamp: "2026-01-01T00:00:00.000Z",
+      metadataHash: "hash-b",
+      aggregateSyncMetadata,
+    })).toBe(false);
+  });
+});
+
 describe("buildVenueHistoricalCharts", () => {
   it("builds lean historical constituent rows grouped by venue slug", () => {
     const result = buildVenueHistoricalCharts(
@@ -568,6 +628,59 @@ describe("buildVenueHistoricalCharts", () => {
           volume24h: 2,
         },
       ],
+    });
+  });
+});
+
+describe("buildAllAggregateHistoricalCharts", () => {
+  it("matches the existing aggregate chart helpers while sharing row normalization", () => {
+    const dailyRecords = [
+      { id: "xyz:meta", timestamp: 100, open_interest: "10", volume_24h: "3" },
+      { id: "xyz:meta", timestamp: 200, open_interest: "12", volume_24h: "4" },
+      { id: "flx:gold", timestamp: 200, open_interest: "7", volume_24h: "2" },
+      { id: "km:bond", timestamp: 200, open_interest: "5", volume_24h: "1" },
+    ];
+    const metadata = [
+      {
+        id: "xyz:meta",
+        data: {
+          contract: "xyz:META",
+          venue: "xyz",
+          referenceAsset: "Meta",
+          referenceAssetGroup: "US Equities",
+          assetClass: ["Single stock synthetic perp"],
+          category: ["RWA Perpetuals", "Equities"],
+        },
+      },
+      {
+        id: "flx:gold",
+        data: {
+          contract: "flx:GOLD",
+          venue: "flx",
+          referenceAsset: "Gold",
+          referenceAssetGroup: "Commodities",
+          assetClass: ["Commodity synthetic perp"],
+          category: ["Commodities"],
+        },
+      },
+      {
+        id: "km:bond",
+        data: {
+          contract: "km:BOND",
+          venue: "km",
+          referenceAsset: "Bond",
+          assetClass: ["Fixed income synthetic perp"],
+        },
+      },
+    ];
+
+    const result = buildAllAggregateHistoricalCharts(dailyRecords, metadata);
+
+    expect(result).toEqual({
+      venueCharts: buildVenueHistoricalCharts(dailyRecords, metadata),
+      categoryCharts: buildCategoryHistoricalCharts(dailyRecords, metadata),
+      overviewBreakdownCharts: buildOverviewBreakdownCharts(dailyRecords, metadata),
+      contractBreakdownCharts: buildContractBreakdownCharts(dailyRecords, metadata),
     });
   });
 });

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -2,8 +2,9 @@ jest.mock("../spreadsheet", () => ({
   getCsvData: jest.fn(),
 }));
 
+import fs from "fs";
 import { toFiniteNumberOrZero, getPercentChangeOrNull, perpsSlug, computeProtocolFees, groupBy } from "./utils";
-import { fileNameNormalizer, mergeHistoricalData } from "./file-cache";
+import { fileNameNormalizer, mergeHistoricalData, storeRouteData } from "./file-cache";
 import { buildPerpsList } from "./list";
 import {
   buildAllAggregateHistoricalCharts,
@@ -439,6 +440,19 @@ describe("fileNameNormalizer", () => {
 
   it("decodes URI components", () => {
     expect(fileNameNormalizer("hello%20world.json")).toBe("helloworld.json");
+  });
+});
+
+describe("storeRouteData", () => {
+  it("rejects when the cache file write fails", async () => {
+    const error = new Error("disk full");
+    const writeFileSpy = jest.spyOn(fs.promises, "writeFile").mockRejectedValueOnce(error);
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(storeRouteData("test-write-failure.json", { ok: true })).rejects.toThrow("disk full");
+
+    writeFileSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

This optimizes RWA perps aggregate historical chart generation.

Previously, `generateAggregateHistoricalCharts` fetched all daily RWA perps records and rebuilt every aggregate chart file on every cron run, even when no daily records or relevant metadata had changed.

This PR adds aggregate sync metadata so no-op cron runs can skip the full aggregate rebuild safely.

## Changes

- Track aggregate chart freshness with:
  - relevant metadata hash
  - last daily sync timestamp
- Skip aggregate chart rebuilds when daily data and relevant metadata are unchanged
- Share normalized aggregate historical rows across aggregate chart builders during rebuilds
- Keep existing full rebuild behavior when daily records or relevant metadata change
- Add tests for:
  - stable metadata hashing
  - aggregate chart reuse conditions
  - combined aggregate chart builder parity with existing helpers

## Test plan

```bash
npx jest src/rwa/perps/perps.test.ts --runInBand
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent caching for historical chart generation to skip regeneration when underlying data and metadata remain unchanged, improving performance.
  * Consolidated chart-building process for more efficient and consistent aggregate chart production.

* **Tests**
  * Added comprehensive test coverage for new caching and chart-building functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->