### PR TITLE
add rise-protocol listing (id 7778)

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1463,5 +1463,28 @@ const data6: Protocol[] = [
     twitter: "Neronaxyz",
     listedAt: 1777660684
   },
+  {
+    id: "7778",
+    name: "Rise",
+    address: null,
+    symbol: "-",
+    url: "https://rise.rich/",
+    description: "Solana launchpad with built-in lending. Token bonding curves and borrow markets are accounted for by the underlying Mayflower program",
+    chain: "Solana",
+    logo: `${baseIconsUrl}/rise.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Launchpad",
+    chains: ["Solana"],
+    module: "rise-protocol/index.js",
+    twitter: "risedotrich",
+    github: ["riserich"],
+    listedAt: 1777679661,
+    dimensions: {
+      dexs: "rise-protocol",
+      fees: "rise-protocol",
+    },
+  },
 ];
 export default data6;


### PR DESCRIPTION
Adds new entry id 7778 (Rise) to `data6.ts`.

Rise is a Solana launchpad with on-chain lending built on top of the Mayflower program.

Companion PRs:
- TVL + Borrowed adapter: DefiLlama/DefiLlama-Adapters#19070
- Volume + Fees + Revenue adapter: DefiLlama/dimension-adapters#6752

Entry fields:
- `name`: Rise
- `url`: https://rise.rich/
- `chain` / `chains`: Solana
- `category`: Launchpad
- `twitter`: risedotrich (verified from https://github.com/riserich/rise-docs README)
- `github`: riserich
- `module`: rise-protocol/index.js
- `dimensions.dexs`: rise-protocol
- `dimensions.fees`: rise-protocol

Logo: 400x400 JPG (brand "R" mark on a peach/lilac gradient) to be attached via edit after PR creation.
