### PR TITLE
Consolidate search list and chain coverage fixes

### DIFF
--- a/defi/src/cli/search/setup.sh
+++ b/defi/src/cli/search/setup.sh
@@ -49,6 +49,7 @@ curl \
     "words",
     "typo",
     "proximity",
+    "topLevelRank:desc",
     "exactness",
     "r:desc",
     "attribute",
@@ -75,7 +76,8 @@ curl \
     "tvl",
     "name",
     "mcapRank",
-    "r"
+    "r",
+    "topLevelRank"
   ]'
 
 curl \

--- a/defi/src/storeGetProtocols.test.ts
+++ b/defi/src/storeGetProtocols.test.ts
@@ -115,6 +115,90 @@ describe("storeGetProtocols visible chain filtering", () => {
     expect(protocols2Data.chains).not.toContain("HyperEVM");
   });
 
+  test("storeGetProtocols includes chains backed only by excluded chart categories", async () => {
+    mockedCraftProtocolsResponse.mockResolvedValue([
+      {
+        id: "1",
+        name: "Visible Protocol",
+        category: "Lending",
+        chains: ["Ethereum"],
+        chainTvls: { Ethereum: 100 },
+        oraclesByChain: {},
+        symbol: "VP",
+        logo: "",
+        url: "",
+        referralUrl: "",
+        parentProtocol: undefined,
+        governanceID: undefined,
+        gecko_id: undefined,
+        tvl: 100,
+      } as any,
+      {
+        id: "2",
+        name: "RWA Protocol",
+        category: "RWA",
+        chains: ["Pharos"],
+        chainTvls: { Pharos: 50 },
+        oraclesByChain: {},
+        symbol: "RP",
+        logo: "",
+        url: "",
+        referralUrl: "",
+        parentProtocol: undefined,
+        governanceID: undefined,
+        gecko_id: undefined,
+        tvl: 50,
+      } as any,
+    ]);
+    mockedGetProtocolTvl.mockImplementation(async (protocol: any) => {
+      if (protocol.id === "2") {
+        return {
+          tvl: 50,
+          tvlPrevDay: 45,
+          tvlPrevWeek: 40,
+          tvlPrevMonth: 35,
+          chainTvls: {
+            Pharos: {
+              tvl: 50,
+              tvlPrevDay: 45,
+              tvlPrevWeek: 40,
+              tvlPrevMonth: 35,
+            },
+          },
+        } as any;
+      }
+
+      return {
+        tvl: 100,
+        tvlPrevDay: 90,
+        tvlPrevWeek: 80,
+        tvlPrevMonth: 70,
+        chainTvls: {
+          Ethereum: {
+            tvl: 100,
+            tvlPrevDay: 90,
+            tvlPrevWeek: 80,
+            tvlPrevMonth: 70,
+          },
+        },
+      } as any;
+    });
+    mockedReadRouteData.mockResolvedValue({
+      ethereum: {
+        fees: {
+          df: { "24h": 1 },
+        },
+      },
+    });
+
+    const { protocols2Data } = await storeGetProtocols({
+      getCoinMarkets: async () => ({}),
+    });
+
+    expect(protocols2Data.protocols.map((p: any) => p.chains)).toEqual([["Ethereum"], ["Pharos"]]);
+    expect(protocols2Data.chains).toEqual(["Ethereum", "Pharos"]);
+  });
+
   test("storeGetProtocols falls back to cached visible chains when dimensions cache is missing or empty", async () => {
     mockedCraftProtocolsResponse.mockResolvedValue([
       {

--- a/defi/src/storeGetProtocols.ts
+++ b/defi/src/storeGetProtocols.ts
@@ -169,9 +169,18 @@ export async function storeGetProtocols({
   ).filter((p) => !hiddenCategoriesFromUISet.has(p.category ?? ""));
 
   const chains = {} as { [chain: string]: number };
+  const protocolChainLabels: string[] = [];
+  const protocolChainLabelsSet = new Set<string>();
   const protocolCategoriesSet: Set<string> = new Set();
 
   trimmedResponse.forEach((p) => {
+    for (const chain of p.chains) {
+      if (protocolChainLabelsSet.has(chain)) continue;
+
+      protocolChainLabelsSet.add(chain);
+      protocolChainLabels.push(chain);
+    }
+
     if (!p.category) return;
 
     protocolCategoriesSet.add(p.category);
@@ -266,7 +275,11 @@ export async function storeGetProtocols({
     console.warn('Missing /dimensions/chain-agg-data while computing visible chains for /lite/protocols2, falling back to cached visible chains');
   }
 
-  const chainsOutput = getVisibleChainLabels(chains, dimensionsChainAggData ?? {}, fallbackChainLabels)
+  const chainsOutput = getVisibleChainLabels(
+    chains,
+    dimensionsChainAggData ?? {},
+    fallbackChainLabels.concat(protocolChainLabels),
+  )
 
 
   const protocols2Data = {

--- a/defi/src/storeGetProtocols.ts
+++ b/defi/src/storeGetProtocols.ts
@@ -3,10 +3,16 @@ import { getProtocolTvl } from "./utils/getProtocolTvl";
 import parentProtocolsList from "./protocols/parentProtocols";
 import type { IParentProtocol } from "./protocols/types";
 import type { IProtocol, LiteProtocol, ProtocolTvls } from "./types";
-import { chainCoingeckoIds, currentChainLabelsList, getChainDisplayName, getChainKeyFromLabel, replaceChainNamesForOraclesByChain } from "./utils/normalizeChain";
+import {
+  chainCoingeckoIds,
+  currentChainLabelsList,
+  getChainDisplayName,
+  getChainKeyFromLabel,
+  replaceChainNamesForOraclesByChain,
+} from "./utils/normalizeChain";
 import { extraSections } from "./utils/normalizeChain";
 import fetch from "node-fetch";
-import { excludeProtocolInCharts, hiddenCategoriesFromUISet, } from "./utils/excludeProtocols";
+import { excludeProtocolInCharts, hiddenCategoriesFromUISet } from "./utils/excludeProtocols";
 import protocols from "./protocols/data";
 import { readRouteData } from "./api2/cache/file-cache";
 
@@ -49,7 +55,7 @@ function getVisibleChainLabel(chain: string) {
 export function getVisibleChainLabels(
   protocolChainTvls: { [chain: string]: number },
   dimensionsChainAggData: any = {},
-  fallbackChainLabels: string[] = [],
+  fallbackChainLabels: string[] = []
 ) {
   const normalizedProtocolChainTvls = new Map<string, number>();
   for (const chain in protocolChainTvls) {
@@ -58,7 +64,7 @@ export function getVisibleChainLabels(
 
     normalizedProtocolChainTvls.set(
       visibleChainLabel,
-      (normalizedProtocolChainTvls.get(visibleChainLabel) ?? 0) + protocolChainTvls[chain],
+      (normalizedProtocolChainTvls.get(visibleChainLabel) ?? 0) + protocolChainTvls[chain]
     );
   }
 
@@ -141,9 +147,10 @@ export async function storeGetProtocols({
           category: protocol.category,
           ...(protocol.tags ? { tags: protocol.tags } : {}),
           chains: protocol.chains,
-          oracles: protocol.oraclesBreakdown && protocol.oraclesBreakdown.length > 0
-            ? protocol.oraclesBreakdown.map((x) => x.name)
-            : protocol.oracles,
+          oracles:
+            protocol.oraclesBreakdown && protocol.oraclesBreakdown.length > 0
+              ? protocol.oraclesBreakdown.map((x) => x.name)
+              : protocol.oracles,
           oraclesByChain: replaceChainNamesForOraclesByChain(true, protocol.oraclesByChain),
           forkedFrom,
           listedAt: protocol.listedAt,
@@ -162,7 +169,7 @@ export async function storeGetProtocols({
           defillamaId: protocol.id,
           governanceID: protocol.governanceID,
           geckoId: protocol.gecko_id,
-          ...(protocol.deprecated ? { deprecated: protocol.deprecated } : {})
+          ...(protocol.deprecated ? { deprecated: protocol.deprecated } : {}),
         };
       })
     )
@@ -254,13 +261,12 @@ export async function storeGetProtocols({
     };
   });
 
-
-  const dimensionsChainAggData = await readRouteData('/dimensions/chain-agg-data', {
+  const dimensionsChainAggData = await readRouteData("/dimensions/chain-agg-data", {
     skipErrorLog: true,
   });
   let fallbackChainLabels: string[] = [];
   if (!hasDimensionsChainAggData(dimensionsChainAggData)) {
-    const previousProtocols2Data = await readRouteData('/lite/protocols2', {
+    const previousProtocols2Data = await readRouteData("/lite/protocols2", {
       skipErrorLog: true,
     });
     if (previousProtocols2Data?.chains) {
@@ -272,15 +278,16 @@ export async function storeGetProtocols({
         }
       }
     }
-    console.warn('Missing /dimensions/chain-agg-data while computing visible chains for /lite/protocols2, falling back to cached visible chains');
+    console.warn(
+      "Missing /dimensions/chain-agg-data while computing visible chains for /lite/protocols2, falling back to cached visible chains"
+    );
   }
 
   const chainsOutput = getVisibleChainLabels(
     chains,
     dimensionsChainAggData ?? {},
-    fallbackChainLabels.concat(protocolChainLabels),
-  )
-
+    fallbackChainLabels.concat(protocolChainLabels)
+  );
 
   const protocols2Data = {
     protocols: trimmedResponse,
@@ -304,7 +311,7 @@ export async function storeGetProtocols({
       mcap: protocol.mcap,
       gecko_id: protocol.gecko_id,
       parent: protocol.parentProtocol,
-      ...(protocol.deprecated ? { deprecated: true } : {})
+      ...(protocol.deprecated ? { deprecated: true } : {}),
     }))
     .concat(extendedParentProtocols);
 

--- a/defi/src/updateSearch.meili.test.ts
+++ b/defi/src/updateSearch.meili.test.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import dotenv from "dotenv";
-import { PAGES_INDEX_SETTINGS } from "./updateSearch";
+import { PAGES_INDEX_SETTINGS, SEARCH_DEPTH_RANK } from "./updateSearch";
 
 if (process.env.APP_ENV) dotenv.config({ path: process.env.APP_ENV, override: false });
 
@@ -19,6 +19,7 @@ interface SearchHit {
   route: string;
   subName?: string;
   type?: string;
+  topLevelRank?: number;
 }
 
 interface SearchCase {
@@ -26,6 +27,7 @@ interface SearchCase {
   firstRoute?: string;
   blockedSubNames?: string[];
   routesWithinRank?: Array<{ route: string; maxRank: number }>;
+  routesBeforeRoutes?: Array<{ beforeRoute: string; afterRoute: string }>;
 }
 
 const SEARCH_CASES: SearchCase[] = [
@@ -37,15 +39,24 @@ const SEARCH_CASES: SearchCase[] = [
   {
     query: "aave",
     firstRoute: "/protocol/aave",
-    routesWithinRank: [{ route: "/protocol/aave?tvl=false&fees=true", maxRank: 15 }],
+    routesWithinRank: [{ route: "/protocol/aave?tvl=false&fees=true", maxRank: 25 }],
   },
   { query: "stabble", firstRoute: "/protocol/stabble" },
+  {
+    query: "stab",
+    firstRoute: "/protocol/stab-protocol",
+    routesWithinRank: [{ route: "/stablecoins", maxRank: 3 }],
+    routesBeforeRoutes: [{ beforeRoute: "/stablecoins", afterRoute: "/protocol/stab-protocol?tvl=true" }],
+  },
   { query: "markit", firstRoute: "/protocol/markit" },
   { query: "cap", firstRoute: "/protocol/cap", routesWithinRank: [{ route: "/token/CAP", maxRank: 15 }] },
   {
     query: "usdt",
     firstRoute: "/stablecoin/tether",
-    routesWithinRank: [{ route: "/stablecoin/tether", maxRank: 5 }, { route: "/token/USDT", maxRank: 10 }],
+    routesWithinRank: [
+      { route: "/stablecoin/tether", maxRank: 5 },
+      { route: "/token/USDT", maxRank: 10 },
+    ],
   },
   { query: "usdc", firstRoute: "/stablecoin/usd-coin", routesWithinRank: [{ route: "/token/USDC", maxRank: 10 }] },
   { query: "eth", routesWithinRank: [{ route: "/token/ETH", maxRank: 5 }] },
@@ -122,7 +133,11 @@ async function getSearchDocuments() {
   if (!process.env.SEARCH_MASTER_KEY) {
     throw new Error("Set SEARCH_MASTER_KEY or APP_ENV pointing to an env file before running search tests");
   }
-  return getProdPagesDocuments();
+  const results = await getProdPagesDocuments();
+  return results.map((result) => ({
+    ...result,
+    topLevelRank: result.topLevelRank ?? (result.subName ? SEARCH_DEPTH_RANK.subPage : SEARCH_DEPTH_RANK.topLevel),
+  }));
 }
 
 describeSearch("search results in Meilisearch", () => {
@@ -158,20 +173,30 @@ describeSearch("search results in Meilisearch", () => {
     }
   });
 
-  test.each(SEARCH_CASES)("$query", async ({ query, firstRoute, blockedSubNames, routesWithinRank }) => {
-    const hits = await search(query);
+  test.each(SEARCH_CASES)(
+    "$query",
+    async ({ query, firstRoute, blockedSubNames, routesWithinRank, routesBeforeRoutes }) => {
+      const hits = await search(query);
 
-    if (firstRoute) expect(hits[0]?.route).toBe(firstRoute);
+      if (firstRoute) expect(hits[0]?.route).toBe(firstRoute);
 
-    for (const subName of blockedSubNames ?? []) {
-      const subpageHit = hits.find((hit) => hit.subName === subName);
-      expect(subpageHit).toBeUndefined();
+      for (const subName of blockedSubNames ?? []) {
+        const subpageHit = hits.find((hit) => hit.subName === subName);
+        expect(subpageHit).toBeUndefined();
+      }
+
+      for (const expected of routesWithinRank ?? []) {
+        const rank = hits.findIndex((hit) => hit.route === expected.route) + 1;
+        expect(rank).toBeGreaterThan(0);
+        expect(rank).toBeLessThanOrEqual(expected.maxRank);
+      }
+
+      for (const expected of routesBeforeRoutes ?? []) {
+        const beforeRank = hits.findIndex((hit) => hit.route === expected.beforeRoute) + 1;
+        const afterRank = hits.findIndex((hit) => hit.route === expected.afterRoute) + 1;
+        expect(beforeRank).toBeGreaterThan(0);
+        if (afterRank > 0) expect(beforeRank).toBeLessThan(afterRank);
+      }
     }
-
-    for (const expected of routesWithinRank ?? []) {
-      const rank = hits.findIndex((hit) => hit.route === expected.route) + 1;
-      expect(rank).toBeGreaterThan(0);
-      expect(rank).toBeLessThanOrEqual(expected.maxRank);
-    }
-  });
+  );
 });

--- a/defi/src/updateSearch.test.ts
+++ b/defi/src/updateSearch.test.ts
@@ -1,5 +1,6 @@
 import {
   DIRECTORY_INDEX_SETTINGS,
+  SEARCH_DEPTH_RANK,
   PAGES_INDEX_SETTINGS,
   SEARCH_RANK,
   buildDirectoryResults,
@@ -22,9 +23,10 @@ describe("search index settings", () => {
     expect(PAGES_INDEX_SETTINGS.displayedAttributes).toContain("subName");
   });
 
-  it("keeps exactness before business ranking", () => {
+  it("keeps result depth before exactness and business ranking", () => {
     const rules = PAGES_INDEX_SETTINGS.rankingRules;
 
+    expect(rules.indexOf("topLevelRank:desc")).toBeLessThan(rules.indexOf("exactness"));
     expect(rules.indexOf("exactness")).toBeLessThan(rules.indexOf("r:desc"));
     expect(rules.indexOf("r:desc")).toBeLessThan(rules.indexOf("attribute"));
     expect(rules.indexOf("v:desc")).toBeLessThan(rules.indexOf("sort"));
@@ -41,6 +43,7 @@ describe("search index settings", () => {
       expect.arrayContaining(["symbol", "previousNames", "nameVariants", "keywords", "alias1", "alias5"])
     );
     expect(PAGES_INDEX_SETTINGS.sortableAttributes).toContain("mcapRank");
+    expect(PAGES_INDEX_SETTINGS.sortableAttributes).toContain("topLevelRank");
   });
 
   it("keeps directory search scoped to official URL entries", () => {
@@ -81,12 +84,23 @@ describe("frontend page search docs", () => {
       tastyMetrics: {},
     });
 
-    expect(fees).toMatchObject({ route: "/fees", routeAlias: "fees", r: SEARCH_RANK.navPage });
-    expect(revenue).toMatchObject({ route: "/revenue", routeAlias: "revenue", r: SEARCH_RANK.navPage });
+    expect(fees).toMatchObject({
+      route: "/fees",
+      routeAlias: "fees",
+      r: SEARCH_RANK.navPage,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
+    });
+    expect(revenue).toMatchObject({
+      route: "/revenue",
+      routeAlias: "revenue",
+      r: SEARCH_RANK.navPage,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
+    });
     expect(holdersRevenue).toMatchObject({
       route: "/holders-revenue",
       routeAlias: "holders revenue",
       r: SEARCH_RANK.navPage,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
     });
   });
 
@@ -181,11 +195,13 @@ describe("entity and subpage search docs", () => {
       name: "MarkIt",
       route: "/protocol/markit?tvl=false&fees=true",
       r: SEARCH_RANK.subPage,
+      topLevelRank: SEARCH_DEPTH_RANK.subPage,
     });
     expect(subPages.find((page) => page.subName === "Revenue")).toMatchObject({
       name: "MarkIt",
       route: "/protocol/markit?tvl=false&revenue=true",
       r: SEARCH_RANK.subPage,
+      topLevelRank: SEARCH_DEPTH_RANK.subPage,
     });
     expect(subPages.some((page) => "routeAlias" in page)).toBe(false);
   });
@@ -212,10 +228,25 @@ describe("entity and subpage search docs", () => {
       v: 0,
     });
 
-    expect(stabble).toMatchObject({ name: "Stabble", symbol: "STB", r: SEARCH_RANK.entity });
-    expect(markit).toMatchObject({ name: "MarkIt", route: "/protocol/markit", r: SEARCH_RANK.entity });
+    expect(stabble).toMatchObject({
+      name: "Stabble",
+      symbol: "STB",
+      r: SEARCH_RANK.entity,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
+    });
+    expect(markit).toMatchObject({
+      name: "MarkIt",
+      route: "/protocol/markit",
+      r: SEARCH_RANK.entity,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
+    });
     expect(markit.nameVariants).toContain("Mark It");
-    expect(stab).toMatchObject({ name: "STAB Protocol", symbol: "ILIS", r: SEARCH_RANK.entity });
+    expect(stab).toMatchObject({
+      name: "STAB Protocol",
+      symbol: "ILIS",
+      r: SEARCH_RANK.entity,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
+    });
     expect(stab.routeAlias).toBeUndefined();
   });
 
@@ -231,6 +262,7 @@ describe("entity and subpage search docs", () => {
       symbol: "USDT",
       route: "/stablecoin/tether",
       r: SEARCH_RANK.entity,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
       type: "Stablecoin",
     });
     expect(usdCoin).toMatchObject({
@@ -238,6 +270,7 @@ describe("entity and subpage search docs", () => {
       symbol: "USDC",
       route: "/stablecoin/usd-coin",
       r: SEARCH_RANK.entity,
+      topLevelRank: SEARCH_DEPTH_RANK.topLevel,
       type: "Stablecoin",
     });
   });

--- a/defi/src/updateSearch.test.ts
+++ b/defi/src/updateSearch.test.ts
@@ -9,6 +9,7 @@ import {
   dedupeFrontendPageResults,
   getFrontendPageRouteAlias,
   getProtocolSubSections,
+  shouldSkipProtocolSearchResult,
 } from "./updateSearch";
 
 describe("search index settings", () => {
@@ -142,6 +143,23 @@ describe("frontend page search docs", () => {
 });
 
 describe("entity and subpage search docs", () => {
+  it("skips zero-tvl canonical bridge rows that duplicate chain search results", () => {
+    const chainNames = new Set(["Arbitrum", "Solana", "Zircuit"]);
+
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Solana", category: "Canonical Bridge", tvl: null }, chainNames)
+    ).toBe(true);
+    expect(shouldSkipProtocolSearchResult({ name: "Arbitrum", category: "Canonical Bridge", tvl: 0 }, chainNames)).toBe(
+      true
+    );
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Arbitrum Bridge", category: "Canonical Bridge", tvl: 100 }, chainNames)
+    ).toBe(false);
+    expect(
+      shouldSkipProtocolSearchResult({ name: "Zircuit", category: "Canonical Bridge", tvl: 100 }, chainNames)
+    ).toBe(false);
+  });
+
   it("keeps protocol subpages below entities and without route aliases", () => {
     const result = buildProtocolSearchResult({
       id: "protocol_markit",
@@ -202,10 +220,7 @@ describe("entity and subpage search docs", () => {
   });
 
   it("keeps stablecoin symbols indexed for USDT and USDC searches", () => {
-    const tether = buildStablecoinSearchResult(
-      { name: "Tether", symbol: "USDT", circulating: { peggedUSD: 100 } },
-      {}
-    );
+    const tether = buildStablecoinSearchResult({ name: "Tether", symbol: "USDT", circulating: { peggedUSD: 100 } }, {});
     const usdCoin = buildStablecoinSearchResult(
       { name: "USD Coin", symbol: "USDC", circulating: { peggedUSD: 100 } },
       {}

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -68,6 +68,7 @@ interface SearchResult {
   alias4?: string;
   alias5?: string;
   r?: number;
+  topLevelRank?: number;
   v: number;
 }
 
@@ -90,6 +91,11 @@ export const SEARCH_RANK = {
   collection: 2,
   subPage: 1,
   deprecated: -1,
+} as const;
+
+export const SEARCH_DEPTH_RANK = {
+  topLevel: 1,
+  subPage: 0,
 } as const;
 
 interface FrontendPage {
@@ -136,9 +142,19 @@ export const PAGES_INDEX_SETTINGS = {
     "nameVariants",
     "keywords",
   ],
-  rankingRules: ["words", "typo", "proximity", "exactness", "r:desc", "attribute", "v:desc", "sort"],
+  rankingRules: [
+    "words",
+    "typo",
+    "proximity",
+    "topLevelRank:desc",
+    "exactness",
+    "r:desc",
+    "attribute",
+    "v:desc",
+    "sort",
+  ],
   filterableAttributes: ["type", "deprecated", "subName"],
-  sortableAttributes: ["v", "tvl", "name", "mcapRank", "r"],
+  sortableAttributes: ["v", "tvl", "name", "mcapRank", "r", "topLevelRank"],
   displayedAttributes: [
     "id",
     "name",
@@ -228,6 +244,7 @@ export function buildFrontendPageSearchResult({
     ...(routeAlias ? { routeAlias } : {}),
     ...getPageSearchAliases(keywords),
     r: SEARCH_RANK.navPage,
+    topLevelRank: SEARCH_DEPTH_RANK.topLevel,
     v: tastyMetrics[page.route] ?? 0,
     type,
     ...(hideType ? { hideType } : {}),
@@ -259,6 +276,7 @@ export function buildProtocolSearchResult({
     ...(previousNames?.length ? { previousNames: [...previousNames] } : {}),
     ...(variants.length ? { nameVariants: variants } : {}),
     r: deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.entity,
+    topLevelRank: SEARCH_DEPTH_RANK.topLevel,
     v,
     type: "Protocol",
   };
@@ -281,6 +299,7 @@ export function buildStablecoinSearchResult(
     logo: `https://icons.llamao.fi/icons/pegged/${slug}?w=48&h=48`,
     route: `/stablecoin/${slug}`,
     r: SEARCH_RANK.entity,
+    topLevelRank: SEARCH_DEPTH_RANK.topLevel,
     v: tastyMetrics[`/stablecoin/${slug}`] ?? 0,
     type: "Stablecoin",
   };
@@ -566,6 +585,7 @@ export const getProtocolSubSections = ({
     ...rest,
     v: tastyMetrics[rest.route] ?? 0,
     r: rest.r === SEARCH_RANK.deprecated ? SEARCH_RANK.deprecated : SEARCH_RANK.subPage,
+    topLevelRank: SEARCH_DEPTH_RANK.subPage,
   }));
 };
 
@@ -1347,6 +1367,7 @@ async function generateSearchList() {
         ...rest,
         v: tastyMetrics[rest.route] ?? 0,
         r: SEARCH_RANK.subPage,
+        topLevelRank: SEARCH_DEPTH_RANK.subPage,
       }))
     );
   }
@@ -1626,6 +1647,7 @@ async function generateSearchList() {
     ].map((result: any) => ({
       ...result,
       r: result.r ?? 1,
+      topLevelRank: result.topLevelRank ?? SEARCH_DEPTH_RANK.topLevel,
     })),
     directoryResults: buildDirectoryResults(tvlData, parentTvl, tastyMetrics),
     // `searchlist.json` is a small popular-results fallback, not the complete

--- a/defi/src/updateSearch.ts
+++ b/defi/src/updateSearch.ts
@@ -116,6 +116,12 @@ interface StablecoinSearchInput {
   circulating: { peggedUSD: number };
 }
 
+interface ProtocolSearchSource {
+  name: string;
+  category?: string;
+  tvl?: number | null;
+}
+
 export const PAGES_INDEX_SETTINGS = {
   searchableAttributes: [
     "alias1",
@@ -146,20 +152,20 @@ export const PAGES_INDEX_SETTINGS = {
     "symbol",
   ],
   synonyms: {
-    stable: ["stablecoin", "stablecoins"],
-    stablecoin: ["stable", "stablecoins"],
-    stablecoins: ["stable", "stablecoin"],
-    mcap: ["market cap", "marketcap"],
-    marketcap: ["market cap", "mcap"],
+    "stable": ["stablecoin", "stablecoins"],
+    "stablecoin": ["stable", "stablecoins"],
+    "stablecoins": ["stable", "stablecoin"],
+    "mcap": ["market cap", "marketcap"],
+    "marketcap": ["market cap", "mcap"],
     "market cap": ["mcap", "marketcap"],
-    tvl: ["total value locked"],
-    apy: ["yield", "yields"],
-    yield: ["apy", "yields"],
-    yields: ["apy", "yield"],
-    dex: ["dexs", "exchange"],
-    dexs: ["dex", "exchanges"],
-    cex: ["cexs", "exchange"],
-    cexs: ["cex", "exchanges"],
+    "tvl": ["total value locked"],
+    "apy": ["yield", "yields"],
+    "yield": ["apy", "yields"],
+    "yields": ["apy", "yield"],
+    "dex": ["dexs", "exchange"],
+    "dexs": ["dex", "exchanges"],
+    "cex": ["cexs", "exchange"],
+    "cexs": ["cex", "exchanges"],
   },
 } as const;
 
@@ -258,6 +264,10 @@ export function buildProtocolSearchResult({
   };
 }
 
+export function shouldSkipProtocolSearchResult(protocol: ProtocolSearchSource, chainNames: Set<string>) {
+  return protocol.category === "Canonical Bridge" && chainNames.has(protocol.name) && !protocol.tvl;
+}
+
 export function buildStablecoinSearchResult(
   stablecoin: StablecoinSearchInput,
   tastyMetrics: Record<string, number>
@@ -300,8 +310,7 @@ export function dedupeFrontendPageResults(results: SearchResult[]): SearchResult
     // the longer one into `nameVariants` so it still matches at search time,
     // and union `keywords` + recompute aliases.
     const sameName = existing.name.trim().toLowerCase() === result.name.trim().toLowerCase();
-    const [primary, secondary] =
-      result.name.length < existing.name.length ? [result, existing] : [existing, result];
+    const [primary, secondary] = result.name.length < existing.name.length ? [result, existing] : [existing, result];
 
     const nameVariants = sameName
       ? mergeKeywords(existing.nameVariants, result.nameVariants)
@@ -968,8 +977,10 @@ async function generateSearchList() {
   const protocols: Array<SearchResult> = [];
   const subProtocols: Array<SearchResult> = [];
   const metadataChainSlugs = new Set<string>();
+  const metadataChainNames = new Set<string>();
   for (const chainSlug in chainsMetadata) {
     metadataChainSlugs.add(chainSlug);
+    metadataChainNames.add(chainsMetadata[chainSlug].name);
   }
 
   // Parent protocols are first-class protocol search results. Their child
@@ -1008,6 +1019,7 @@ async function generateSearchList() {
   // added unless they hit the narrow `chain#` fallback below.
   for (const protocol of tvlData.protocols) {
     if (protocol.name === "LlamaSwap") continue;
+    if (shouldSkipProtocolSearchResult(protocol, metadataChainNames)) continue;
     const prevNames = previousNamesMap.get(protocol.name);
     const result = buildProtocolSearchResult({
       id: `protocol_${normalize(protocol.name)}`,


### PR DESCRIPTION
## Summary

This consolidates the search-list work from #11950, the protocol chain coverage work from #11949, and the follow-up Meilisearch ranking fix for subpage flooding.

- Include chains that only appear on protocol rows, even when their backing protocol is in an excluded chart category such as RWA.
- Skip zero/null-TVL canonical bridge placeholder rows from protocol search when the row name already matches a chain metadata name.
- Add a `topLevelRank` search ranking signal so protocol and chain subpages rank below distinct top-level matches.
- Keep the manual Meilisearch setup script aligned with the code-owned index settings.

## Why

The first two branches solve adjacent search-list data quality problems:

- Some chains, such as protocol-only RWA chains, can be present on `/lite/protocols2` protocol entries but absent from the top-level chain list because chart category filtering removes their TVL from the visible chain accumulator. Since search chain metadata is seeded from that top-level chain list, those chains can become undiscoverable.
- Some chain placeholder rows from `/lite/protocols2` were indexed as `Protocol` results even though the same name already exists as a proper `Chain` result from app metadata. Searching for a chain such as Solana could show duplicate Chain/Protocol entries.

The follow-up search ranking change fixes another issue exposed while testing the same search area: a query like `stab` correctly finds `STAB Protocol`, but the inherited protocol subpages (`TVL`, `Mcap`, `FDV`, token pages, etc.) could fill the next ranks before the `/stablecoins` page. `topLevelRank` keeps exact top-level entity matches first while preventing child tab docs from crowding out other strong top-level results.

## Implementation Notes

- `storeGetProtocols` now tracks chain labels directly from visible protocol rows and includes those labels in the fallback chain list used by `getVisibleChainLabels`.
- `updateSearch` now builds a metadata chain-name set and skips canonical bridge placeholder protocol rows with no TVL when a chain result already owns that name.
- Search docs now carry `topLevelRank: 1` for top-level docs and `topLevelRank: 0` for protocol/chain subpages.
- The pages index ranking rules now place `topLevelRank:desc` before `exactness`, so top-level docs beat inherited child docs before Meili compares exact string quality.
- The Meilisearch regression suite backfills `topLevelRank` when loading current prod docs into a temporary test index, allowing the new settings to be tested before prod docs are regenerated.

## Validation

- `npx jest src/updateSearch.test.ts src/storeGetProtocols.test.ts --runInBand --no-cache --watchman=false`
- `npx prettier --check src/updateSearch.ts src/updateSearch.test.ts src/updateSearch.meili.test.ts src/storeGetProtocols.ts src/storeGetProtocols.test.ts`
- `RUN_SEARCH_MEILI_TESTS=1 SEARCH_TEST_MEILI_HOST=https://search-core.defillama.com SEARCH_TEST_MEILI_KEY="$SEARCH_MASTER_KEY" SEARCH_TEST_ALLOW_VERSION_MISMATCH=1 npx jest src/updateSearch.meili.test.ts --runInBand --no-cache --watchman=false`
- `git diff --check`

Replaces #11949 and #11950.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added depth-aware search ranking to prioritize top-level pages over subpages in search results.

* **Bug Fixes**
  * Improved protocol visibility when chains come from excluded categories.
  * Enhanced fallback chain handling when dimension data is unavailable.

* **Tests**
  * Extended test coverage for search ranking behavior and protocol filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->