### PR TITLE
Filter chain placeholders from protocol search

### DIFF
--- a/defi/src/updateSearch.test.ts
+++ b/defi/src/updateSearch.test.ts
@@ -9,6 +9,7 @@ import {
   dedupeFrontendPageResults,
   getFrontendPageRouteAlias,
   getProtocolSubSections,
+  shouldSkipProtocolSearchResult,
 } from "./updateSearch";
 
 describe("search index settings", () => {
@@ -142,6 +143,23 @@ describe("frontend page search docs", () => {
 });
 
 describe("entity and subpage search docs", () => {
+  it("skips zero-tvl canonical bridge rows that duplicate chain search results", () => {
+    const chainNames = new Set(["Arbitrum", "Solana", "Zircuit"]);
+
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Solana", category: "Canonical Bridge", tvl: null }, chainNames)
+    ).toBe(true);
+    expect(shouldSkipProtocolSearchResult({ name: "Arbitrum", category: "Canonical Bridge", tvl: 0 }, chainNames)).toBe(
+      true
+    );
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Arbitrum Bridge", category: "Canonical Bridge", tvl: 100 }, chainNames)
+    ).toBe(false);
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Zircuit", category: "Canonical Bridge", tvl: 100 }, chainNames)
+    ).toBe(false);
+  });
+
   it("keeps protocol subpages below entities and without route aliases", () => {
     const result = buildProtocolSearchResult({
       id: "protocol_markit",
@@ -202,10 +220,7 @@ describe("entity and subpage search docs", () => {
   });
 
   it("keeps stablecoin symbols indexed for USDT and USDC searches", () => {
-    const tether = buildStablecoinSearchResult(
-      { name: "Tether", symbol: "USDT", circulating: { peggedUSD: 100 } },
-      {}
-    );
+    const tether = buildStablecoinSearchResult({ name: "Tether", symbol: "USDT", circulating: { peggedUSD: 100 } }, {});
     const usdCoin = buildStablecoinSearchResult(
       { name: "USD Coin", symbol: "USDC", circulating: { peggedUSD: 100 } },
       {}

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -116,6 +116,12 @@ interface StablecoinSearchInput {
   circulating: { peggedUSD: number };
 }
 
+interface ProtocolSearchSource {
+  name: string;
+  category?: string;
+  tvl?: number | null;
+}
+
 export const PAGES_INDEX_SETTINGS = {
   searchableAttributes: [
     "alias1",
@@ -146,20 +152,20 @@ export const PAGES_INDEX_SETTINGS = {
     "symbol",
   ],
   synonyms: {
-    stable: ["stablecoin", "stablecoins"],
-    stablecoin: ["stable", "stablecoins"],
-    stablecoins: ["stable", "stablecoin"],
-    mcap: ["market cap", "marketcap"],
-    marketcap: ["market cap", "mcap"],
+    "stable": ["stablecoin", "stablecoins"],
+    "stablecoin": ["stable", "stablecoins"],
+    "stablecoins": ["stable", "stablecoin"],
+    "mcap": ["market cap", "marketcap"],
+    "marketcap": ["market cap", "mcap"],
     "market cap": ["mcap", "marketcap"],
-    tvl: ["total value locked"],
-    apy: ["yield", "yields"],
-    yield: ["apy", "yields"],
-    yields: ["apy", "yield"],
-    dex: ["dexs", "exchange"],
-    dexs: ["dex", "exchanges"],
-    cex: ["cexs", "exchange"],
-    cexs: ["cex", "exchanges"],
+    "tvl": ["total value locked"],
+    "apy": ["yield", "yields"],
+    "yield": ["apy", "yields"],
+    "yields": ["apy", "yield"],
+    "dex": ["dexs", "exchange"],
+    "dexs": ["dex", "exchanges"],
+    "cex": ["cexs", "exchange"],
+    "cexs": ["cex", "exchanges"],
   },
 } as const;
 
@@ -258,6 +264,10 @@ export function buildProtocolSearchResult({
   };
 }
 
+export function shouldSkipProtocolSearchResult(protocol: ProtocolSearchSource, chainNames: Set<string>) {
+  return protocol.category === "Canonical Bridge" && chainNames.has(protocol.name) && !protocol.tvl;
+}
+
 export function buildStablecoinSearchResult(
   stablecoin: StablecoinSearchInput,
   tastyMetrics: Record<string, number>
@@ -300,8 +310,7 @@ export function dedupeFrontendPageResults(results: SearchResult[]): SearchResult
     // the longer one into `nameVariants` so it still matches at search time,
     // and union `keywords` + recompute aliases.
     const sameName = existing.name.trim().toLowerCase() === result.name.trim().toLowerCase();
-    const [primary, secondary] =
-      result.name.length < existing.name.length ? [result, existing] : [existing, result];
+    const [primary, secondary] = result.name.length < existing.name.length ? [result, existing] : [existing, result];
 
     const nameVariants = sameName
       ? mergeKeywords(existing.nameVariants, result.nameVariants)
@@ -968,8 +977,10 @@ async function generateSearchList() {
   const protocols: Array<SearchResult> = [];
   const subProtocols: Array<SearchResult> = [];
   const metadataChainSlugs = new Set<string>();
+  const metadataChainNames = new Set<string>();
   for (const chainSlug in chainsMetadata) {
     metadataChainSlugs.add(chainSlug);
+    metadataChainNames.add(chainsMetadata[chainSlug].name);
   }
 
   // Parent protocols are first-class protocol search results. Their child
@@ -1008,6 +1019,7 @@ async function generateSearchList() {
   // added unless they hit the narrow `chain#` fallback below.
   for (const protocol of tvlData.protocols) {
     if (protocol.name === "LlamaSwap") continue;
+    if (shouldSkipProtocolSearchResult(protocol, metadataChainNames)) continue;
     const prevNames = previousNamesMap.get(protocol.name);
     const result = buildProtocolSearchResult({
       id: `protocol_${normalize(protocol.name)}`,


### PR DESCRIPTION
## Summary
- Skip zero/null-TVL canonical bridge rows from protocol search when the row name already matches a chain metadata name.
- Keep real canonical bridge protocol results, such as named bridge pages with TVL.
- Add unit coverage for Solana-style placeholders and opposite-edge canonical bridge cases.

## Why
Some chain placeholder rows from /lite/protocols2 were indexed as type Protocol, so searching Solana showed both the Chain result and a duplicate Protocol result. Chain entities are already built from appMetadata-chains.json.

## Validation
- ./node_modules/.bin/jest src/updateSearch.test.ts --runInBand --no-watchman
- ./node_modules/.bin/prettier --check src/updateSearch.ts src/updateSearch.test.ts
- git diff --check