### PR TITLE
remove chaos oracle from gmx v2

### DIFF
--- a/defi/src/protocols/data3.ts
+++ b/defi/src/protocols/data3.ts
@@ -14807,11 +14807,12 @@ const data3_0: Protocol[] = [
       {
         name: "Chainlink",
         type: "Primary",
-        proof: ["https://docs.gmx.io/docs/intro"]
+        proof: ["https://docs.gmx.io/docs/intro", "https://docs.gmx.io/docs/providing-liquidity/#glv-pools", "https://docs.gmx.io/docs/trading/fees/#price-impact-caps-by-market"]
       },
       {
         name: "Chaos",
         type: "Primary",
+		endDate: "2026-05-13",
         proof: ["https://x.com/GMX_IO/status/1866794916392874021", "https://gov.gmx.io/t/implementation-of-chaos-labs-risk-oracles/3861"]
       }
     ],


### PR DESCRIPTION
Hi! This PR removes Chaos Labs as an oracle for GMX V2 Perps. If you observe the docs I share, you will see that Chaos Labs provides risk parameter recommendations but is not involved in price oracle infrastructure or real-time price delivery. Only price feeds from Chainlink Data Streams are used as an oracle for accurate pricing, so liquidations occur at fair market prices. Therefore, only Chainlink should be listed as an oracle for GMX V2 Perps.

Here is the proof:
- https://docs.gmx.io/docs/intro/
- https://docs.gmx.io/docs/providing-liquidity/#glv-pools
- https://docs.gmx.io/docs/trading/fees/#price-impact-caps-by-market

Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Chainlink protocol documentation references with additional GMX resources.
  * Updated Chaos protocol end date to May 13, 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/defillama-server/pull/12002)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->