### PR TITLE
fix(protocol): set Hashlock Markets URL (id 7822)

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -2404,7 +2404,7 @@ const data6: Protocol[] = [
     name: "Hashlock Markets",
     address: null,
     symbol: "-",
-    url: " ", // pending to add url https://hashlock.markets
+    url: "https://hashlock.markets",
     description: "Hashlock Markets is an RFQ-based DEX where users create swap intents, market makers submit sealed bids, and winning quotes settle non-custodially through HTLC atomic swaps",
     chain: "Ethereum",
     logo: `${baseIconsUrl}/hashlock-markets.jpg`,


### PR DESCRIPTION
## Summary
The Hashlock Markets entry in \`defi/src/protocols/data6.ts\` (id 7822) has \`url: \" \"\` (single-space placeholder) with an inline TODO \`// pending to add url https://hashlock.markets\`. The protocol is live; wiring in the canonical homepage.

## Verification
\`\`\`
$ curl -s https://api.llama.fi/protocol/hashlock-markets | jq '{name, url, twitter}'
{
  "name": "Hashlock Markets",
  "url": " ",
  "twitter": "HashlockMarkets"
}
\`\`\`
After this PR + next deploy, the Website link on \`defillama.com/protocol/hashlock-markets\` will resolve to https://hashlock.markets.

## Scope
- Single-line change: \`url: \" \"\` → \`url: \"https://hashlock.markets\"\`
- Removes the stale inline TODO comment
- No other fields touched (description, tags, chains, dimensions left as-is)

## Related
- Adapter: \`dexs/hashlock-markets/\` in DefiLlama/dimension-adapters (PR #6778, merged 2026-05-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Hashlock Markets protocol entry with the actual marketplace URL.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11987)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->