### PR TITLE
Correct Flying Tulip ftUSD description (stablecoin, not yield-bearing)

### DIFF
--- a/defi/src/protocols/data6.ts
+++ b/defi/src/protocols/data6.ts
@@ -1097,7 +1097,7 @@ const data6: Protocol[] = [
     address: null,
     symbol: "-",
     url: "https://flyingtulip.com/",
-    description: "ftUSD is a yield-bearing stablecoin backed by USDC, USDT and ftUSD-wrapped collateral deployed via MintAndRedeem into Aave yield strategies. Holders can stake into sftUSD to earn FT rewards funded by protocol fees that buy FT on the open market.",
+    description: "ftUSD is a stablecoin backed by USDC, USDT and ftUSD-wrapped collateral deployed via MintAndRedeem into Aave yield strategies. Holders can stake into sftUSD (the yield-bearing form) to earn FT rewards funded by protocol fees that buy FT on the open market.",
     chain: "Ethereum",
     logo: `${baseIconsUrl}/flying-tulip-ftusd.jpg`,
     audits: "2",


### PR DESCRIPTION
## Summary

Small wording fix on the Flying Tulip ftUSD protocol entry (id 7759).

ftUSD is a stablecoin. **sftUSD** is the yield-bearing form — it's the staked variant that receives FT rewards funded by protocol fees buying FT on the open market via the EpochRewardsVault. The current description conflates the two and reads as if ftUSD itself pays yield, which it does not.

## Diff

\`\`\`diff
- description: "ftUSD is a yield-bearing stablecoin backed by USDC, USDT and ftUSD-wrapped collateral deployed via MintAndRedeem into Aave yield strategies. Holders can stake into sftUSD to earn FT rewards funded by protocol fees that buy FT on the open market.",
+ description: "ftUSD is a stablecoin backed by USDC, USDT and ftUSD-wrapped collateral deployed via MintAndRedeem into Aave yield strategies. Holders can stake into sftUSD (the yield-bearing form) to earn FT rewards funded by protocol fees that buy FT on the open market.",
\`\`\`

No other fields change. Module path, dimensions, chains, category, parent are all unchanged.