### PR TITLE
stop tracking euler bsc for failures

### DIFF
--- a/coins/src/adapters/moneyMarkets/euler/index.ts
+++ b/coins/src/adapters/moneyMarkets/euler/index.ts
@@ -36,12 +36,12 @@ const v2ChainConfigs = {
     fromBlock: 786314,
     vaultCount: 0,
   },
-  bsc: {
-    factory: "0x7F53E2755eB3c43824E162F7F6F087832B9C9Df6",
-    vaultLens: "0xBfD019C90e8Ca8286f9919DF31c25BF989C6bD46",
-    fromBlock: 46370655,
-    vaultCount: 58,
-  },
+  // bsc: {
+  //   factory: "0x7F53E2755eB3c43824E162F7F6F087832B9C9Df6",
+  //   vaultLens: "0xBfD019C90e8Ca8286f9919DF31c25BF989C6bD46",
+  //   fromBlock: 46370655,
+  //   vaultCount: 58,
+  // },
   base: {
     factory: "0x7F321498A801A191a93C840750ed637149dDf8D0",
     vaultLens: "0xCCC8D18e40c439F5234042FbEA0f4f1528f52f00",
@@ -70,6 +70,8 @@ function eulerV2(timestamp: number = 0) {
         timestamp,
         config.factory,
         config.fromBlock,
+      ).catch(() =>
+        console.log(`Error fetching eulerV2 token prices for ${chain}`),
       ),
     ),
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for Euler v2 token price fetching to ensure failures on individual chains do not impact other chains' availability.

* **Changes**
  * Temporarily disabled Binance Smart Chain (BSC) support for the Euler v2 adapter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/11998)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->