### PR TITLE
Include protocol-only chains in protocols2

### DIFF
--- a/defi/src/storeGetProtocols.test.ts
+++ b/defi/src/storeGetProtocols.test.ts
@@ -115,6 +115,90 @@ describe("storeGetProtocols visible chain filtering", () => {
     expect(protocols2Data.chains).not.toContain("HyperEVM");
   });
 
+  test("storeGetProtocols includes chains backed only by excluded chart categories", async () => {
+    mockedCraftProtocolsResponse.mockResolvedValue([
+      {
+        id: "1",
+        name: "Visible Protocol",
+        category: "Lending",
+        chains: ["Ethereum"],
+        chainTvls: { Ethereum: 100 },
+        oraclesByChain: {},
+        symbol: "VP",
+        logo: "",
+        url: "",
+        referralUrl: "",
+        parentProtocol: undefined,
+        governanceID: undefined,
+        gecko_id: undefined,
+        tvl: 100,
+      } as any,
+      {
+        id: "2",
+        name: "RWA Protocol",
+        category: "RWA",
+        chains: ["Pharos"],
+        chainTvls: { Pharos: 50 },
+        oraclesByChain: {},
+        symbol: "RP",
+        logo: "",
+        url: "",
+        referralUrl: "",
+        parentProtocol: undefined,
+        governanceID: undefined,
+        gecko_id: undefined,
+        tvl: 50,
+      } as any,
+    ]);
+    mockedGetProtocolTvl.mockImplementation(async (protocol: any) => {
+      if (protocol.id === "2") {
+        return {
+          tvl: 50,
+          tvlPrevDay: 45,
+          tvlPrevWeek: 40,
+          tvlPrevMonth: 35,
+          chainTvls: {
+            Pharos: {
+              tvl: 50,
+              tvlPrevDay: 45,
+              tvlPrevWeek: 40,
+              tvlPrevMonth: 35,
+            },
+          },
+        } as any;
+      }
+
+      return {
+        tvl: 100,
+        tvlPrevDay: 90,
+        tvlPrevWeek: 80,
+        tvlPrevMonth: 70,
+        chainTvls: {
+          Ethereum: {
+            tvl: 100,
+            tvlPrevDay: 90,
+            tvlPrevWeek: 80,
+            tvlPrevMonth: 70,
+          },
+        },
+      } as any;
+    });
+    mockedReadRouteData.mockResolvedValue({
+      ethereum: {
+        fees: {
+          df: { "24h": 1 },
+        },
+      },
+    });
+
+    const { protocols2Data } = await storeGetProtocols({
+      getCoinMarkets: async () => ({}),
+    });
+
+    expect(protocols2Data.protocols.map((p: any) => p.chains)).toEqual([["Ethereum"], ["Pharos"]]);
+    expect(protocols2Data.chains).toEqual(["Ethereum", "Pharos"]);
+  });
+
   test("storeGetProtocols falls back to cached visible chains when dimensions cache is missing or empty", async () => {
     mockedCraftProtocolsResponse.mockResolvedValue([
       {

--- a/defi/src/storeGetProtocols.ts
+++ b/defi/src/storeGetProtocols.ts
@@ -169,9 +169,18 @@ export async function storeGetProtocols({
   ).filter((p) => !hiddenCategoriesFromUISet.has(p.category ?? ""));
 
   const chains = {} as { [chain: string]: number };
+  const protocolChainLabels: string[] = [];
+  const protocolChainLabelsSet = new Set<string>();
   const protocolCategoriesSet: Set<string> = new Set();
 
   trimmedResponse.forEach((p) => {
+    for (const chain of p.chains) {
+      if (protocolChainLabelsSet.has(chain)) continue;
+
+      protocolChainLabelsSet.add(chain);
+      protocolChainLabels.push(chain);
+    }
+
     if (!p.category) return;
 
     protocolCategoriesSet.add(p.category);
@@ -266,7 +275,11 @@ export async function storeGetProtocols({
     console.warn('Missing /dimensions/chain-agg-data while computing visible chains for /lite/protocols2, falling back to cached visible chains');
   }
 
-  const chainsOutput = getVisibleChainLabels(chains, dimensionsChainAggData ?? {}, fallbackChainLabels)
+  const chainsOutput = getVisibleChainLabels(
+    chains,
+    dimensionsChainAggData ?? {},
+    fallbackChainLabels.concat(protocolChainLabels),
+  )
 
 
   const protocols2Data = {


### PR DESCRIPTION
## Summary
- include every chain emitted by /lite/protocols2 protocol entries in the top-level chains list
- preserve existing TVL aggregation semantics for excluded chart categories
- add regression coverage for a chain backed only by an RWA protocol

## Why
Chains like Pharos can exist on protocol records but be absent from /lite/protocols2.chains because their only backing protocol is in an excluded chart category. appMetadata-chains.json and search are seeded from that top-level chain list, so those chains were not discoverable.

## Validation
- ./node_modules/.bin/jest src/storeGetProtocols.test.ts --runInBand --watchman=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved display of blockchain chains with protocol TVL data by ensuring they appear in results even when dimension cache data is unavailable.

* **Tests**
  * Added test coverage for protocol chain visibility handling in various data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->