### PR TITLE
fix(api): resolve chain chart aliases

### DIFF
--- a/defi/src/api2/routes/chainRouteAliases.test.ts
+++ b/defi/src/api2/routes/chainRouteAliases.test.ts
@@ -1,0 +1,59 @@
+import { chainChartFileResponse, getChainRouteFilePaths } from "./chainRouteAliases";
+import { readRouteData } from "../cache/file-cache";
+import { fileResponse } from "./utils";
+
+jest.mock("../cache/file-cache", () => ({
+  readRouteData: jest.fn(),
+}));
+
+jest.mock("./utils", () => ({
+  fileResponse: jest.fn(),
+}));
+
+describe("getChainRouteFilePaths", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("falls back from old chain labels to current chart file labels", () => {
+    expect(getChainRouteFilePaths("charts/Optimism")).toEqual(["charts/Optimism", "charts/OP Mainnet"]);
+    expect(getChainRouteFilePaths("v2/historicalChainTvl/xDai")).toEqual([
+      "v2/historicalChainTvl/xDai",
+      "v2/historicalChainTvl/Gnosis",
+    ]);
+    expect(getChainRouteFilePaths("lite/charts/OKExChain")).toEqual(["lite/charts/OKExChain", "lite/charts/OKTChain"]);
+  });
+
+  it("keeps non-chain routes and current labels unchanged", () => {
+    expect(getChainRouteFilePaths("chains")).toEqual(["chains"]);
+    expect(getChainRouteFilePaths("charts/OP%20Mainnet")).toEqual(["charts/OP%20Mainnet"]);
+  });
+});
+
+describe("chainChartFileResponse", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("serves the current-label file when the old-label file is missing", async () => {
+    const response = {};
+    (readRouteData as jest.Mock).mockResolvedValueOnce(null);
+
+    await chainChartFileResponse("charts/Optimism", response as any);
+
+    expect(readRouteData).toHaveBeenCalledWith("charts/Optimism", {
+      readAsArrayBuffer: true,
+      skipErrorLog: true,
+    });
+    expect(fileResponse).toHaveBeenCalledWith("charts/OP Mainnet", response);
+  });
+
+  it("uses the normal file handler when there is no alias", async () => {
+    const response = {};
+
+    await chainChartFileResponse("charts/OP%20Mainnet", response as any);
+
+    expect(readRouteData).not.toHaveBeenCalled();
+    expect(fileResponse).toHaveBeenCalledWith("charts/OP%20Mainnet", response);
+  });
+});

--- a/defi/src/api2/routes/chainRouteAliases.ts
+++ b/defi/src/api2/routes/chainRouteAliases.ts
@@ -1,0 +1,58 @@
+import * as HyperExpress from "hyper-express";
+import { chainCoingeckoIds, getChainDisplayName, getChainIdFromDisplayName } from "../../utils/normalizeChain";
+import { readRouteData } from "../cache/file-cache";
+import { fileResponse } from "./utils";
+
+const chainRoutePrefixes = ["v2/historicalChainTvl", "lite/charts", "charts"];
+
+export function getChainRouteFilePaths(routePath: string) {
+  const aliasedPath = getAliasedChainRoutePath(routePath);
+  if (!aliasedPath) return [routePath];
+  return [routePath, aliasedPath];
+}
+
+export async function chainChartFileResponse(routePath: string, res: HyperExpress.Response) {
+  const aliasedPath = getAliasedChainRoutePath(routePath);
+  if (!aliasedPath) return fileResponse(routePath, res);
+
+  const primaryData = await readRouteData(routePath, {
+    readAsArrayBuffer: true,
+    skipErrorLog: true,
+  });
+  if (primaryData) {
+    res.set('Cache-Control', 'public, max-age=600');
+    res.set('Content-Type', 'application/json');
+    return res.send(primaryData);
+  }
+
+  return fileResponse(aliasedPath, res);
+}
+
+function getAliasedChainRoutePath(routePath: string) {
+  for (const prefix of chainRoutePrefixes) {
+    const routePrefix = `${prefix}/`;
+    if (!routePath.startsWith(routePrefix)) continue;
+
+    const rawChainName = routePath.slice(routePrefix.length);
+    if (!rawChainName || rawChainName.includes("/")) return null;
+
+    const chainName = decodeRouteSegment(rawChainName);
+    if (!chainName || chainName.includes("/")) return null;
+
+    const chainKey = getChainIdFromDisplayName(chainName);
+    const chainLabel = getChainDisplayName(chainKey, true);
+    if (chainLabel === chainName || chainCoingeckoIds[chainLabel] === undefined) return null;
+
+    return `${prefix}/${chainLabel}`;
+  }
+
+  return null;
+}
+
+function decodeRouteSegment(segment: string) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -35,6 +35,8 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   // todo add logging middleware to all routes
   // router.get("/config/:chain/:contract", ew(getContractName));  // too many requests to handle here
   // add secret route to delete from PG cache
+  const defaultFileHandler = createFileHandler(fileResponse);
+  const chainChartFileHandler = createFileHandler(chainChartFileResponse);
 
   router.get("/protocol/:name", ew(async (req: any, res: any) => getProtocolishData(req, res, {
     dataType: 'protocol', skipAggregatedTvl: false, useNewChainNames: false, restrictResponseSize: req.query_parameters.restrictResponseSize !== 'false'
@@ -211,24 +213,15 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.post("/historicalLiquidity/:token", ew(getHistoricalLiquidityHandler)) // TODO: ensure that env vars are set
 
 
-  function defaultFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
-    const fullPath = req.path;
-    const routerPath = fullPath.replace(routerBasePath, '');
-    const sanitizedPath = sanitizeRoutePath(routerPath);
-    if (!sanitizedPath) {
-      return errorResponse(res, 'Invalid path', { statusCode: 400 });
+  function createFileHandler(responseHandler: (filePath: string, res: HyperExpress.Response) => any) {
+    return function routeFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
+      const routerPath = req.path.replace(routerBasePath, '');
+      const sanitizedPath = sanitizeRoutePath(routerPath);
+      if (!sanitizedPath) {
+        return errorResponse(res, 'Invalid path', { statusCode: 400 });
+      }
+      return responseHandler(sanitizedPath, res);
     }
-    return fileResponse(sanitizedPath, res);
-  }
-
-  function chainChartFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
-    const fullPath = req.path;
-    const routerPath = fullPath.replace(routerBasePath, '');
-    const sanitizedPath = sanitizeRoutePath(routerPath);
-    if (!sanitizedPath) {
-      return errorResponse(res, 'Invalid path', { statusCode: 400 });
-    }
-    return chainChartFileResponse(sanitizedPath, res);
   }
 
   function sanitizeRoutePath(filePath: string): string | null {

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -82,6 +82,7 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/cexs", (_: any, res: HyperExpress.Response) => fileResponse('cex_agg', res));
 
 
+  router.post("/inflows/batch", ew(getBatchInflows))
   router.get("/inflows/:protocol/:timestamp", ew(getInflows))
   router.get("/lite/protocols2", defaultFileHandler);
   router.get("/lite/v2/protocols", defaultFileHandler);
@@ -465,6 +466,8 @@ type R2DataOptions = {
   res?: HyperExpress.Response;
 }
 
+const MAX_BATCH_INFLOW_PROTOCOLS = 100
+
 async function returnR2Data({ endpoint, parseJson = true, errorMessage, cacheMinutes = 30, res }: R2DataOptions) {
   try {
     const response = await getR2(endpoint);
@@ -477,6 +480,67 @@ async function returnR2Data({ endpoint, parseJson = true, errorMessage, cacheMin
   } catch (e) {
     return errorResponse(res!, errorMessage ?? 'no data')
   }
+}
+
+async function getBatchInflows(req: HyperExpress.Request, res: HyperExpress.Response) {
+  const rawBody = req.body ?? (await req.text());
+  let body: any;
+  try {
+    body = typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody
+  } catch {
+    return errorResponse(res, "Invalid JSON body")
+  }
+
+  const startTimestamp = Number(body?.startTimestamp);
+  const endTimestamp = body?.endTimestamp == null ? undefined : Number(body.endTimestamp);
+  const protocols = body?.protocols;
+
+  if (!Number.isFinite(startTimestamp)) return errorResponse(res, "Invalid startTimestamp")
+  if (endTimestamp !== undefined && !Number.isFinite(endTimestamp)) return errorResponse(res, "Invalid endTimestamp")
+  if (!Array.isArray(protocols) || protocols.length === 0) return errorResponse(res, "No protocols provided")
+  if (protocols.length > MAX_BATCH_INFLOW_PROTOCOLS)
+    return errorResponse(res, `Too many protocols, max ${MAX_BATCH_INFLOW_PROTOCOLS}`, { statusCode: 413 })
+
+  const ids: { id: string; tokensToExclude: string[] }[] = [];
+  const protocolById: { [id: string]: string } = {};
+  const seenProtocolIds = new Set<string>();
+
+  for (const item of protocols) {
+    if (!item || typeof item.protocol !== "string" || item.protocol.length === 0)
+      return errorResponse(res, "Invalid protocol item")
+
+    const name = sluggify({ name: item.protocol } as any);
+    const protocolData = cache.protocolSlugMap[name];
+    if (!protocolData) continue;
+
+    if (seenProtocolIds.has(protocolData.id))
+      return errorResponse(res, `Duplicate protocol: ${item.protocol}`)
+    seenProtocolIds.add(protocolData.id)
+
+    let tokensToExclude: string[] = [];
+    if (Array.isArray(item.tokensToExclude)) {
+      tokensToExclude = item.tokensToExclude.filter((token: unknown): token is string => typeof token === "string");
+    } else if (typeof item.tokensToExclude === "string" && item.tokensToExclude) {
+      tokensToExclude = item.tokensToExclude.split(",");
+    }
+
+    ids.push({ id: protocolData.id, tokensToExclude });
+    protocolById[protocolData.id] = item.protocol;
+  }
+
+  const inflows = await pgGetInflows({
+    ids,
+    startTimestamp,
+    endTimestamp,
+  })
+
+  const response: { [protocol: string]: any } = {};
+  for (const id in inflows) {
+    const protocol = protocolById[id];
+    if (protocol) response[protocol] = inflows[id];
+  }
+
+  return successResponse(res, response, 60);
 }
 
 function r2Wrapper({ endpoint, parseJson, errorMessage, cacheMinutes, }: R2DataOptions) {

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -82,7 +82,6 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   router.get("/cexs", (_: any, res: HyperExpress.Response) => fileResponse('cex_agg', res));
 
 
-  router.post("/inflows/batch", ew(getBatchInflows))
   router.get("/inflows/:protocol/:timestamp", ew(getInflows))
   router.get("/lite/protocols2", defaultFileHandler);
   router.get("/lite/v2/protocols", defaultFileHandler);
@@ -214,44 +213,31 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   function defaultFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
     const fullPath = req.path;
     const routerPath = fullPath.replace(routerBasePath, '');
-    const sanitizedPath = sanitizePath(routerPath);
+    const sanitizedPath = sanitizeRoutePath(routerPath);
     if (!sanitizedPath) {
       return errorResponse(res, 'Invalid path', { statusCode: 400 });
     }
     return fileResponse(sanitizedPath, res);
-
-
-    function sanitizePath(filePath: string): string | null {
-      // Remove leading slash and normalize the path
-      const normalizedPath = path.normalize(filePath.replace(/^\/+/, ''));
-
-      // Check for path traversal attempts
-      if (normalizedPath.includes('..') || normalizedPath.startsWith('/') || path.isAbsolute(normalizedPath)) {
-        return null;
-      }
-
-      return normalizedPath;
-    }
   }
 
   function chainChartFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
     const fullPath = req.path;
     const routerPath = fullPath.replace(routerBasePath, '');
-    const sanitizedPath = sanitizePath(routerPath);
+    const sanitizedPath = sanitizeRoutePath(routerPath);
     if (!sanitizedPath) {
       return errorResponse(res, 'Invalid path', { statusCode: 400 });
     }
     return chainChartFileResponse(sanitizedPath, res);
+  }
 
-    function sanitizePath(filePath: string): string | null {
-      const normalizedPath = path.normalize(filePath.replace(/^\/+/, ''));
+  function sanitizeRoutePath(filePath: string): string | null {
+    const normalizedPath = path.normalize(filePath.replace(/^\/+/, ''));
 
-      if (normalizedPath.includes('..') || normalizedPath.startsWith('/') || path.isAbsolute(normalizedPath)) {
-        return null;
-      }
-
-      return normalizedPath;
+    if (normalizedPath.includes('..') || normalizedPath.startsWith('/') || path.isAbsolute(normalizedPath)) {
+      return null;
     }
+
+    return normalizedPath;
   }
 
   function configRouteResponse(_req: HyperExpress.Request, res: HyperExpress.Response) {
@@ -479,8 +465,6 @@ type R2DataOptions = {
   res?: HyperExpress.Response;
 }
 
-const MAX_BATCH_INFLOW_PROTOCOLS = 100
-
 async function returnR2Data({ endpoint, parseJson = true, errorMessage, cacheMinutes = 30, res }: R2DataOptions) {
   try {
     const response = await getR2(endpoint);
@@ -493,67 +477,6 @@ async function returnR2Data({ endpoint, parseJson = true, errorMessage, cacheMin
   } catch (e) {
     return errorResponse(res!, errorMessage ?? 'no data')
   }
-}
-
-async function getBatchInflows(req: HyperExpress.Request, res: HyperExpress.Response) {
-  const rawBody = req.body ?? (await req.text());
-  let body: any;
-  try {
-    body = typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody
-  } catch {
-    return errorResponse(res, "Invalid JSON body")
-  }
-
-  const startTimestamp = Number(body?.startTimestamp);
-  const endTimestamp = body?.endTimestamp == null ? undefined : Number(body.endTimestamp);
-  const protocols = body?.protocols;
-
-  if (!Number.isFinite(startTimestamp)) return errorResponse(res, "Invalid startTimestamp")
-  if (endTimestamp !== undefined && !Number.isFinite(endTimestamp)) return errorResponse(res, "Invalid endTimestamp")
-  if (!Array.isArray(protocols) || protocols.length === 0) return errorResponse(res, "No protocols provided")
-  if (protocols.length > MAX_BATCH_INFLOW_PROTOCOLS)
-    return errorResponse(res, `Too many protocols, max ${MAX_BATCH_INFLOW_PROTOCOLS}`, { statusCode: 413 })
-
-  const ids: { id: string; tokensToExclude: string[] }[] = [];
-  const protocolById: { [id: string]: string } = {};
-  const seenProtocolIds = new Set<string>();
-
-  for (const item of protocols) {
-    if (!item || typeof item.protocol !== "string" || item.protocol.length === 0)
-      return errorResponse(res, "Invalid protocol item")
-
-    const name = sluggify({ name: item.protocol } as any);
-    const protocolData = cache.protocolSlugMap[name];
-    if (!protocolData) continue;
-
-    if (seenProtocolIds.has(protocolData.id))
-      return errorResponse(res, `Duplicate protocol: ${item.protocol}`)
-    seenProtocolIds.add(protocolData.id)
-
-    let tokensToExclude: string[] = [];
-    if (Array.isArray(item.tokensToExclude)) {
-      tokensToExclude = item.tokensToExclude.filter((token: unknown): token is string => typeof token === "string");
-    } else if (typeof item.tokensToExclude === "string" && item.tokensToExclude) {
-      tokensToExclude = item.tokensToExclude.split(",");
-    }
-
-    ids.push({ id: protocolData.id, tokensToExclude });
-    protocolById[protocolData.id] = item.protocol;
-  }
-
-  const inflows = await pgGetInflows({
-    ids,
-    startTimestamp,
-    endTimestamp,
-  })
-
-  const response: { [protocol: string]: any } = {};
-  for (const id in inflows) {
-    const protocol = protocolById[id];
-    if (protocol) response[protocol] = inflows[id];
-  }
-
-  return successResponse(res, response, 60);
 }
 
 function r2Wrapper({ endpoint, parseJson, errorMessage, cacheMinutes, }: R2DataOptions) {

--- a/defi/src/api2/routes/index.ts
+++ b/defi/src/api2/routes/index.ts
@@ -29,6 +29,7 @@ import { saveEvent } from "../../dexAggregators/db/saveEvent";
 import { reportError } from "../../reportError";
 import { reportError as reportSupport } from "../../reportSupport";
 import { saveBlacklistPemrit } from "../../dexAggregators/db/saveBlacklistPemrit";
+import { chainChartFileResponse } from "./chainRouteAliases";
 
 export default function setRoutes(router: HyperExpress.Router, routerBasePath: string) {
   // todo add logging middleware to all routes
@@ -66,7 +67,7 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   // router.get("/rwa/historical/:name", ew(async (req: any, res: any) => rwaChartHandler(req, res)));
   router.get("/categories", defaultFileHandler);
   router.get("/langs", defaultFileHandler);
-  router.get("/lite/charts/:chain", defaultFileHandler);
+  router.get("/lite/charts/:chain", chainChartFileHandler);
   // router.get("/lite/charts/categories/:category", defaultFileHandler); // deprecated, replaced by getCategoryChartByChainData - used to be a r2 wrapper
   router.get("/lite/chains-by-categories", defaultFileHandler);
   router.get("/lite/chains-by-tags", defaultFileHandler);
@@ -107,9 +108,9 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
   // router.get("/chain-assets/historical-flows/:chain/:period", ew(async (req: any, res: any) => chainAssetsHandler(req, res, { isFlows: true, isHistorical: true })));
 
   router.get("/charts", v1ChartsGlobalResponse)
-  router.get("/charts/:name", defaultFileHandler)
+  router.get("/charts/:name", chainChartFileHandler)
   router.get("/v2/historicalChainTvl", historicalChainTvlGlobalResponse)
-  router.get("/v2/historicalChainTvl/:name", defaultFileHandler)
+  router.get("/v2/historicalChainTvl/:name", chainChartFileHandler)
 
   router.get("/overview/:type", ew(getOverviewFileRoute))
   router.get("/overview/:type/:chain", ew(getOverviewFileRoute))
@@ -225,6 +226,26 @@ export default function setRoutes(router: HyperExpress.Router, routerBasePath: s
       const normalizedPath = path.normalize(filePath.replace(/^\/+/, ''));
 
       // Check for path traversal attempts
+      if (normalizedPath.includes('..') || normalizedPath.startsWith('/') || path.isAbsolute(normalizedPath)) {
+        return null;
+      }
+
+      return normalizedPath;
+    }
+  }
+
+  function chainChartFileHandler(req: HyperExpress.Request, res: HyperExpress.Response) {
+    const fullPath = req.path;
+    const routerPath = fullPath.replace(routerBasePath, '');
+    const sanitizedPath = sanitizePath(routerPath);
+    if (!sanitizedPath) {
+      return errorResponse(res, 'Invalid path', { statusCode: 400 });
+    }
+    return chainChartFileResponse(sanitizedPath, res);
+
+    function sanitizePath(filePath: string): string | null {
+      const normalizedPath = path.normalize(filePath.replace(/^\/+/, ''));
+
       if (normalizedPath.includes('..') || normalizedPath.startsWith('/') || path.isAbsolute(normalizedPath)) {
         return null;
       }


### PR DESCRIPTION
## Summary

- Resolve old chain labels to current chain labels when serving generated chain chart files.
- Apply alias fallback only to the three affected chart routes: `/charts/:name`, `/lite/charts/:chain`, and `/v2/historicalChainTvl/:name`.
- Keep the shared `fileResponse(filePath: string, res)` utility unchanged to avoid widening the blast radius for unrelated routes.
- Suppress expected old-label cache misses before trying the current-label fallback.

## Current live issue

These old-label routes currently 404 even though their current-label files exist:

- `/charts/Optimism` -> `/charts/OP Mainnet`
- `/v2/historicalChainTvl/xDai` -> `/v2/historicalChainTvl/Gnosis`
- `/lite/charts/OKExChain` -> `/lite/charts/OKTChain`

The same old-label mismatch affects other renamed chains such as Klaytn/Kaia, Fuel/Fuel Ignition, EOS/Vaulta, Gravity/Gravity by Galxe, and others.

## Regression coverage

The focused regression test suite now checks all important cases:

- Old-label route paths produce current-label fallback paths, e.g. `Optimism -> OP Mainnet`, `xDai -> Gnosis`, and `OKExChain -> OKTChain`.
- Current-label paths and unrelated routes do not get rewritten.
- A missing old-label chart file is retried via the current-label file path.
- A route with no alias goes through the normal file handler without extra cache reads.

## Testing

```bash
cd defi
npm test -- chainRouteAliases.test.ts --runInBand
```

Result: 1 suite / 4 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart endpoints (/lite/charts, /charts, /v2/historicalChainTvl) now transparently fall back to current normalized chain labels for legacy requests, improving compatibility and ensuring chart responses when old-label requests arrive.

* **Tests**
  * Added tests verifying label rewriting and fallback behavior for chain chart requests, including missing-file fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11974)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->