### PR TITLE
fix: prevent negative historical chain TVL

### DIFF
--- a/defi/src/storeGetCharts.test.ts
+++ b/defi/src/storeGetCharts.test.ts
@@ -1,8 +1,8 @@
 import { getChainDefaultChartData } from "./storeGetCharts";
 
 describe("getChainDefaultChartData", () => {
-  it("does not emit negative chain TVL from rounded excluded sections", async () => {
-    const chart = await getChainDefaultChartData({
+  it("does not emit negative chain TVL from rounded excluded sections", () => {
+    const chart = getChainDefaultChartData({
       tvl: [["1778284800", 1272372]],
       liquidstaking: [["1778284800", 1027410]],
       doublecounted: [["1778284800", 244963]],
@@ -11,13 +11,24 @@ describe("getChainDefaultChartData", () => {
     expect(chart).toEqual([{ date: 1778284800, tvl: 0 }]);
   });
 
-  it("keeps positive chain TVL after exclusions", async () => {
-    const chart = await getChainDefaultChartData({
+  it("keeps positive chain TVL after exclusions", () => {
+    const chart = getChainDefaultChartData({
       tvl: [["1778284800", 1272380]],
       liquidstaking: [["1778284800", 1027410]],
       doublecounted: [["1778284800", 244963]],
     });
 
     expect(chart).toEqual([{ date: 1778284800, tvl: 7 }]);
+  });
+
+  it("adds back overlapping liquid staking and double-counted TVL", () => {
+    const chart = getChainDefaultChartData({
+      tvl: [["1778284800", 1000000]],
+      liquidstaking: [["1778284800", 300000]],
+      doublecounted: [["1778284800", 300000]],
+      dcAndLsOverlap: [["1778284800", 300000]],
+    });
+
+    expect(chart).toEqual([{ date: 1778284800, tvl: 700000 }]);
   });
 });

--- a/defi/src/storeGetCharts.test.ts
+++ b/defi/src/storeGetCharts.test.ts
@@ -1,0 +1,23 @@
+import { getChainDefaultChartData } from "./storeGetCharts";
+
+describe("getChainDefaultChartData", () => {
+  it("does not emit negative chain TVL from rounded excluded sections", async () => {
+    const chart = await getChainDefaultChartData({
+      tvl: [["1778284800", 1272372]],
+      liquidstaking: [["1778284800", 1027410]],
+      doublecounted: [["1778284800", 244963]],
+    });
+
+    expect(chart).toEqual([{ date: 1778284800, tvl: 0 }]);
+  });
+
+  it("keeps positive chain TVL after exclusions", async () => {
+    const chart = await getChainDefaultChartData({
+      tvl: [["1778284800", 1272380]],
+      liquidstaking: [["1778284800", 1027410]],
+      doublecounted: [["1778284800", 244963]],
+    });
+
+    expect(chart).toEqual([{ date: 1778284800, tvl: 7 }]);
+  });
+});

--- a/defi/src/storeGetCharts.ts
+++ b/defi/src/storeGetCharts.ts
@@ -476,7 +476,7 @@ function roundNumbersInObject(obj: any): any {
   return obj;
 }
 
-async function getChainDefaultChartData(chartBody: any) {
+export async function getChainDefaultChartData(chartBody: any) {
   const tvl = Object.fromEntries(chartBody.tvl);
 
   chartBody.doublecounted?.forEach(([date, value]: [string, number]) => {
@@ -499,6 +499,6 @@ async function getChainDefaultChartData(chartBody: any) {
 
   return Object.entries(tvl).map((v: any) => ({
     date: Number(v[0]),
-    tvl: Number(v[1]),
+    tvl: Math.max(Number(v[1]), 0),
   }))
 }

--- a/defi/src/storeGetCharts.ts
+++ b/defi/src/storeGetCharts.ts
@@ -435,7 +435,7 @@ export async function storeGetCharts({ ...options }: any = {}) {
         const simpleChartFile = chain === "total" ? "charts-total" : `charts/${chain}`;
         await storeRouteData(simpleChartFile, simpleChartData)
 
-        const historicalTvlChartData = await getChainDefaultChartData(data)
+        const historicalTvlChartData = getChainDefaultChartData(data)
         const historicalTvlChartFile = chain === "total" ? "v2/historicalChainTvl-total" : `v2/historicalChainTvl/${chain}`;
         await storeRouteData(historicalTvlChartFile, historicalTvlChartData)
       }
@@ -476,7 +476,16 @@ function roundNumbersInObject(obj: any): any {
   return obj;
 }
 
-export async function getChainDefaultChartData(chartBody: any) {
+type ChainDefaultChartSection = [string, number][];
+
+interface ChainDefaultChartDataBody {
+  tvl: ChainDefaultChartSection;
+  doublecounted?: ChainDefaultChartSection;
+  liquidstaking?: ChainDefaultChartSection;
+  dcAndLsOverlap?: ChainDefaultChartSection;
+}
+
+export function getChainDefaultChartData(chartBody: ChainDefaultChartDataBody) {
   const tvl = Object.fromEntries(chartBody.tvl);
 
   chartBody.doublecounted?.forEach(([date, value]: [string, number]) => {
@@ -497,8 +506,8 @@ export async function getChainDefaultChartData(chartBody: any) {
     }
   });
 
-  return Object.entries(tvl).map((v: any) => ({
-    date: Number(v[0]),
-    tvl: Math.max(Number(v[1]), 0),
+  return Object.entries(tvl).map(([date, value]) => ({
+    date: Number(date),
+    tvl: Math.max(value, 0),
   }))
 }

--- a/defi/src/storeGetCharts.ts
+++ b/defi/src/storeGetCharts.ts
@@ -485,6 +485,11 @@ interface ChainDefaultChartDataBody {
   dcAndLsOverlap?: ChainDefaultChartSection;
 }
 
+/**
+ * Builds the default historical chain TVL chart after removing excluded sections,
+ * restoring overlap between liquid staking and double-counted TVL, and clamping
+ * tiny negative residuals to zero.
+ */
 export function getChainDefaultChartData(chartBody: ChainDefaultChartDataBody) {
   const tvl = Object.fromEntries(chartBody.tvl);
 


### PR DESCRIPTION
## Summary
- Clamp computed historical chain TVL at zero after subtracting excluded liquid staking and double-counted sections
- Add a regression test for rounded excluded sections producing a `-1` chain TVL residual

## Context
`/v2/historicalChainTvl/milkyway` currently emits `tvl: -1`, which renders as `-$1` on https://defillama.com/chain/milkyway. The raw chain TVL is fully offset by liquid staking and double-counted sections, and independently rounded sections can leave a tiny negative residual. Historical chain TVL schema expects non-negative values.

## Test
- `npm_config_cache=/tmp/npm-cache npx jest src/storeGetCharts.test.ts --runInBand --no-cache`

Note: `npx tsc --noEmit --pretty false --skipLibCheck` still fails on existing repo-wide type/generated-file issues unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where chart TVL (Total Value Locked) could display as negative; values are now clamped to zero to prevent negative chart points.

* **Tests**
  * Added tests covering TVL exclusion edge cases, including scenarios that clamp to zero, preserve positive remainders, and account for overlapping adjustments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11962)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->