### PR TITLE
Add chain breakdown to token usage

### DIFF
--- a/defi/src/getTokenInProtocols.test.ts
+++ b/defi/src/getTokenInProtocols.test.ts
@@ -1,0 +1,94 @@
+import { getTokensInProtocolsInternal } from "./getTokenInProtocols";
+
+describe("getTokensInProtocolsInternal", () => {
+  it("returns base-chain token usage without changing token-level totals", async () => {
+    const protocol = { name: "Test Protocol", category: "Lending" } as any;
+
+    const result = await getTokensInProtocolsInternal("USDC", {
+      protocolList: [protocol],
+      getLastHourlyTokensUsd: async () => ({
+        PK: "hourlyUsdTokensTvl#123",
+        SK: 1777766400,
+        tvl: {
+          USDC: 150,
+          WETH: 50,
+        },
+        ethereum: {
+          USDC: 100,
+          WETH: 50,
+        },
+        arbitrum: {
+          USDC: 50,
+        },
+        borrowed: {
+          USDC: -25,
+        },
+        ownTokens: {
+          USDC: 999,
+        },
+        "ethereum-borrowed": {
+          USDC: -25,
+        },
+      }),
+      protocolHasMisrepresentedTokens: async () => false,
+    });
+
+    expect(result).toEqual([
+      {
+        name: "Test Protocol",
+        category: "Lending",
+        amountUsd: {
+          USDC: 150,
+        },
+        amountUsdByChain: {
+          ethereum: 100,
+          arbitrum: 50,
+        },
+        misrepresentedTokens: false,
+      },
+    ]);
+  });
+
+  it("aggregates multiple matching token keys inside each chain bucket", async () => {
+    const protocol = { name: "Test Protocol", category: "DEX" } as any;
+
+    const result = await getTokensInProtocolsInternal("USD", {
+      protocolList: [protocol],
+      getLastHourlyTokensUsd: async () => ({
+        PK: "hourlyUsdTokensTvl#456",
+        SK: 1777766400,
+        tvl: {
+          USDC: 100,
+          USDT: 25,
+        },
+        ethereum: {
+          USDC: 70,
+          USDT: 5,
+        },
+        base: {
+          USDC: 30,
+          USDT: 20,
+          WETH: 20,
+        },
+        borrowed: {
+          USDT: 999,
+        },
+        "ethereum-borrowed": {
+          USDT: 20,
+        },
+      }),
+      protocolHasMisrepresentedTokens: async () => false,
+    });
+
+    expect(result[0]).toMatchObject({
+      amountUsd: {
+        USDC: 100,
+        USDT: 25,
+      },
+      amountUsdByChain: {
+        ethereum: 75,
+        base: 50,
+      },
+    });
+  });
+});

--- a/defi/src/getTokenInProtocols.test.ts
+++ b/defi/src/getTokenInProtocols.test.ts
@@ -12,13 +12,17 @@ describe("getTokensInProtocolsInternal", () => {
         tvl: {
           USDC: 150,
           WETH: 50,
+          "bad-USDC": "100",
+          "nan-USDC": Number.NaN,
         },
         ethereum: {
           USDC: 100,
           WETH: 50,
+          "bad-USDC": "100",
         },
         arbitrum: {
           USDC: 50,
+          "nan-USDC": Number.NaN,
         },
         borrowed: {
           USDC: -25,
@@ -90,5 +94,19 @@ describe("getTokensInProtocolsInternal", () => {
         base: 50,
       },
     });
+  });
+
+  it("skips protocols without a token amount map", async () => {
+    const protocol = { name: "Test Protocol", category: "DEX" } as any;
+
+    const result = await getTokensInProtocolsInternal("USDC", {
+      protocolList: [protocol],
+      getLastHourlyTokensUsd: async () => ({
+        tvl: null,
+      }),
+      protocolHasMisrepresentedTokens: async () => false,
+    });
+
+    expect(result).toEqual([]);
   });
 });

--- a/defi/src/getTokenInProtocols.ts
+++ b/defi/src/getTokenInProtocols.ts
@@ -4,16 +4,18 @@ import { getLastRecord, hourlyUsdTokensTvl } from "./utils/getLastRecord";
 import { importAdapter } from "./utils/imports/importAdapter";
 import { chainKeyToChainLabelMap } from "./utils/normalizeChain";
 
-const isTokenAmountMap = (value: unknown): value is Record<string, number> =>
+const isTokenAmountMap = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
+
+const isValidAmount = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
 
 const isBaseChainKey = (key: string) => chainKeyToChainLabelMap[key] !== undefined;
 
-const getMatchingTokenAmounts = (tokenTvl: Record<string, number>, symbol: string) => {
+const getMatchingTokenAmounts = (tokenTvl: Record<string, unknown>, symbol: string) => {
   const amountUsd = {} as Record<string, number>;
 
   Object.entries(tokenTvl).forEach(([token, value]) => {
-    if (token.includes(symbol)) {
+    if (token.includes(symbol) && isValidAmount(value)) {
       amountUsd[token] = value;
     }
   });
@@ -28,7 +30,7 @@ const getMatchingTokenAmountsByChain = (lastTvl: Record<string, unknown>, symbol
     if (!isBaseChainKey(storeKey) || !isTokenAmountMap(tokenTvl)) return;
 
     const chainTotal = Object.entries(tokenTvl).reduce((sum, [token, value]) => {
-      if (!token.includes(symbol) || typeof value !== "number") return sum;
+      if (!token.includes(symbol) || !isValidAmount(value)) return sum;
       return sum + value;
     }, 0);
 
@@ -60,7 +62,7 @@ export async function getTokensInProtocolsInternal(symbol: string, {
         getLastHourlyTokensUsd(protocol),
         protocolHasMisrepresentedTokens(protocol),
       ]);
-      if(typeof lastTvl?.tvl !== "object"){
+      if(!isTokenAmountMap(lastTvl?.tvl)){
         return null
       }
       const amountUsd = getMatchingTokenAmounts(lastTvl.tvl, symbol)

--- a/defi/src/getTokenInProtocols.ts
+++ b/defi/src/getTokenInProtocols.ts
@@ -2,6 +2,43 @@ import { successResponse, wrap, IResponse, errorResponse } from "./utils/shared"
 import protocols, { Protocol} from "./protocols/data";
 import { getLastRecord, hourlyUsdTokensTvl } from "./utils/getLastRecord";
 import { importAdapter } from "./utils/imports/importAdapter";
+import { chainKeyToChainLabelMap } from "./utils/normalizeChain";
+
+const isTokenAmountMap = (value: unknown): value is Record<string, number> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const isBaseChainKey = (key: string) => chainKeyToChainLabelMap[key] !== undefined;
+
+const getMatchingTokenAmounts = (tokenTvl: Record<string, number>, symbol: string) => {
+  const amountUsd = {} as Record<string, number>;
+
+  Object.entries(tokenTvl).forEach(([token, value]) => {
+    if (token.includes(symbol)) {
+      amountUsd[token] = value;
+    }
+  });
+
+  return amountUsd;
+};
+
+const getMatchingTokenAmountsByChain = (lastTvl: Record<string, unknown>, symbol: string) => {
+  const amountUsdByChain = {} as Record<string, number>;
+
+  Object.entries(lastTvl).forEach(([storeKey, tokenTvl]) => {
+    if (!isBaseChainKey(storeKey) || !isTokenAmountMap(tokenTvl)) return;
+
+    const chainTotal = Object.entries(tokenTvl).reduce((sum, [token, value]) => {
+      if (!token.includes(symbol) || typeof value !== "number") return sum;
+      return sum + value;
+    }, 0);
+
+    if (chainTotal !== 0) {
+      amountUsdByChain[storeKey] = chainTotal;
+    }
+  });
+
+  return amountUsdByChain;
+};
 
 async function _protocolHasMisrepresentedTokens(protocol: Protocol){
   const module = await importAdapter(protocol);
@@ -26,21 +63,16 @@ export async function getTokensInProtocolsInternal(symbol: string, {
       if(typeof lastTvl?.tvl !== "object"){
         return null
       }
-      const amountUsd = {} as any
-      let matches = 0
-      Object.entries(lastTvl.tvl).forEach(([s, v])=>{
-        if(s.includes(symbol)){
-          amountUsd[s] = v;
-          matches++;
-        }
-      })
-      if(matches === 0){
+      const amountUsd = getMatchingTokenAmounts(lastTvl.tvl, symbol)
+      if(Object.keys(amountUsd).length === 0){
         return null
       }
+      const amountUsdByChain = getMatchingTokenAmountsByChain(lastTvl, symbol)
       return {
           name: protocol.name,
           category: protocol.category,
           amountUsd,
+          amountUsdByChain,
           misrepresentedTokens,
       }
     })


### PR DESCRIPTION
Closes #11230

Adds per-chain token usage to `/tokenProtocols/:symbol` while preserving the existing response shape.

Changes:
- Keeps `amountUsd` unchanged as the existing aggregate token-level map from `tvl`
- Adds `amountUsdByChain` with matching token usage grouped by base chain
- Filters chain buckets through the canonical chain key map so non-chain fields like `tvl`, `PK`, `SK`, `borrowed`, `ownTokens`, and `ethereum-borrowed` are not included
- Adds focused tests using production-shaped cached `hourlyUsdTokensTvl` records

Verification:
- `git diff --check`
- `npm test -- --runTestsByPath src/getTokenInProtocols.test.ts --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protocol token reporting now includes chain-level USD amount breakdowns alongside aggregate totals, enabling more granular analysis across blockchain networks.

* **Tests**
  * Added comprehensive test coverage for token matching and cross-chain aggregation, verifying accurate calculation of combined amounts across multiple token variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->