### PR TITLE
Support Mezo Tigris V3 pools and unify V2/V3

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -28292,13 +28292,13 @@ const data4: Protocol[] = [
   },
   {
     id: "6794",
-    name: "Tigris Mezo",
+    name: "Mezo Tigris V2",
     address: null,
     symbol: "-",
     url: "https://mezo.org/explore/pools",
-    description: "Tigris is Mezo's native ve(3,3) DEX and incentive management system featuring stable/volatile AMM pools, vote-escrow tokenomics, and fee distribution to voters",
+    description: "An Aerodrome-style AMM with either constant-product or stable-curve pricing.",
     chain: "Mezo",
-    logo: `${baseIconsUrl}/tigris-mezo.jpg`,
+    logo: `${baseIconsUrl}/mezo-tigris-v2.jpg`,
     audits: "0",
     gecko_id: null,
     cmcId: null,
@@ -28306,6 +28306,7 @@ const data4: Protocol[] = [
     chains: ["Mezo"],
     module: "mezo-tigris/index.js",
     twitter: "MezoNetwork",
+    parentProtocol: "parent#mezo-tigris",
     listedAt: 1759338887
   },
   {

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -2124,7 +2124,7 @@ const data6: Protocol[] = [
     cmcId: null,
     tags: ["CLMM"],
     chains: ["Mezo"],
-    module: "mezo-swap-v3/index.js",
+    module: "mezo-tigris-v3/index.js",
     twitter: "MezoNetwork",
     parentProtocol: "parent#mezo-tigris",
     listedAt: 1778159220

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -2126,6 +2126,7 @@ const data6: Protocol[] = [
     chains: ["Mezo"],
     module: "mezo-swap-v3/index.js",
     twitter: "MezoNetwork",
+    parentProtocol: "parent#mezo-tigris",
     listedAt: 1778159220
   },
 ];

--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -2109,5 +2109,24 @@ const data6: Protocol[] = [
     excludeTvlFromParent: true, // full tvl value is represented under the usdh product
     listedAt: 1778142267
   },
+  {
+    id: "7808",
+    name: "Mezo Tigris V3",
+    address: null,
+    symbol: "-",
+    url: "https://mezo.org/explore/pools",
+    description:
+      "A concentrated liquidity DEX based on Velodrome Slipstream.",
+    chain: "Mezo",
+    logo: `${baseIconsUrl}/mezo-tigris-v3.jpg`,
+    audits: "0",
+    gecko_id: null,
+    cmcId: null,
+    tags: ["CLMM"],
+    chains: ["Mezo"],
+    module: "mezo-swap-v3/index.js",
+    twitter: "MezoNetwork",
+    listedAt: 1778159220
+  },
 ];
 export default data6;

--- a/defi/src/protocols/parentProtocols.ts
+++ b/defi/src/protocols/parentProtocols.ts
@@ -9648,6 +9648,18 @@ const parentProtocols: IParentProtocol[] = [
     twitter: "HermeticaFi",
     stablecoins: ["hermetica-usdh"],
   },
+  {
+    id: "parent#mezo-tigris",
+    name: "Mezo Tigris",
+    url: "https://mezo.org/feature/swap",
+    description:
+      "Tigris is Mezo's native ve(3,3) DEX and incentive management system featuring stable/volatile AMM pools, vote-escrow tokenomics, and fee distribution to voters.",
+    logo: `${baseIconsUrl}/tigris-mezo.jpg`,
+    gecko_id: null,
+    cmcId: null,
+    chains: [],
+    twitter: "MezoNetwork",
+  },
 ];
 
 export default parentProtocols;


### PR DESCRIPTION
### Description
This PR adds support for Mezo Tigris V3 pools and introduces a unified structure for handling both V2 and V3 pools under a parent Mezo Tigris.
Previously, Mezo Tigris only supported V2 pools and did not include any V3 integration. With this update, both versions are now processed through a unified Mezo Tigris.

### Changes
* Added support for Mezo Tigris V3 pools
* Renamed Mezo Tigris to Mezo Tigris V2
* Introduced a parent Mezo Tigris to unify V2 and V3 pool handling

### Related PRs
* DefiLlama/DefiLlama-Adapters#19147
* DefiLlama/icons#2376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mezo Tigris V3 protocol
  * Updated Mezo Tigris V2 protocol metadata and branding
  * Implemented parent protocol hierarchy tracking for enhanced protocol organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->