### PR TITLE
Added Chainlink as primary oracle for Makina

### DIFF
--- a/defi/src/protocols/data5.ts
+++ b/defi/src/protocols/data5.ts
@@ -1630,6 +1630,13 @@ const data5: Protocol[] = [
     category: "Onchain Capital Allocator",
     chains: ["Ethereum"],
     audit_links: ["https://docs.makina.finance/concepts/security/audits"],
+    oraclesBreakdown: [
+      {
+        name: "Chainlink",
+        type: "Primary",
+        proof: ["https://docs.makina.finance/concepts/oracle-registry", "https://docs.makina.finance/contracts/core/interfaces/IOracleRegistry.sol/interface.IOracleRegistry", "https://dune.com/makinafi/makina#oracle-registry"],
+      },
+    ],
     module: "makina-finance/index.js",
     twitter: "makinafi",
     github: ["MakinaHQ"],


### PR DESCRIPTION
Hello DefiLlama team!

This PR adds Chainlink as the primary oracle for Makina. Makina relies on its Oracle Registry to source asset prices, which are used in critical protocol logic including collateral valuation, liquidations, and solvency/risk checks. A majority of these price feeds are sourced from Chainlink. Because these prices directly determine user collateral value and liquidation conditions, incorrect or manipulated oracle data could lead to bad debt or loss of funds. As such, Chainlink is a critical security dependency for the portion of Makina TVS that relies on these feeds.

Evidence:
- https://docs.makina.finance/concepts/oracle-registry
- https://docs.makina.finance/contracts/core/interfaces/IOracleRegistry.sol/interface.IOracleRegistry
- https://dune.com/makinafi/makina#oracle-registry

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle breakdown information for the Makina protocol, including Chainlink oracle details with reference links.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11989)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->