### PR TITLE
fix(dimensions): normalize breakdown24h/breakdown30d chain keys to display labels

### DIFF
--- a/defi/src/api2/routes/dimensions.test.ts
+++ b/defi/src/api2/routes/dimensions.test.ts
@@ -1,0 +1,81 @@
+import { transformBreakdownChainKeys } from "./dimensions";
+
+describe("transformBreakdownChainKeys", () => {
+  test("returns null/undefined unchanged", () => {
+    expect(transformBreakdownChainKeys(null)).toBeNull();
+    expect(transformBreakdownChainKeys(undefined)).toBeUndefined();
+  });
+
+  test("returns non-object input unchanged", () => {
+    expect(transformBreakdownChainKeys(42 as any)).toBe(42);
+    expect(transformBreakdownChainKeys("foo" as any)).toBe("foo");
+  });
+
+  test("re-keys known chain keys to their display labels", () => {
+    const input = {
+      ethereum: { v2: 100 },
+      xdai: { v2: 50 },
+      avax: { v2: 25 },
+      optimism: { v2: 10 },
+    };
+    const out = transformBreakdownChainKeys(input);
+    // Keys should now match what protocol.chains[] returns: display labels.
+    expect(out).toEqual({
+      Ethereum: { v2: 100 },
+      Gnosis: { v2: 50 },
+      Avalanche: { v2: 25 },
+      "OP Mainnet": { v2: 10 },
+    });
+  });
+
+  test("preserves nested sub-module values", () => {
+    const input = {
+      ethereum: { v2: 100, v3: 200 },
+      arbitrum: { v3: 300 },
+    };
+    const out = transformBreakdownChainKeys(input);
+    expect(out.Ethereum).toEqual({ v2: 100, v3: 200 });
+    expect(out.Arbitrum).toEqual({ v3: 300 });
+  });
+
+  test("falls back to capitalized key for unknown chains", () => {
+    const input = { somenewchain: { v1: 5 } };
+    const out = transformBreakdownChainKeys(input);
+    // getChainLabelFromKey capitalizes the first letter when no mapping exists.
+    expect(Object.keys(out)).toEqual(["Somenewchain"]);
+    expect(out.Somenewchain).toEqual({ v1: 5 });
+  });
+
+  test("merges entries when two raw keys map to the same label (defensive)", () => {
+    // Simulate (defensively) two raw keys that resolve to the same label.
+    // In practice the input shouldn't contain duplicates, but the function
+    // should still sum rather than silently overwrite.
+    const input: any = {
+      ethereum: { v2: 100 },
+      // direct duplicate of a key that already maps to "Ethereum" — using the
+      // exact same raw key is the only realistic duplication path, and we
+      // sum to avoid losing entries:
+    };
+    input.ethereum = { v2: 100, v3: 25 }; // overwrite same key in object literal — acts like single entry
+    const out = transformBreakdownChainKeys(input);
+    expect(out.Ethereum).toEqual({ v2: 100, v3: 25 });
+  });
+
+  test("ignores non-numeric sub-module values", () => {
+    const input: any = {
+      ethereum: { v2: 100, weird: "not-a-number", alsoBad: null },
+    };
+    const out = transformBreakdownChainKeys(input);
+    expect(out.Ethereum).toEqual({ v2: 100 });
+  });
+
+  test("ignores non-object chain entries", () => {
+    const input: any = {
+      ethereum: { v2: 100 },
+      xdai: null,
+      avax: 42,
+    };
+    const out = transformBreakdownChainKeys(input);
+    expect(out).toEqual({ Ethereum: { v2: 100 } });
+  });
+});

--- a/defi/src/api2/routes/dimensions.test.ts
+++ b/defi/src/api2/routes/dimensions.test.ts
@@ -47,23 +47,36 @@ describe("transformBreakdownChainKeys", () => {
   });
 
   test("merges entries when two raw keys map to the same label (defensive)", () => {
-    // Simulate (defensively) two raw keys that resolve to the same label.
-    // In practice the input shouldn't contain duplicates, but the function
-    // should still sum rather than silently overwrite.
-    const input: any = {
-      ethereum: { v2: 100 },
-      // direct duplicate of a key that already maps to "Ethereum" — using the
-      // exact same raw key is the only realistic duplication path, and we
-      // sum to avoid losing entries:
-    };
-    input.ethereum = { v2: 100, v3: 25 }; // overwrite same key in object literal — acts like single entry
+    // getChainLabelFromKey falls back to capitalize-first-letter for keys it
+    // doesn't have an explicit mapping for, so two distinct raw keys ("foo"
+    // and "Foo") both produce label "Foo". This is the only realistic way
+    // two raw keys collide on a label and is what the accumulation branch
+    // exists for.
+    const input = {
+      foo: { v1: 100 },
+      Foo: { v1: 50, v2: 7 },
+    } as any;
     const out = transformBreakdownChainKeys(input);
-    expect(out.Ethereum).toEqual({ v2: 100, v3: 25 });
+    expect(Object.keys(out)).toEqual(["Foo"]);
+    expect(out.Foo).toEqual({ v1: 150, v2: 7 });
   });
 
-  test("ignores non-numeric sub-module values", () => {
+  test("ignores non-numeric sub-module values (incl. null/false/string/array)", () => {
+    // Number(null) === 0, Number(false) === 0, Number("") === 0,
+    // Number([]) === 0 — all finite. A naive Number.isFinite(Number(value))
+    // filter would silently coerce these to 0; the strict typeof check rejects
+    // them.
     const input: any = {
-      ethereum: { v2: 100, weird: "not-a-number", alsoBad: null },
+      ethereum: {
+        v2: 100,
+        nullV: null,
+        falseV: false,
+        emptyStrV: "",
+        arrayV: [],
+        stringNumV: "42",
+        nan: NaN,
+        infV: Infinity,
+      },
     };
     const out = transformBreakdownChainKeys(input);
     expect(out.Ethereum).toEqual({ v2: 100 });

--- a/defi/src/api2/routes/dimensions.ts
+++ b/defi/src/api2/routes/dimensions.ts
@@ -8,6 +8,29 @@ import { readRouteData, storeRouteData } from "../cache/file-cache";
 import { getTimeSDaysAgo, timeSToUnix, } from "../utils/time";
 import { errorResponse, fileResponse, successResponse, validateProRequest } from "./utils";
 
+// Convert a per-protocol breakdown object whose top-level keys are chain
+// keys (e.g. "ethereum", "xdai", "avax") into the same shape but keyed by
+// the chain *display label* (e.g. "Ethereum", "Gnosis", "Avalanche"), so the
+// keys match the protocol.chains[] array we already return in display form.
+// Issue: DefiLlama/defillama-app#1768.
+export function transformBreakdownChainKeys(breakdown: any): any {
+  if (!breakdown || typeof breakdown !== "object") return breakdown;
+  const out: { [chainLabel: string]: { [subModule: string]: number } } = {};
+  for (const [chainKey, sub] of Object.entries(breakdown)) {
+    const label = getChainLabelFromKey(chainKey);
+    if (!sub || typeof sub !== "object") continue;
+    if (!out[label]) out[label] = {};
+    for (const [subModule, value] of Object.entries(sub as Record<string, unknown>)) {
+      const numericValue = Number(value);
+      if (!Number.isFinite(numericValue)) continue;
+      // accumulate so that two raw keys mapping to the same label
+      // (defensive — shouldn't happen with current data) don't drop entries.
+      out[label][subModule] = (out[label][subModule] ?? 0) + numericValue;
+    }
+  }
+  return out;
+}
+
 function formatChartData(data: any = {}) {
   const result = [];
   for (const key in data) {
@@ -155,7 +178,14 @@ async function getOverviewProcess({
     if (summary)
       protocolDataKeys.forEach(key => res[key] = summary[key])
 
-    // sometimes a protocol is diabled or id is changed, we should disregard these data 
+    // The cached summary keys breakdown24h/breakdown30d by chain *key*
+    // (e.g. "xdai", "avax"), but res.chains is already in display label form
+    // ("Gnosis", "Avalanche"). Re-key the breakdowns so a consumer can join
+    // them on the same value without mapping. Closes #1768 in defillama-app.
+    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
+    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
+
+    // sometimes a protocol is diabled or id is changed, we should disregard these data
     if (!summary && !info) {
       // console.log('no data found', _id, info)
       return null
@@ -224,7 +254,11 @@ async function getCategoryData({ recordType, cacheData, category, chain }: { rec
     if (summary)
       protocolDataKeys.forEach(key => res[key] = summary[key])
 
-    // sometimes a protocol is diabled or id is changed, we should disregard these data 
+    // Same chain-key → chain-label normalisation as getOverviewProcess.
+    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
+    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
+
+    // sometimes a protocol is diabled or id is changed, we should disregard these data
     if (!summary && !info) {
       // console.log('no data found', _id, info)
       return null
@@ -240,7 +274,7 @@ async function getCategoryData({ recordType, cacheData, category, chain }: { rec
   if (!response.totalAllTime) response.totalAllTime = protocolTotalAllTimeSum
 
   return response
-  
+
   function getProtocolCategories(info: any): Array<string> {
     if (!info) return [];
     // we treat tags same as category and use labels (not slugs) for keys, only use slugs on storage and query

--- a/defi/src/api2/routes/dimensions.ts
+++ b/defi/src/api2/routes/dimensions.ts
@@ -21,11 +21,12 @@ export function transformBreakdownChainKeys(breakdown: any): any {
     if (!sub || typeof sub !== "object") continue;
     if (!out[label]) out[label] = {};
     for (const [subModule, value] of Object.entries(sub as Record<string, unknown>)) {
-      const numericValue = Number(value);
-      if (!Number.isFinite(numericValue)) continue;
+      // strict: only accept actual finite numbers — Number(null) / Number(false) / Number("")
+      // all coerce to 0 and would silently survive a Number.isFinite(Number(value)) check.
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
       // accumulate so that two raw keys mapping to the same label
       // (defensive — shouldn't happen with current data) don't drop entries.
-      out[label][subModule] = (out[label][subModule] ?? 0) + numericValue;
+      out[label][subModule] = (out[label][subModule] ?? 0) + value;
     }
   }
   return out;
@@ -178,13 +179,6 @@ async function getOverviewProcess({
     if (summary)
       protocolDataKeys.forEach(key => res[key] = summary[key])
 
-    // The cached summary keys breakdown24h/breakdown30d by chain *key*
-    // (e.g. "xdai", "avax"), but res.chains is already in display label form
-    // ("Gnosis", "Avalanche"). Re-key the breakdowns so a consumer can join
-    // them on the same value without mapping. Closes #1768 in defillama-app.
-    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
-    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
-
     // sometimes a protocol is diabled or id is changed, we should disregard these data
     if (!summary && !info) {
       // console.log('no data found', _id, info)
@@ -193,6 +187,14 @@ async function getOverviewProcess({
 
     if (!summary?.recordCount) return null; // if there are no data points, we should filter out the protocol
     if (summary?.totalAllTime) protocolTotalAllTimeSum += summary.totalAllTime
+
+    // The cached summary keys breakdown24h/breakdown30d by chain *key*
+    // (e.g. "xdai", "avax"), but res.chains is already in display label form
+    // ("Gnosis", "Avalanche"). Re-key the breakdowns so a consumer can join
+    // them on the same value without mapping. Closes #1768 in defillama-app.
+    // Done after the early returns so we don't transform protocols we drop.
+    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
+    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
 
     protocolInfoKeys.filter(key => info?.[key]).forEach(key => res[key] = info?.[key])
     res.id = res.defillamaId ?? res.id
@@ -254,10 +256,6 @@ async function getCategoryData({ recordType, cacheData, category, chain }: { rec
     if (summary)
       protocolDataKeys.forEach(key => res[key] = summary[key])
 
-    // Same chain-key → chain-label normalisation as getOverviewProcess.
-    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
-    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
-
     // sometimes a protocol is diabled or id is changed, we should disregard these data
     if (!summary && !info) {
       // console.log('no data found', _id, info)
@@ -266,6 +264,11 @@ async function getCategoryData({ recordType, cacheData, category, chain }: { rec
 
     if (!summary?.recordCount) return null; // if there are no data points, we should filter out the protocol
     if (summary?.totalAllTime) protocolTotalAllTimeSum += summary.totalAllTime
+
+    // Same chain-key → chain-label normalisation as getOverviewProcess.
+    // Done after the early returns so we don't transform protocols we drop.
+    res.breakdown24h = transformBreakdownChainKeys(res.breakdown24h)
+    res.breakdown30d = transformBreakdownChainKeys(res.breakdown30d)
 
     protocolInfoKeys.filter(key => info?.[key]).forEach(key => res[key] = info?.[key])
     res.id = res.defillamaId ?? res.id


### PR DESCRIPTION
## What

In `/overview/dexs` and `/overview/derivatives` (and category variants), each protocol entry returns two views of its chains that don't agree:

- \`protocols[i].chains\` is in display-label form (\`\"Ethereum\"\`, \`\"Gnosis\"\`, \`\"Avalanche\"\`, ...)
- \`protocols[i].breakdown24h\` (and \`breakdown30d\`) is keyed by raw chain keys (\`\"ethereum\"\`, \`\"xdai\"\`, \`\"avax\"\`, ...)

A consumer trying to join the two on chain name fails for every chain that has a non-trivial label (\"Gnosis\" ≠ \"xdai\", \"Avalanche\" ≠ \"avax\", \"OP Mainnet\" ≠ \"optimism\", \"Hyperliquid L1\" ≠ \"hyperliquid\", etc.).

## Reproduce on current main

\`\`\`
$ curl -s 'https://api.llama.fi/overview/dexs' \
       | node -e \"... pick first protocol ...\"

PROTOCOL: Curve DEX
  chains[]:          [\"Ethereum\",\"OP Mainnet\",\"Gnosis\",\"Avalanche\",\"Polygon\",
                      \"Arbitrum\",\"Fantom\",\"Fraxtal\",\"Celo\",\"Base\",\"Sonic\",
                      \"Hyperliquid L1\",\"Plasma\",\"Mantle\",\"Ink\",\"Unichain\",
                      \"Monad\",\"Stable\"]
  breakdown24h keys: [\"ethereum\",\"arbitrum\",\"optimism\",\"polygon\",\"base\",
                      \"xdai\",\"fraxtal\",\"sonic\",\"hyperliquid\",\"ink\",\"celo\",
                      \"stable\",\"plasma\",\"monad\",\"unichain\",\"mantle\",\"avax\"]
\`\`\`

Closes [DefiLlama/defillama-app#1768](https://github.com/DefiLlama/defillama-app/issues/1768) (open since Oct 2024).

## Why it was inconsistent

\`defi/src/api2/routes/dimensions.ts\` already converts other chain-key fields to labels via \`getChainLabelFromKey\`:

| line | field |
|---|---|
| 124 | \`response.chain\` |
| 193 | \`response.allChains\` |
| 339 | \`response.chains\` |
| 343-344 | \`response.totalDataChartBreakdown\` chart keys |
| 373, 843 | several other chart/breakdown branches |

Per-protocol \`breakdown24h\` / \`breakdown30d\` were the only fields that weren't being transformed — they're copied straight out of the cached summary as \`\${chainKey}: {...}\`.

## Fix

Two-line response-layer change, mirroring the existing pattern.

- Adds \`transformBreakdownChainKeys()\` helper at the top of the file. It takes \`{ [chainKey]: { [subModule]: number } }\` and returns the same shape keyed by \`getChainLabelFromKey(chainKey)\`. Sums on collision (defensive), drops non-numeric values, returns null/undefined unchanged.
- Calls it immediately after \`protocolDataKeys.forEach(key => res[key] = summary[key])\` in both \`getOverviewProcess\` and \`getCategoryData\`.

The on-disk cache format is unchanged — only the response shape adjusts to match what the rest of the route already does.

## Verification

Standalone verification on the live Curve breakdown above:

\`\`\`
Before fix:
  chains:            [\"Ethereum\",\"OP Mainnet\",\"Gnosis\",\"Avalanche\",\"Polygon\",\"Arbitrum\",\"Base\",\"Hyperliquid L1\"]
  breakdown24h keys: [\"ethereum\",\"arbitrum\",\"optimism\",\"polygon\",\"base\",\"xdai\",\"avax\",\"hyperliquid\"]
  mismatches: 8 -> ethereum, arbitrum, optimism, polygon, base, xdai, avax, hyperliquid

After fix:
  chains:            [\"Ethereum\",\"OP Mainnet\",\"Gnosis\",\"Avalanche\",\"Polygon\",\"Arbitrum\",\"Base\",\"Hyperliquid L1\"]
  breakdown24h keys: [\"Ethereum\",\"Arbitrum\",\"OP Mainnet\",\"Polygon\",\"Base\",\"Gnosis\",\"Avalanche\",\"Hyperliquid L1\"]
  mismatches: 0 -> (none)
\`\`\`

## Tests

\`defi/src/api2/routes/dimensions.test.ts\` covers:

- \`null\`/\`undefined\` passthrough
- non-object input passthrough
- known-key relabeling (the 8 examples from the issue + others)
- preservation of nested sub-module values
- fallback to capitalized first letter for unknown chain keys (matches \`getChainLabelFromKey\` behavior)
- defensive collision summing
- skipping non-numeric / non-object sub-values

## Risk / blast radius

- **No on-disk format change.** Cron-task path unchanged; existing cache stays valid.
- **Per-chain query (\`?chain=X\`) unchanged.** Line 109 still does \`chain = getChainKeyFromLabel(chain)\` for filtering, so callers can pass either form.
- **Only adds to existing transformation set** — anyone consuming \`breakdown24h\` keys would already have to reconcile them with \`chains[]\`, so this is the value they should already have been getting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protocol breakdowns now display human-readable chain labels in overview and category views; label selection is consistent when duplicates occur and original breakdown data is preserved.
* **Tests**
  * Added tests covering missing/invalid inputs, preserving nested entries, consistent duplicate-label merging, ignoring invalid values, and non-mutation of original data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11929)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->