### PR TITLE
add rise-protocol listing (id 7778)

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1490,5 +1490,28 @@ const data6: Protocol[] = [
       "open-interest": "dango-oi",
     }
   },
+  {
+    id: "7778",
+    name: "Rise",
+    address: null,
+    symbol: "-",
+    url: "https://rise.rich/",
+    description: "Solana launchpad with built-in lending. Token bonding curves and borrow markets are accounted for by the underlying Mayflower program",
+    chain: "Solana",
+    logo: `${baseIconsUrl}/rise.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    category: "Launchpad",
+    chains: ["Solana"],
+    module: "rise-protocol/index.js",
+    twitter: "risedotrich",
+    github: ["riserich"],
+    listedAt: 1777679661,
+    dimensions: {
+      dexs: "rise-protocol",
+      fees: "rise-protocol",
+    },
+  },
 ];
 export default data6;


### PR DESCRIPTION
Adds the **Rise** protocol (id `7778`) to `defi/src/protocols/data6.ts`.

Rise is a Solana launchpad with on-chain lending built in. Token bonding curves and borrow markets are accounted for by the underlying Mayflower program via CPI.

- Category: Launchpad
- Chain: Solana
- Adapters wired up:
  - `dexs: rise-protocol` (Volume + Fees)
  - `fees: rise-protocol`
  - TVL via `rise-protocol/index.js` in `DefiLlama-Adapters`

Companion PRs:
- DefiLlama/DefiLlama-Adapters#19086 — TVL adapter
- DefiLlama/dimension-adapters#6765 — Volume + Fees + Revenue adapter
- DefiLlama/icons#2372 — protocol icon (`rise.jpg`)