### PR TITLE
Support forex perps asset class filters

### DIFF
--- a/defi/src/rwa/perps/aggregate.ts
+++ b/defi/src/rwa/perps/aggregate.ts
@@ -45,7 +45,9 @@ const OVERVIEW_BREAKDOWNS_BY_TARGET = {
   all: ["venue", "assetGroup", "assetClass", "baseAsset"],
   venue: ["assetGroup", "assetClass", "baseAsset"],
   assetGroup: ["venue", "assetClass", "baseAsset"],
-} satisfies Record<"all" | "venue" | "assetGroup", PerpsOverviewBreakdown[]>;
+  assetClass: ["venue", "assetGroup", "assetClass", "baseAsset"],
+  excludeAssetClass: ["venue", "assetGroup", "assetClass", "baseAsset"],
+} satisfies Record<"all" | "venue" | "assetGroup" | "assetClass" | "excludeAssetClass", PerpsOverviewBreakdown[]>;
 
 function getMetadataMap(metadata: MetadataRecord[]) {
   const metadataMap = new Map<string, MetadataPayload>();
@@ -260,6 +262,7 @@ export function buildOverviewBreakdownCharts(
   const charts: Record<string, PerpsBreakdownChartRow[]> = {};
   const rowsByVenue = buildGroupMap(rows, (row) => perpsSlug(row.venue));
   const rowsByAssetGroup = buildGroupMap(rows, (row) => perpsSlug(getAssetGroupLabel(row)));
+  const rowsByAssetClass = buildGroupMap(rows, (row) => perpsSlug(getAssetClassLabel(row)));
 
   for (const metric of BREAKDOWN_METRIC_KEYS) {
     for (const breakdown of OVERVIEW_BREAKDOWNS_BY_TARGET.all) {
@@ -288,6 +291,26 @@ export function buildOverviewBreakdownCharts(
     }
   }
 
+  for (const assetClassSlug in rowsByAssetClass) {
+    const assetClassRows = rowsByAssetClass[assetClassSlug];
+    for (const metric of BREAKDOWN_METRIC_KEYS) {
+      for (const breakdown of OVERVIEW_BREAKDOWNS_BY_TARGET.assetClass) {
+        charts[`overview-breakdown/assetclass/${assetClassSlug}/${metric.toLowerCase()}/${breakdown.toLowerCase()}.json`] =
+          buildBreakdownChartRows(assetClassRows, metric, (row) => toOverviewSeriesLabel(row, breakdown));
+      }
+    }
+  }
+
+  for (const assetClassSlug in rowsByAssetClass) {
+    const filteredRows = rows.filter((row) => perpsSlug(getAssetClassLabel(row)) !== assetClassSlug);
+    for (const metric of BREAKDOWN_METRIC_KEYS) {
+      for (const breakdown of OVERVIEW_BREAKDOWNS_BY_TARGET.excludeAssetClass) {
+        charts[`overview-breakdown/excludeassetclass/${assetClassSlug}/${metric.toLowerCase()}/${breakdown.toLowerCase()}.json`] =
+          buildBreakdownChartRows(filteredRows, metric, (row) => toOverviewSeriesLabel(row, breakdown));
+      }
+    }
+  }
+
   return charts;
 }
 
@@ -299,6 +322,7 @@ export function buildContractBreakdownCharts(
   const charts: Record<string, PerpsBreakdownChartRow[]> = {};
   const rowsByVenue = buildGroupMap(rows, (row) => perpsSlug(row.venue));
   const rowsByAssetGroup = buildGroupMap(rows, (row) => perpsSlug(getAssetGroupLabel(row)));
+  const rowsByAssetClass = buildGroupMap(rows, (row) => perpsSlug(getAssetClassLabel(row)));
 
   for (const metric of BREAKDOWN_METRIC_KEYS) {
     charts[`contract-breakdown/all/${metric.toLowerCase()}.json`] = buildBreakdownChartRows(
@@ -327,6 +351,25 @@ export function buildContractBreakdownCharts(
         metric,
         getContractLabel
       );
+    }
+  }
+
+  for (const assetClassSlug in rowsByAssetClass) {
+    const assetClassRows = rowsByAssetClass[assetClassSlug];
+    for (const metric of BREAKDOWN_METRIC_KEYS) {
+      charts[`contract-breakdown/assetclass/${assetClassSlug}/${metric.toLowerCase()}.json`] = buildBreakdownChartRows(
+        assetClassRows,
+        metric,
+        getContractLabel
+      );
+    }
+  }
+
+  for (const assetClassSlug in rowsByAssetClass) {
+    const filteredRows = rows.filter((row) => perpsSlug(getAssetClassLabel(row)) !== assetClassSlug);
+    for (const metric of BREAKDOWN_METRIC_KEYS) {
+      charts[`contract-breakdown/excludeassetclass/${assetClassSlug}/${metric.toLowerCase()}.json`] =
+        buildBreakdownChartRows(filteredRows, metric, getContractLabel);
     }
   }
 

--- a/defi/src/rwa/perps/perps.test.ts
+++ b/defi/src/rwa/perps/perps.test.ts
@@ -679,6 +679,13 @@ describe("buildOverviewBreakdownCharts", () => {
     expect(result["overview-breakdown/assetgroup/unknown/openinterest/baseasset.json"]).toEqual([
       { timestamp: 200, Bond: 5 },
     ]);
+    expect(result["overview-breakdown/assetclass/single-stock-synthetic-perp/openinterest/venue.json"]).toEqual([
+      { timestamp: 100, xyz: 10 },
+      { timestamp: 200, xyz: 12 },
+    ]);
+    expect(result["overview-breakdown/excludeassetclass/single-stock-synthetic-perp/openinterest/assetgroup.json"]).toEqual([
+      { timestamp: 200, Commodities: 7, Unknown: 5 },
+    ]);
   });
 
   it("omits zero-only pre-launch breakdown keys and keeps post-start zeroes", () => {
@@ -748,6 +755,7 @@ describe("buildContractBreakdownCharts", () => {
             contract: "xyz:META",
             venue: "xyz",
             referenceAssetGroup: "US Equities",
+            assetClass: ["Single stock synthetic perp"],
           },
         },
         {
@@ -756,6 +764,7 @@ describe("buildContractBreakdownCharts", () => {
             contract: "flx:GOLD",
             venue: "flx",
             referenceAssetGroup: "Commodities",
+            assetClass: ["Commodity synthetic perp"],
           },
         },
       ]
@@ -771,6 +780,13 @@ describe("buildContractBreakdownCharts", () => {
     ]);
     expect(result["contract-breakdown/assetgroup/commodities/volume24h.json"]).toEqual([
       { timestamp: 200, "flx:GOLD": 2 },
+    ]);
+    expect(result["contract-breakdown/assetclass/single-stock-synthetic-perp/openinterest.json"]).toEqual([
+      { timestamp: 100, "xyz:META": 10 },
+      { timestamp: 200, "xyz:META": 12 },
+    ]);
+    expect(result["contract-breakdown/excludeassetclass/single-stock-synthetic-perp/openinterest.json"]).toEqual([
+      { timestamp: 200, "flx:GOLD": 7 },
     ]);
   });
 
@@ -875,7 +891,14 @@ describe("server route helpers", () => {
     expect(parsePerpsChartTarget({})).toEqual({ kind: "all" });
     expect(parsePerpsChartTarget({ venue: " XYZ " })).toEqual({ kind: "venue", slug: "xyz" });
     expect(parsePerpsChartTarget({ assetGroup: "US Equities" })).toEqual({ kind: "assetGroup", slug: "us-equities" });
+    expect(parsePerpsChartTarget({ assetClass: "Forex Perps" })).toEqual({ kind: "assetClass", slug: "forex-perps" });
+    expect(parsePerpsChartTarget({ excludeAssetClass: "Forex Perps" })).toEqual({
+      kind: "excludeAssetClass",
+      slug: "forex-perps",
+    });
     expect(parsePerpsChartTarget({ venue: "xyz", assetGroup: "us-equities" })).toBeNull();
+    expect(parsePerpsChartTarget({ venue: "xyz", assetClass: "forex-perps" })).toBeNull();
+    expect(parsePerpsChartTarget({ assetClass: "forex-perps", excludeAssetClass: "forex-perps" })).toBeNull();
   });
 
   it("builds cached breakdown file paths and rejects invalid combinations", () => {
@@ -901,6 +924,44 @@ describe("server route helpers", () => {
         key: "volume24h",
       })
     ).toBe("charts/contract-breakdown/assetgroup/us-equities/volume24h.json");
+
+    expect(
+      getPerpsOverviewBreakdownFilePath({
+        target: { kind: "assetClass", slug: "forex-perps" },
+        key: "openInterest",
+        breakdown: "assetGroup",
+      })
+    ).toBe("charts/overview-breakdown/assetclass/forex-perps/openinterest/assetgroup.json");
+
+    expect(
+      getPerpsOverviewBreakdownFilePath({
+        target: { kind: "assetClass", slug: "forex-perps" },
+        key: "openInterest",
+        breakdown: "assetClass",
+      })
+    ).toBe("charts/overview-breakdown/assetclass/forex-perps/openinterest/assetclass.json");
+
+    expect(
+      getPerpsContractBreakdownFilePath({
+        target: { kind: "assetClass", slug: "forex-perps" },
+        key: "markets",
+      })
+    ).toBe("charts/contract-breakdown/assetclass/forex-perps/markets.json");
+
+    expect(
+      getPerpsOverviewBreakdownFilePath({
+        target: { kind: "excludeAssetClass", slug: "forex-perps" },
+        key: "openInterest",
+        breakdown: "assetGroup",
+      })
+    ).toBe("charts/overview-breakdown/excludeassetclass/forex-perps/openinterest/assetgroup.json");
+
+    expect(
+      getPerpsContractBreakdownFilePath({
+        target: { kind: "excludeAssetClass", slug: "forex-perps" },
+        key: "markets",
+      })
+    ).toBe("charts/contract-breakdown/excludeassetclass/forex-perps/markets.json");
 
     expect(
       getPerpsContractBreakdownFilePath({

--- a/defi/src/rwa/perps/server-helpers.ts
+++ b/defi/src/rwa/perps/server-helpers.ts
@@ -7,12 +7,16 @@ export type PerpsOverviewBreakdown = "venue" | "assetGroup" | "assetClass" | "ba
 export type PerpsChartTarget =
   | { kind: "all" }
   | { kind: "venue"; slug: string }
-  | { kind: "assetGroup"; slug: string };
+  | { kind: "assetGroup"; slug: string }
+  | { kind: "assetClass"; slug: string }
+  | { kind: "excludeAssetClass"; slug: string };
 
 const OVERVIEW_BREAKDOWNS_BY_TARGET = {
   all: new Set<PerpsOverviewBreakdown>(["venue", "assetGroup", "assetClass", "baseAsset"]),
   venue: new Set<PerpsOverviewBreakdown>(["assetGroup", "assetClass", "baseAsset"]),
   assetGroup: new Set<PerpsOverviewBreakdown>(["venue", "assetClass", "baseAsset"]),
+  assetClass: new Set<PerpsOverviewBreakdown>(["venue", "assetGroup", "assetClass", "baseAsset"]),
+  excludeAssetClass: new Set<PerpsOverviewBreakdown>(["venue", "assetGroup", "assetClass", "baseAsset"]),
 };
 
 export function normalizePerpsAssetGroup(value: unknown): string {
@@ -97,6 +101,10 @@ function buildTargetPath(target: PerpsChartTarget): string {
       return `venue/${target.slug}`;
     case "assetGroup":
       return `assetgroup/${target.slug}`;
+    case "assetClass":
+      return `assetclass/${target.slug}`;
+    case "excludeAssetClass":
+      return `excludeassetclass/${target.slug}`;
     default:
       return "all";
   }
@@ -105,13 +113,24 @@ function buildTargetPath(target: PerpsChartTarget): string {
 export function parsePerpsChartTarget(params: {
   venue?: unknown;
   assetGroup?: unknown;
+  assetClass?: unknown;
+  excludeAssetClass?: unknown;
 }): PerpsChartTarget | null {
   const venueSlug = normalizeTargetParam(params.venue);
   const assetGroupSlug = normalizeTargetParam(params.assetGroup);
+  const assetClassSlug = normalizeTargetParam(params.assetClass);
+  const excludeAssetClassSlug = normalizeTargetParam(params.excludeAssetClass);
 
-  if (venueSlug && assetGroupSlug) return null;
+  const targetCount =
+    Number(Boolean(venueSlug)) +
+    Number(Boolean(assetGroupSlug)) +
+    Number(Boolean(assetClassSlug)) +
+    Number(Boolean(excludeAssetClassSlug));
+  if (targetCount > 1) return null;
   if (venueSlug) return { kind: "venue", slug: venueSlug };
   if (assetGroupSlug) return { kind: "assetGroup", slug: assetGroupSlug };
+  if (assetClassSlug) return { kind: "assetClass", slug: assetClassSlug };
+  if (excludeAssetClassSlug) return { kind: "excludeAssetClass", slug: excludeAssetClassSlug };
   return { kind: "all" };
 }
 

--- a/defi/src/rwa/perps/server.ts
+++ b/defi/src/rwa/perps/server.ts
@@ -166,6 +166,8 @@ export function setRoutes(router: HyperExpress.Router): void {
             const target = parsePerpsChartTarget({
                 venue: req.query.venue,
                 assetGroup: req.query.assetGroup,
+                assetClass: req.query.assetClass,
+                excludeAssetClass: req.query.excludeAssetClass,
             });
             if (!target) return errorResponse(res, 'Invalid target query parameters', 400);
 
@@ -186,6 +188,8 @@ export function setRoutes(router: HyperExpress.Router): void {
             const target = parsePerpsChartTarget({
                 venue: req.query.venue,
                 assetGroup: req.query.assetGroup,
+                assetClass: req.query.assetClass,
+                excludeAssetClass: req.query.excludeAssetClass,
             });
             if (!target) return errorResponse(res, 'Invalid target query parameters', 400);
 


### PR DESCRIPTION
## Summary
- add assetClass and excludeAssetClass support to RWA perps chart dataset aggregation
- generate cached chart outputs for asset-class include/exclude variants
- add coverage for Forex Perps-only and Forex-excluded time-series datasets

## Tests
- ./node_modules/.bin/jest src/rwa/perps/perps.test.ts --runInBand --no-watchman