### PR TITLE
Update Phlox protocol metadata

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1393,7 +1393,7 @@ const data6: Protocol[] = [
     forkedFromIds: ["2198"],
     chains: ["LUKSO"],
     module: "phlox/index.js",
-    twitter: null,
+    twitter: "phloxsocial",
     github: ["phlox-labs"],
     listedAt: 1777517385
   },

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1382,7 +1382,7 @@ const data6: Protocol[] = [
     name: "Phlox",
     address: null,
     symbol: "-",
-    url: " ", // pending to add url https://phlox.finance
+    url: "https://phlox.social",
     description: "Phlox is a LUKSO-focused DeFi app with a Uniswap V3-style DEX",
     chain: "LUKSO",
     logo: `${baseIconsUrl}/phlox.jpg`,
@@ -1394,6 +1394,7 @@ const data6: Protocol[] = [
     chains: ["LUKSO"],
     module: "phlox/index.js",
     twitter: null,
+    github: ["phlox-labs"],
     listedAt: 1777517385
   },
   {


### PR DESCRIPTION
Updates Phlox listing metadata now that the TVL adapter is live.

Changes:
- Set URL to https://phlox.social
- Add GitHub org tracking: phlox-labs
- Keep existing phlox.jpg logo
- Leave twitter as null because no verified official X/Twitter account was found

Related adapter PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/19000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Phlox protocol entry with its official website (https://phlox.social).
  * Added Phlox GitHub reference and configured its Twitter handle for accurate linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->