### PR TITLE
Hide search subpage labels from matching

### DIFF
--- a/defi/README.md
+++ b/defi/README.md
@@ -21,7 +21,7 @@ export APP_ENV=/Users/mint/p/defillama-server/defi/.env
 npm run test:search
 ```
 
-The env file should include `SEARCH_MASTER_KEY`, `TASTY_API_URL`, `TASTY_API_KEY`, and `INTERNAL_API_KEY`.
+The test suite always uses production search documents as the data source, so the env file must include `SEARCH_MASTER_KEY`.
 
 To run against the prod Meilisearch host with a temporary test index:
 

--- a/defi/README.md
+++ b/defi/README.md
@@ -12,6 +12,29 @@ npm test # Run tests
 npm run format # Format code
 ```
 
+### Search regression tests
+
+Run the Meilisearch ranking regression suite:
+
+```bash
+export APP_ENV=/Users/mint/p/defillama-server/defi/.env
+npm run test:search
+```
+
+The env file should include `SEARCH_MASTER_KEY`, `TASTY_API_URL`, `TASTY_API_KEY`, and `INTERNAL_API_KEY`.
+
+To run against the prod Meilisearch host with a temporary test index:
+
+```bash
+set -a
+source .env
+set +a
+SEARCH_TEST_MEILI_HOST=https://search-core.defillama.com \
+SEARCH_TEST_MEILI_KEY="$SEARCH_MASTER_KEY" \
+SEARCH_TEST_MEILI_VERSION=1.9.0 \
+npm run test:search
+```
+
 ### Local dev server
 
 ```bash

--- a/defi/package.json
+++ b/defi/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "serve": "node --max-old-space-size=8192 node_modules/serverless/bin/serverless offline start",
     "test": "jest",
+    "test:search": "bash src/cli/search/test-local-meili.sh",
     "test:protocols-metadata": "npm run prebuild && jest --testPathPattern='protocols/data.test' --reporters=default --reporters=./reporters/data-test-discord-reporter.js --no-coverage --forceExit",
     "test:api": "cd api-tests && jest",
     "test:beta-api": "cd api-tests && jest --testPathPattern='beta'",

--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -38,8 +38,7 @@ curl \
     "symbol",
     "previousNames",
     "nameVariants",
-    "keywords",
-    "subName"
+    "keywords"
   ]'
 
 curl \

--- a/defi/src/cli/search/test-local-meili.sh
+++ b/defi/src/cli/search/test-local-meili.sh
@@ -10,8 +10,8 @@ export SEARCH_TEST_MEILI_VERSION="${SEARCH_TEST_MEILI_VERSION:-1.9.0}"
 MEILI_HTTP_ADDR="${SEARCH_TEST_MEILI_HOST#http://}"
 MEILI_HTTP_ADDR="${MEILI_HTTP_ADDR#https://}"
 
-if [[ -z "${SEARCH_MASTER_KEY:-}" && -z "${INTERNAL_API_KEY:-}" && -z "${APP_ENV:-}" ]]; then
-  echo "Set SEARCH_MASTER_KEY, INTERNAL_API_KEY, or APP_ENV=/path/to/.env before running this test."
+if [[ -z "${SEARCH_MASTER_KEY:-}" && -z "${APP_ENV:-}" ]]; then
+  echo "Set SEARCH_MASTER_KEY or APP_ENV=/path/to/.env before running this test."
   exit 1
 fi
 

--- a/defi/src/cli/search/test-local-meili.sh
+++ b/defi/src/cli/search/test-local-meili.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+export RUN_SEARCH_MEILI_TESTS=1
+export SEARCH_TEST_MEILI_HOST="${SEARCH_TEST_MEILI_HOST:-http://127.0.0.1:7700}"
+export SEARCH_TEST_MEILI_KEY="${SEARCH_TEST_MEILI_KEY:-masterKey}"
+export SEARCH_TEST_MEILI_VERSION="${SEARCH_TEST_MEILI_VERSION:-1.9.0}"
+MEILI_HTTP_ADDR="${SEARCH_TEST_MEILI_HOST#http://}"
+MEILI_HTTP_ADDR="${MEILI_HTTP_ADDR#https://}"
+
+if [[ -z "${SEARCH_MASTER_KEY:-}" && -z "${INTERNAL_API_KEY:-}" && -z "${APP_ENV:-}" ]]; then
+  echo "Set SEARCH_MASTER_KEY, INTERNAL_API_KEY, or APP_ENV=/path/to/.env before running this test."
+  exit 1
+fi
+
+check_meili_version() {
+  local version
+  version="$(
+    curl -fsS \
+      -H "Authorization: Bearer $SEARCH_TEST_MEILI_KEY" \
+      "$SEARCH_TEST_MEILI_HOST/version" \
+      | node -e "let s=''; process.stdin.on('data', c => s += c); process.stdin.on('end', () => console.log(JSON.parse(s).pkgVersion))"
+  )"
+
+  if [[ "$version" != "$SEARCH_TEST_MEILI_VERSION" && "${SEARCH_TEST_ALLOW_VERSION_MISMATCH:-}" != "1" ]]; then
+    echo "Meilisearch at $SEARCH_TEST_MEILI_HOST is $version, but prod search is $SEARCH_TEST_MEILI_VERSION."
+    echo "Use a matching Meilisearch server, or set SEARCH_TEST_ALLOW_VERSION_MISMATCH=1 for a non-parity run."
+    exit 1
+  fi
+}
+
+if ! curl -fsS "$SEARCH_TEST_MEILI_HOST/health" >/dev/null 2>&1; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    docker rm -f defillama-search-test-meili >/dev/null 2>&1 || true
+    docker run \
+      --name defillama-search-test-meili \
+      -p 7700:7700 \
+      -e MEILI_MASTER_KEY="$SEARCH_TEST_MEILI_KEY" \
+      -d "getmeili/meilisearch:v$SEARCH_TEST_MEILI_VERSION" >/dev/null
+  elif command -v meilisearch >/dev/null 2>&1; then
+    LOCAL_MEILI_VERSION="$(meilisearch --version | awk '{ print $2 }')"
+    if [[ "$LOCAL_MEILI_VERSION" != "$SEARCH_TEST_MEILI_VERSION" && "${SEARCH_TEST_ALLOW_VERSION_MISMATCH:-}" != "1" ]]; then
+      echo "Local meilisearch is $LOCAL_MEILI_VERSION, but prod search is $SEARCH_TEST_MEILI_VERSION."
+      echo "Run a matching Docker image, install the matching binary, or set SEARCH_TEST_ALLOW_VERSION_MISMATCH=1 for a non-parity run."
+      exit 1
+    fi
+    MEILI_DB_PATH="${SEARCH_TEST_MEILI_DB_PATH:-/tmp/defillama-search-test-meili}"
+    rm -rf "$MEILI_DB_PATH"
+    meilisearch \
+      --master-key "$SEARCH_TEST_MEILI_KEY" \
+      --http-addr "$MEILI_HTTP_ADDR" \
+      --db-path "$MEILI_DB_PATH" >/tmp/defillama-search-test-meili.log 2>&1 &
+    MEILI_PID=$!
+    trap 'kill "$MEILI_PID" >/dev/null 2>&1 || true' EXIT
+  else
+    echo "No Meilisearch server at $SEARCH_TEST_MEILI_HOST."
+    echo "Start one with either:"
+    echo "  docker run --rm -p 7700:7700 -e MEILI_MASTER_KEY=masterKey getmeili/meilisearch:v$SEARCH_TEST_MEILI_VERSION"
+    echo "  meilisearch --master-key masterKey --http-addr 127.0.0.1:7700"
+    echo "Then rerun with SEARCH_TEST_MEILI_HOST and SEARCH_TEST_MEILI_KEY set if you used non-defaults."
+    exit 1
+  fi
+
+  for _ in {1..60}; do
+    if curl -fsS "$SEARCH_TEST_MEILI_HOST/health" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+
+  if ! curl -fsS "$SEARCH_TEST_MEILI_HOST/health" >/dev/null 2>&1; then
+    echo "Meilisearch did not become healthy at $SEARCH_TEST_MEILI_HOST."
+    echo "If the script started a local binary, check /tmp/defillama-search-test-meili.log."
+    exit 1
+  fi
+fi
+
+check_meili_version
+
+npx jest src/updateSearch.meili.test.ts --runInBand --no-cache --watchman=false

--- a/defi/src/updateSearch.meili.test.ts
+++ b/defi/src/updateSearch.meili.test.ts
@@ -1,0 +1,184 @@
+import fetch from "node-fetch";
+import dotenv from "dotenv";
+import { PAGES_INDEX_SETTINGS, generateSearchList } from "./updateSearch";
+
+if (process.env.APP_ENV) dotenv.config({ path: process.env.APP_ENV, override: false });
+
+const shouldRun = process.env.RUN_SEARCH_MEILI_TESTS === "1";
+const describeSearch = shouldRun ? describe : describe.skip;
+const host = process.env.SEARCH_TEST_MEILI_HOST ?? "http://127.0.0.1:7700";
+const key = process.env.SEARCH_TEST_MEILI_KEY ?? "masterKey";
+const prodHost = process.env.SEARCH_PROD_MEILI_HOST ?? "https://search-core.defillama.com";
+const dataSource = process.env.SEARCH_TEST_DATA_SOURCE ?? (process.env.SEARCH_MASTER_KEY ? "prod" : "generated");
+const index = `test_pages_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+if (shouldRun) jest.setTimeout(300_000);
+
+interface SearchHit {
+  id: string;
+  name: string;
+  route: string;
+  subName?: string;
+  type?: string;
+}
+
+interface SearchCase {
+  query: string;
+  firstRoute?: string;
+  blockedSubNames?: string[];
+  topRoutes?: Array<{ route: string; maxRank: number }>;
+}
+
+const SEARCH_CASES: SearchCase[] = [
+  { query: "fees", firstRoute: "/fees", blockedSubNames: ["Fees"] },
+  { query: "revenue", firstRoute: "/revenue", blockedSubNames: ["Revenue"] },
+  { query: "holders-revenue", firstRoute: "/holders-revenue", blockedSubNames: ["Holders Revenue"] },
+  { query: "mcap", blockedSubNames: ["Mcap"] },
+  { query: "tvl", blockedSubNames: ["TVL"] },
+  { query: "aave", firstRoute: "/protocol/aave", topRoutes: [{ route: "/protocol/aave?tvl=false&fees=true", maxRank: 15 }] },
+  { query: "stabble", firstRoute: "/protocol/stabble" },
+  { query: "markit", firstRoute: "/protocol/markit" },
+  { query: "cap", firstRoute: "/protocol/cap", topRoutes: [{ route: "/token/CAP", maxRank: 15 }] },
+  {
+    query: "usdt",
+    ...(dataSource === "prod" ? { firstRoute: "/stablecoin/tether" } : {}),
+    topRoutes: [{ route: "/stablecoin/tether", maxRank: 5 }, { route: "/token/USDT", maxRank: 10 }],
+  },
+  { query: "usdc", firstRoute: "/stablecoin/usd-coin", topRoutes: [{ route: "/token/USDC", maxRank: 10 }] },
+  { query: "eth", topRoutes: [{ route: "/token/ETH", maxRank: 5 }] },
+  { query: "sol", topRoutes: [{ route: "/token/SOL", maxRank: 5 }] },
+  { query: "mega", topRoutes: [{ route: "/token/MEGA", maxRank: 5 }] },
+];
+
+async function meiliRequest(baseUrl: string, bearerToken: string | undefined, path: string, options: any = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers ?? {}),
+  };
+  if (bearerToken) headers.Authorization = `Bearer ${bearerToken}`;
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${options.method ?? "GET"} ${path} ${res.status}: ${text}`);
+  return text ? JSON.parse(text) : {};
+}
+
+async function meili(path: string, options: any = {}) {
+  return meiliRequest(host, key, path, options);
+}
+
+async function prodMeili(path: string, options: any = {}) {
+  return meiliRequest(prodHost, process.env.SEARCH_MASTER_KEY, path, options);
+}
+
+async function waitTask(taskUid: number) {
+  for (let i = 0; i < 180; i++) {
+    const task = await meili(`/tasks/${taskUid}`);
+    if (["succeeded", "failed", "canceled"].includes(task.status)) {
+      if (task.status !== "succeeded") throw new Error(JSON.stringify(task, null, 2));
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`Meili task ${taskUid} timed out`);
+}
+
+async function putSetting(setting: string, value: unknown) {
+  const task = await meili(`/indexes/${index}/settings/${setting}`, {
+    method: "PUT",
+    body: JSON.stringify(value),
+  });
+  await waitTask(task.taskUid);
+}
+
+async function search(q: string): Promise<SearchHit[]> {
+  const res = await meili("/multi-search", {
+    method: "POST",
+    body: JSON.stringify({ queries: [{ indexUid: index, q, limit: 50, offset: 0 }] }),
+  });
+  return res?.results?.[0]?.hits ?? [];
+}
+
+async function getProdPagesDocuments() {
+  const results: SearchHit[] = [];
+  const limit = 100_000;
+  let offset = 0;
+
+  while (true) {
+    const res = await prodMeili(`/indexes/pages/documents?limit=${limit}&offset=${offset}`);
+    results.push(...res.results);
+    if (res.results.length < limit || results.length >= res.total) return results;
+    offset += limit;
+  }
+}
+
+async function getSearchDocuments() {
+  if (dataSource === "prod") {
+    if (!process.env.SEARCH_MASTER_KEY) {
+      throw new Error("Set SEARCH_MASTER_KEY or run with SEARCH_TEST_DATA_SOURCE=generated");
+    }
+    return getProdPagesDocuments();
+  }
+  if (dataSource === "generated") {
+    if (!process.env.INTERNAL_API_KEY) {
+      throw new Error("Set INTERNAL_API_KEY or APP_ENV pointing to an env file before running generated search tests");
+    }
+    const { results } = await generateSearchList();
+    return results;
+  }
+  throw new Error(`Unsupported SEARCH_TEST_DATA_SOURCE: ${dataSource}`);
+}
+
+describeSearch("search results in Meilisearch", () => {
+  beforeAll(async () => {
+    const results = await getSearchDocuments();
+    const createIndex = await meili("/indexes", {
+      method: "POST",
+      body: JSON.stringify({ uid: index, primaryKey: "id" }),
+    });
+    await waitTask(createIndex.taskUid);
+
+    await putSetting("searchable-attributes", PAGES_INDEX_SETTINGS.searchableAttributes);
+    await putSetting("ranking-rules", PAGES_INDEX_SETTINGS.rankingRules);
+    await putSetting("filterable-attributes", PAGES_INDEX_SETTINGS.filterableAttributes);
+    await putSetting("sortable-attributes", PAGES_INDEX_SETTINGS.sortableAttributes);
+    await putSetting("displayed-attributes", PAGES_INDEX_SETTINGS.displayedAttributes);
+    await putSetting("synonyms", PAGES_INDEX_SETTINGS.synonyms);
+
+    const addDocs = await meili(`/indexes/${index}/documents`, {
+      method: "POST",
+      body: JSON.stringify(results),
+    });
+    await waitTask(addDocs.taskUid);
+  });
+
+  afterAll(async () => {
+    if (!shouldRun) return;
+    try {
+      const task = await meili(`/indexes/${index}`, { method: "DELETE" });
+      await waitTask(task.taskUid);
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  test.each(SEARCH_CASES)("$query", async ({ query, firstRoute, blockedSubNames, topRoutes }) => {
+    const hits = await search(query);
+
+    if (firstRoute) expect(hits[0]?.route).toBe(firstRoute);
+
+    for (const subName of blockedSubNames ?? []) {
+      const subpageHit = hits.find((hit) => hit.subName === subName);
+      expect(subpageHit).toBeUndefined();
+    }
+
+    for (const expected of topRoutes ?? []) {
+      const rank = hits.findIndex((hit) => hit.route === expected.route) + 1;
+      expect(rank).toBeGreaterThan(0);
+      expect(rank).toBeLessThanOrEqual(expected.maxRank);
+    }
+  });
+});

--- a/defi/src/updateSearch.meili.test.ts
+++ b/defi/src/updateSearch.meili.test.ts
@@ -26,7 +26,7 @@ interface SearchCase {
   query: string;
   firstRoute?: string;
   blockedSubNames?: string[];
-  topRoutes?: Array<{ route: string; maxRank: number }>;
+  routesWithinRank?: Array<{ route: string; maxRank: number }>;
 }
 
 const SEARCH_CASES: SearchCase[] = [
@@ -35,19 +35,23 @@ const SEARCH_CASES: SearchCase[] = [
   { query: "holders-revenue", firstRoute: "/holders-revenue", blockedSubNames: ["Holders Revenue"] },
   { query: "mcap", blockedSubNames: ["Mcap"] },
   { query: "tvl", blockedSubNames: ["TVL"] },
-  { query: "aave", firstRoute: "/protocol/aave", topRoutes: [{ route: "/protocol/aave?tvl=false&fees=true", maxRank: 15 }] },
+  {
+    query: "aave",
+    firstRoute: "/protocol/aave",
+    routesWithinRank: [{ route: "/protocol/aave?tvl=false&fees=true", maxRank: 15 }],
+  },
   { query: "stabble", firstRoute: "/protocol/stabble" },
   { query: "markit", firstRoute: "/protocol/markit" },
-  { query: "cap", firstRoute: "/protocol/cap", topRoutes: [{ route: "/token/CAP", maxRank: 15 }] },
+  { query: "cap", firstRoute: "/protocol/cap", routesWithinRank: [{ route: "/token/CAP", maxRank: 15 }] },
   {
     query: "usdt",
     ...(dataSource === "prod" ? { firstRoute: "/stablecoin/tether" } : {}),
-    topRoutes: [{ route: "/stablecoin/tether", maxRank: 5 }, { route: "/token/USDT", maxRank: 10 }],
+    routesWithinRank: [{ route: "/stablecoin/tether", maxRank: 5 }, { route: "/token/USDT", maxRank: 10 }],
   },
-  { query: "usdc", firstRoute: "/stablecoin/usd-coin", topRoutes: [{ route: "/token/USDC", maxRank: 10 }] },
-  { query: "eth", topRoutes: [{ route: "/token/ETH", maxRank: 5 }] },
-  { query: "sol", topRoutes: [{ route: "/token/SOL", maxRank: 5 }] },
-  { query: "mega", topRoutes: [{ route: "/token/MEGA", maxRank: 5 }] },
+  { query: "usdc", firstRoute: "/stablecoin/usd-coin", routesWithinRank: [{ route: "/token/USDC", maxRank: 10 }] },
+  { query: "eth", routesWithinRank: [{ route: "/token/ETH", maxRank: 5 }] },
+  { query: "sol", routesWithinRank: [{ route: "/token/SOL", maxRank: 5 }] },
+  { query: "mega", routesWithinRank: [{ route: "/token/MEGA", maxRank: 2 }] },
 ];
 
 async function meiliRequest(baseUrl: string, bearerToken: string | undefined, path: string, options: any = {}) {
@@ -165,7 +169,7 @@ describeSearch("search results in Meilisearch", () => {
     }
   });
 
-  test.each(SEARCH_CASES)("$query", async ({ query, firstRoute, blockedSubNames, topRoutes }) => {
+  test.each(SEARCH_CASES)("$query", async ({ query, firstRoute, blockedSubNames, routesWithinRank }) => {
     const hits = await search(query);
 
     if (firstRoute) expect(hits[0]?.route).toBe(firstRoute);
@@ -175,7 +179,7 @@ describeSearch("search results in Meilisearch", () => {
       expect(subpageHit).toBeUndefined();
     }
 
-    for (const expected of topRoutes ?? []) {
+    for (const expected of routesWithinRank ?? []) {
       const rank = hits.findIndex((hit) => hit.route === expected.route) + 1;
       expect(rank).toBeGreaterThan(0);
       expect(rank).toBeLessThanOrEqual(expected.maxRank);

--- a/defi/src/updateSearch.meili.test.ts
+++ b/defi/src/updateSearch.meili.test.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import dotenv from "dotenv";
-import { PAGES_INDEX_SETTINGS, generateSearchList } from "./updateSearch";
+import { PAGES_INDEX_SETTINGS } from "./updateSearch";
 
 if (process.env.APP_ENV) dotenv.config({ path: process.env.APP_ENV, override: false });
 
@@ -9,7 +9,6 @@ const describeSearch = shouldRun ? describe : describe.skip;
 const host = process.env.SEARCH_TEST_MEILI_HOST ?? "http://127.0.0.1:7700";
 const key = process.env.SEARCH_TEST_MEILI_KEY ?? "masterKey";
 const prodHost = process.env.SEARCH_PROD_MEILI_HOST ?? "https://search-core.defillama.com";
-const dataSource = process.env.SEARCH_TEST_DATA_SOURCE ?? (process.env.SEARCH_MASTER_KEY ? "prod" : "generated");
 const index = `test_pages_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
 if (shouldRun) jest.setTimeout(300_000);
@@ -45,7 +44,7 @@ const SEARCH_CASES: SearchCase[] = [
   { query: "cap", firstRoute: "/protocol/cap", routesWithinRank: [{ route: "/token/CAP", maxRank: 15 }] },
   {
     query: "usdt",
-    ...(dataSource === "prod" ? { firstRoute: "/stablecoin/tether" } : {}),
+    firstRoute: "/stablecoin/tether",
     routesWithinRank: [{ route: "/stablecoin/tether", maxRank: 5 }, { route: "/token/USDT", maxRank: 10 }],
   },
   { query: "usdc", firstRoute: "/stablecoin/usd-coin", routesWithinRank: [{ route: "/token/USDC", maxRank: 10 }] },
@@ -120,20 +119,10 @@ async function getProdPagesDocuments() {
 }
 
 async function getSearchDocuments() {
-  if (dataSource === "prod") {
-    if (!process.env.SEARCH_MASTER_KEY) {
-      throw new Error("Set SEARCH_MASTER_KEY or run with SEARCH_TEST_DATA_SOURCE=generated");
-    }
-    return getProdPagesDocuments();
+  if (!process.env.SEARCH_MASTER_KEY) {
+    throw new Error("Set SEARCH_MASTER_KEY or APP_ENV pointing to an env file before running search tests");
   }
-  if (dataSource === "generated") {
-    if (!process.env.INTERNAL_API_KEY) {
-      throw new Error("Set INTERNAL_API_KEY or APP_ENV pointing to an env file before running generated search tests");
-    }
-    const { results } = await generateSearchList();
-    return results;
-  }
-  throw new Error(`Unsupported SEARCH_TEST_DATA_SOURCE: ${dataSource}`);
+  return getProdPagesDocuments();
 }
 
 describeSearch("search results in Meilisearch", () => {

--- a/defi/src/updateSearch.test.ts
+++ b/defi/src/updateSearch.test.ts
@@ -12,12 +12,13 @@ import {
 } from "./updateSearch";
 
 describe("search index settings", () => {
-  it("searches route aliases before names and sub names", () => {
+  it("searches route aliases before names and keeps subpage labels display-only", () => {
     const attrs = PAGES_INDEX_SETTINGS.searchableAttributes;
 
     expect(attrs).toContain("routeAlias");
     expect(attrs.indexOf("routeAlias")).toBeLessThan(attrs.indexOf("name"));
-    expect(attrs.indexOf("routeAlias")).toBeLessThan(attrs.indexOf("subName"));
+    expect(attrs).not.toContain("subName");
+    expect(PAGES_INDEX_SETTINGS.displayedAttributes).toContain("subName");
   });
 
   it("keeps exactness before business ranking", () => {
@@ -25,6 +26,7 @@ describe("search index settings", () => {
 
     expect(rules.indexOf("exactness")).toBeLessThan(rules.indexOf("r:desc"));
     expect(rules.indexOf("r:desc")).toBeLessThan(rules.indexOf("attribute"));
+    expect(rules.indexOf("v:desc")).toBeLessThan(rules.indexOf("sort"));
   });
 
   it("supports frontend entity filters", () => {
@@ -158,10 +160,12 @@ describe("entity and subpage search docs", () => {
     });
 
     expect(subPages.find((page) => page.subName === "Fees")).toMatchObject({
+      name: "MarkIt",
       route: "/protocol/markit?tvl=false&fees=true",
       r: SEARCH_RANK.subPage,
     });
     expect(subPages.find((page) => page.subName === "Revenue")).toMatchObject({
+      name: "MarkIt",
       route: "/protocol/markit?tvl=false&revenue=true",
       r: SEARCH_RANK.subPage,
     });

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -83,8 +83,8 @@ interface TokenSearchData {
 
 export const SEARCH_RANK = {
   // Higher `r` wins after textual relevance. Keep navigation pages above
-  // entities for exact aliases like "yields", while subpages stay below their
-  // parent entity unless the query specifically matches the subpage text.
+  // entities for exact aliases like "yields", while subpages stay below parent
+  // entities and are found through parent names rather than generic tab names.
   navPage: 4,
   entity: 3,
   collection: 2,
@@ -129,7 +129,6 @@ export const PAGES_INDEX_SETTINGS = {
     "previousNames",
     "nameVariants",
     "keywords",
-    "subName",
   ],
   rankingRules: ["words", "typo", "proximity", "exactness", "r:desc", "attribute", "v:desc", "sort"],
   filterableAttributes: ["type", "deprecated", "subName"],

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -813,7 +813,7 @@ export function buildDirectoryResults(
   return allResults;
 }
 
-async function generateSearchList() {
+export async function generateSearchList() {
   const endAt = Date.now();
   const startAt = endAt - 1000 * 60 * 60 * 24 * 90;
   // Fetch all source datasets up front. The important split:

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -813,7 +813,7 @@ export function buildDirectoryResults(
   return allResults;
 }
 
-export async function generateSearchList() {
+async function generateSearchList() {
   const endAt = Date.now();
   const startAt = endAt - 1000 * 60 * 60 * 24 * 90;
   // Fetch all source datasets up front. The important split:


### PR DESCRIPTION
## Summary

- Stop indexing `subName` as a searchable field for the pages search index
- Keep subpage labels available for display and filtering
- Mirror the searchable attribute change in the manual Meili setup script
- Update search tests to cover display-only subpage labels

## Why

Generic metric queries like `fees` were matching every protocol subpage named `Fees`, so low-value protocol tabs could appear immediately after the main `/fees` result. Subpages should be found through their parent entity names, not through generic tab labels.

## Validation

```bash
cd /Users/mint/p/defillama-server/defi
npx jest src/updateSearch.test.ts --runInBand --no-cache --watchman=false
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nameVariants to searchable attributes for improved search matching.

* **Bug Fixes**
  * Moved subName from searchable to display-only attributes (still shown in UI).
  * Subpage objects now include the parent protocol name for clearer results.

* **Tests**
  * Added Meilisearch integration and regression tests validating ranking and attributes.
  * Added local test script and npm script to run the search test suite.

* **Documentation**
  * Added "Search regression tests" instructions to README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->